### PR TITLE
fix: exclude JPA existsBy* queries from limit-without-order-by detection (#34)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/LimitWithoutOrderByDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/LimitWithoutOrderByDetector.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 public class LimitWithoutOrderByDetector implements DetectionRule {
 
   private static final Pattern LIMIT_PATTERN =
-      Pattern.compile("\\bLIMIT\\b", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("\\bLIMIT\\b|\\bFETCH\\s+FIRST\\b", Pattern.CASE_INSENSITIVE);
 
   private static final Pattern ORDER_BY_PATTERN =
       Pattern.compile("\\bORDER\\s+BY\\b", Pattern.CASE_INSENSITIVE);
@@ -40,11 +40,21 @@ public class LimitWithoutOrderByDetector implements DetectionRule {
           "\\b(?:COUNT|SUM|AVG|MIN|MAX)\\s*\\(", Pattern.CASE_INSENSITIVE);
 
   /**
-   * Matches LIMIT 1 — existence checks (e.g., {@code SELECT id FROM t WHERE cond LIMIT 1})
+   * Matches LIMIT 1 or LIMIT ? — existence checks (e.g., {@code SELECT id FROM t WHERE cond LIMIT 1})
    * intentionally use LIMIT 1 without ORDER BY to quickly check if any row matches.
+   * JPA existsBy* methods generate parameterized LIMIT (LIMIT ?) which should also be excluded.
    */
   private static final Pattern LIMIT_ONE_PATTERN =
-      Pattern.compile("\\bLIMIT\\s+1\\b", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "\\bLIMIT\\s+(?:1\\b|\\?)|\\bFETCH\\s+FIRST\\s+(?:1\\b|\\?)\\s+ROWS?\\s+ONLY\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Matches JPA existsBy* method names in the captured stack trace.
+   * When a query originates from an existsBy* call, ordering is irrelevant.
+   */
+  private static final Pattern EXISTS_BY_METHOD =
+      Pattern.compile("\\.existsBy\\w+:");
 
   @Override
   public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
@@ -83,8 +93,13 @@ public class LimitWithoutOrderByDetector implements DetectionRule {
         continue;
       }
 
-      // Skip LIMIT 1 — commonly used for existence checks where ordering is irrelevant
+      // Skip LIMIT 1 or LIMIT ? — commonly used for existence checks where ordering is irrelevant
       if (LIMIT_ONE_PATTERN.matcher(outerSql).find()) {
+        continue;
+      }
+
+      // Skip queries originating from JPA existsBy* methods (intent-based detection)
+      if (query.stackTrace() != null && EXISTS_BY_METHOD.matcher(query.stackTrace()).find()) {
         continue;
       }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/LimitWithoutOrderByDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/LimitWithoutOrderByDetectorTest.java
@@ -109,6 +109,65 @@ class LimitWithoutOrderByDetectorTest {
     assertThat(issues).isEmpty();
   }
 
+  // ── #34: JPA existsBy* false positive fix ──────────────────────
+
+  @Test
+  void noIssueForParameterizedLimitInExistenceCheck() {
+    // JPA existsBy* generates: SELECT id FROM users WHERE nickname=? AND discriminator=? LIMIT ?
+    List<Issue> issues =
+        detector.evaluate(
+            List.of(q("SELECT id FROM users WHERE nickname=? AND discriminator=? LIMIT ?")),
+            emptyIndex);
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void noIssueForSelect1WithParameterizedLimit() {
+    List<Issue> issues =
+        detector.evaluate(
+            List.of(q("SELECT 1 FROM users WHERE username = ? LIMIT ?")),
+            emptyIndex);
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void noIssueForFetchFirstParameterized() {
+    // Hibernate generates "fetch first ? rows only" instead of "LIMIT ?"
+    List<Issue> issues =
+        detector.evaluate(
+            List.of(q("select m1_0.id from members m1_0 where m1_0.email=? fetch first ? rows only")),
+            emptyIndex);
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void noIssueForExistsByMethodInStackTrace() {
+    // Even with a non-trivial LIMIT, existsBy* in the stack trace should skip
+    String stackTrace =
+        "jdk.proxy3.$Proxy122.existsByEmail:-1\n"
+            + "com.example.UserService.checkExists:42";
+    QueryRecord record =
+        new QueryRecord(
+            "select m1_0.id from members m1_0 where m1_0.email=? fetch first ? rows only",
+            1000L, System.currentTimeMillis(), stackTrace);
+    List<Issue> issues = detector.evaluate(List.of(record), emptyIndex);
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void stillDetectsWhenStackTraceHasNoExistsBy() {
+    // Non-existsBy call with LIMIT but no ORDER BY should still be flagged
+    String stackTrace =
+        "jdk.proxy3.$Proxy122.findByStatus:-1\n"
+            + "com.example.UserService.getUsers:50";
+    QueryRecord record =
+        new QueryRecord(
+            "SELECT id, name FROM users WHERE status = ? LIMIT 10",
+            1000L, System.currentTimeMillis(), stackTrace);
+    List<Issue> issues = detector.evaluate(List.of(record), emptyIndex);
+    assertThat(issues).hasSize(1);
+  }
+
   @Test
   void stillDetectsLimitGreaterThan1WithoutOrderBy() {
     // LIMIT > 1 without ORDER BY is still non-deterministic

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/repository/MemberRepository.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   Member findByEmailNative(String email);
 
   List<Member> findByNameContaining(String name);
+
+  boolean existsByEmail(String email);
 }


### PR DESCRIPTION
#34

## What
- Expand `LIMIT_ONE_PATTERN` to match `LIMIT ?` and `FETCH FIRST ? ROWS ONLY`
- Add stack trace-based intent detection to skip `existsBy*` method calls                                                                                            
- Add Hibernate 6+ `FETCH FIRST` syntax support to `LIMIT_PATTERN`  

## Why
<!-- 왜 필요한지 -->
JPA `existsBy*` methods generate queries with `LIMIT ?` or `fetch first ? rows only`, which did not match the existing `LIMIT 1` literal pattern, causing false positive WARNINGs (#34)                                   
                                                                                                                                                                       
Existence checks have no meaningful result ordering, so LIMIT without ORDER BY should not trigger a warning  

## Checklist
- [x] `./gradlew build` passes
- [ ] Tests added (true positive + false positive)
- [ ] False positive test suites still pass
- [ ] Commit messages follow conventional commits
