### PR TITLE
fix: guard against NPE when expression-based index has null columnName

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/DmlWithoutIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/DmlWithoutIndexDetector.java
@@ -71,7 +71,7 @@ public class DmlWithoutIndexDetector implements DetectionRule {
       // Check if at least one WHERE column is the leading column of any index
       Set<String> leadingIndexColumns = new HashSet<>();
       for (IndexInfo idx : tableIndexes) {
-        if (idx.seqInIndex() == 1) {
+        if (idx.seqInIndex() == 1 && idx.columnName() != null) {
           leadingIndexColumns.add(idx.columnName().toLowerCase());
         }
       }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/DmlWithoutIndexDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/DmlWithoutIndexDetectorTest.java
@@ -226,6 +226,26 @@ class DmlWithoutIndexDetectorTest {
       List<Issue> issues = detector.evaluate(List.of(), indexWithPrimaryKey("orders"));
       assertThat(issues).isEmpty();
     }
+
+    @Test
+    @DisplayName("No NPE when expression-based index has null columnName (GitHub #31)")
+    void noNpeOnExpressionBasedIndexWithNullColumnName() {
+      String sql = "UPDATE orders SET processed = true WHERE status = 'pending'";
+      // Expression-based index returns null for columnName
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "orders",
+                  List.of(
+                      new IndexInfo("orders", "idx_expr", null, 1, true, 500),
+                      new IndexInfo("orders", "PRIMARY", "id", 1, false, 10000))));
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      // Should not throw NPE; status is not indexed so issue is reported
+      assertThat(issues).hasSize(1);
+      assertThat(issues.get(0).type()).isEqualTo(IssueType.DML_WITHOUT_INDEX);
+    }
   }
 
   // ── Mutation-killing tests ──────────────────────────────────────────


### PR DESCRIPTION
(#31)

## What
Add null check for expression-based index columnName in DmlWithoutIndexDetector    

## Why
MySQL 8.x expression-based indexes (e.g. `CREATE UNIQUE INDEX idx ON t ((CASE WHEN ...))`) return NULL for Column_name in SHOW INDEX, causing NPE at DmlWithoutIndexDetector:75 (#31) 

## Checklist
- [x] `./gradlew build` passes
- [x] Tests added (true positive + false positive)
- [x] False positive test suites still pass
- [x] Commit messages follow conventional commits
