### PR TITLE
fix: remove SNAPSHOT from
  version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.2.0-SNAPSHOT
+version=0.2.0
 group=io.github.haroya01


### PR DESCRIPTION
Central Portal does not support SNAPSHOT publishing.