### PR TITLE
fix: disable SNAPSHOT PR
  from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "java",
+  "release-type": "simple",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "include-component-in-tag": false,


### PR DESCRIPTION
Central Portal does not support SNAPSHOT. Switch
   release-type from java to simple.