### PR TITLE
fix: support composite unique index in unbounded-result-set detection (#33)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/UnboundedResultSetDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/UnboundedResultSetDetector.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,6 +85,25 @@ public class UnboundedResultSetDetector implements DetectionRule {
   private static final Pattern SINGLE_EQUALITY_PATTERN =
       Pattern.compile("\\bWHERE\\s+(?:\\w+\\.)?(\\w+)\\s*=\\s*\\?\\s*$", Pattern.CASE_INSENSITIVE);
 
+  /**
+   * Extracts column names from equality conditions: {@code (alias.)column = ?}. Used to collect
+   * all equality columns in a WHERE clause for unique index checks.
+   */
+  private static final Pattern EQUALITY_COLUMN_PATTERN =
+      Pattern.compile("(?:\\w+\\.)?(\\w+)\\s*=\\s*\\?", Pattern.CASE_INSENSITIVE);
+
+  /** Matches OR — unique index check is unsafe when OR is present in the WHERE clause. */
+  private static final Pattern OR_PATTERN =
+      Pattern.compile("\\bOR\\b", Pattern.CASE_INSENSITIVE);
+
+  /** Extracts the WHERE clause from a SQL statement. */
+  private static final Pattern WHERE_CLAUSE_PATTERN =
+      Pattern.compile("\\bWHERE\\b(.+)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  /** Matches parenthesized subqueries to strip before column extraction. */
+  private static final Pattern SUBQUERY_PATTERN =
+      Pattern.compile("\\([^()]*\\bSELECT\\b[^()]*\\)", Pattern.CASE_INSENSITIVE);
+
   /** Matches a single equality condition followed by LIMIT 1. */
   private static final Pattern SINGLE_EQUALITY_LIMIT1_PATTERN =
       Pattern.compile(
@@ -148,18 +168,20 @@ public class UnboundedResultSetDetector implements DetectionRule {
         continue;
       }
 
-      // Check index metadata: if the query has a single equality condition
-      // on a column with a unique index, skip it.
+      // Check index metadata: if all columns of a unique index (single or composite)
+      // appear as AND-connected equality conditions, the result is at most one row.
       List<String> tables = SqlParser.extractTableNames(sql);
       String table = tables.isEmpty() ? null : tables.get(0);
 
-      Matcher singleEqMatcher = SINGLE_EQUALITY_PATTERN.matcher(sql);
-      if (singleEqMatcher.find()) {
-        String column = singleEqMatcher.group(1);
-        if (indexMetadata != null
-            && table != null
-            && indexMetadata.hasUniqueIndexOn(table, column)) {
-          continue;
+      if (indexMetadata != null && table != null) {
+        String whereClause = extractWhereClause(sql);
+        if (whereClause != null && !OR_PATTERN.matcher(whereClause).find()) {
+          String cleaned = stripSubqueries(whereClause);
+          Set<String> eqColumns = extractEqualityColumns(cleaned);
+          if (!eqColumns.isEmpty()
+              && indexMetadata.hasUniqueIndexCoveredBy(table, eqColumns)) {
+            continue;
+          }
         }
       }
 
@@ -183,5 +205,28 @@ public class UnboundedResultSetDetector implements DetectionRule {
     }
 
     return issues;
+  }
+
+  private static String extractWhereClause(String sql) {
+    Matcher m = WHERE_CLAUSE_PATTERN.matcher(sql);
+    return m.find() ? m.group(1).trim() : null;
+  }
+
+  /** Removes parenthesized subqueries so that inner columns are not extracted. */
+  private static String stripSubqueries(String whereClause) {
+    String result = whereClause;
+    while (SUBQUERY_PATTERN.matcher(result).find()) {
+      result = SUBQUERY_PATTERN.matcher(result).replaceAll("");
+    }
+    return result;
+  }
+
+  private static Set<String> extractEqualityColumns(String whereClause) {
+    Set<String> columns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    Matcher m = EQUALITY_COLUMN_PATTERN.matcher(whereClause);
+    while (m.find()) {
+      columns.add(m.group(1));
+    }
+    return columns;
   }
 }

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/IndexMetadata.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/IndexMetadata.java
@@ -1,8 +1,12 @@
 package io.queryaudit.core.model;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -35,40 +39,46 @@ public class IndexMetadata {
 
   /**
    * Returns {@code true} if the given column on the given table has a UNIQUE (or PRIMARY KEY)
-   * index. A unique single-column index guarantees at most one row for an equality predicate, so
-   * queries filtered on such a column do not need a LIMIT clause.
-   */
-  /**
-   * Returns {@code true} if the given column on the given table has a UNIQUE (or PRIMARY KEY)
-   * single-column index. A unique single-column index guarantees at most one row for an equality
-   * predicate, so queries filtered on such a column do not need a LIMIT clause.
+   * single-column index. Convenience delegate to {@link #hasUniqueIndexCoveredBy(String, Set)}.
    */
   public boolean hasUniqueIndexOn(String table, String column) {
-    if (table == null || column == null) {
+    if (column == null) {
+      return false;
+    }
+    return hasUniqueIndexCoveredBy(table, Set.of(column));
+  }
+
+  /**
+   * Returns {@code true} if there exists a UNIQUE (or PRIMARY KEY) index on the given table
+   * whose columns are all contained in the provided set of equality columns. Handles both
+   * single-column and composite unique indexes — when all columns of such an index appear as
+   * equality conditions, the query is guaranteed to return at most one row.
+   */
+  public boolean hasUniqueIndexCoveredBy(String table, Set<String> columns) {
+    if (table == null || columns == null || columns.isEmpty()) {
       return false;
     }
     List<IndexInfo> indexes = indexesByTable.get(table);
     if (indexes == null) {
       return false;
     }
-    // Collect unique index names that contain the target column at position 1
-    java.util.Set<String> candidateIndexNames =
-        indexes.stream()
-            .filter(
-                idx ->
-                    !idx.nonUnique()
-                        && idx.seqInIndex() == 1
-                        && idx.columnName() != null
-                        && idx.columnName().equalsIgnoreCase(column)
-                        && idx.indexName() != null)
-            .map(IndexInfo::indexName)
-            .collect(java.util.stream.Collectors.toSet());
 
-    // Verify that at least one candidate index is a single-column index
-    for (String indexName : candidateIndexNames) {
-      long columnsInIndex =
-          indexes.stream().filter(idx -> indexName.equals(idx.indexName())).count();
-      if (columnsInIndex == 1) {
+    // Group unique index entries by index name
+    Map<String, List<IndexInfo>> uniqueIndexes =
+        indexes.stream()
+            .filter(idx -> !idx.nonUnique() && idx.indexName() != null)
+            .collect(Collectors.groupingBy(IndexInfo::indexName));
+
+    // Check if any unique index has all its columns covered by the equality columns
+    for (List<IndexInfo> indexEntries : uniqueIndexes.values()) {
+      boolean allCovered =
+          indexEntries.stream()
+              .allMatch(
+                  idx ->
+                      idx.columnName() != null
+                          && columns.stream()
+                              .anyMatch(col -> col.equalsIgnoreCase(idx.columnName())));
+      if (allCovered) {
         return true;
       }
     }
@@ -123,11 +133,11 @@ public class IndexMetadata {
       return other;
     }
 
-    Map<String, List<IndexInfo>> merged = new java.util.HashMap<>();
+    Map<String, List<IndexInfo>> merged = new HashMap<>();
 
     // Copy all entries from this (primary source)
     for (Map.Entry<String, List<IndexInfo>> entry : this.indexesByTable.entrySet()) {
-      merged.put(entry.getKey(), new java.util.ArrayList<>(entry.getValue()));
+      merged.put(entry.getKey(), new ArrayList<>(entry.getValue()));
     }
 
     // Add entries from other, skipping index names that already exist in primary
@@ -136,15 +146,15 @@ public class IndexMetadata {
       List<IndexInfo> otherIndexes = entry.getValue();
 
       if (!merged.containsKey(table)) {
-        merged.put(table, new java.util.ArrayList<>(otherIndexes));
+        merged.put(table, new ArrayList<>(otherIndexes));
       } else {
         List<IndexInfo> existing = merged.get(table);
-        java.util.Set<String> existingNames =
+        Set<String> existingNames =
             existing.stream()
                 .map(IndexInfo::indexName)
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .map(String::toLowerCase)
-                .collect(java.util.stream.Collectors.toSet());
+                .collect(Collectors.toSet());
 
         for (IndexInfo info : otherIndexes) {
           String name = info.indexName();

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/UnboundedResultSetDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/UnboundedResultSetDetectorTest.java
@@ -353,6 +353,141 @@ class UnboundedResultSetDetectorTest {
 
       assertThat(issues).hasSize(1);
     }
+
+    // ── Issue #33: composite unique index false positives ──────────────
+
+    @Test
+    void noIssueWhenAllColumnsOfCompositeUniqueIndexUsed() {
+      // UNIQUE(oauth_provider, oauth_sub) — both columns in WHERE → at most 1 row
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql = "SELECT * FROM users WHERE oauth_provider = ? AND oauth_sub = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void noIssueWhenCompositeUniqueColumnsInDifferentOrder() {
+      // WHERE clause order doesn't need to match index column order
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql = "SELECT * FROM users WHERE oauth_sub = ? AND oauth_provider = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void noIssueWhenThreeColumnCompositeUniqueIndexFullyMatched() {
+      // UNIQUE(tenant_id, region, code) — all three in WHERE
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "warehouses",
+                  List.of(
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "tenant_id", 1, false, 10),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "region", 2, false, 100),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "code", 3, false, 1000))));
+
+      String sql =
+          "SELECT * FROM warehouses WHERE tenant_id = ? AND region = ? AND code = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void flagsWhenCompositeUniqueIndexPartiallyMatched() {
+      // UNIQUE(tenant_id, region, code) — only 2 of 3 columns → not guaranteed single row
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "warehouses",
+                  List.of(
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "tenant_id", 1, false, 10),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "region", 2, false, 100),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "code", 3, false, 1000))));
+
+      String sql = "SELECT * FROM warehouses WHERE tenant_id = ? AND region = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).hasSize(1);
+    }
+
+    @Test
+    void noIssueWhenCompositeUniqueWithAliasedColumns() {
+      // Aliased table: u.oauth_provider, u.oauth_sub
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql = "SELECT * FROM users u WHERE u.oauth_provider = ? AND u.oauth_sub = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void doesNotExtractColumnsFromSubqueries() {
+      // "user_id = ?" in the scalar subquery should not be counted as a main WHERE equality column.
+      // UNIQUE(oauth_provider, user_id) exists, but only oauth_provider is in the outer WHERE.
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_provider_uid", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_provider_uid", "user_id", 2, false, 1000))));
+
+      String sql =
+          "SELECT * FROM users WHERE oauth_provider = ? "
+              + "AND status = (SELECT status FROM defaults WHERE user_id = ?)";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).hasSize(1);
+    }
+
+    @Test
+    void flagsWhenOrInWhereClause() {
+      // OR breaks uniqueness guarantee even if all composite columns appear
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql =
+          "SELECT * FROM users WHERE oauth_provider = ? OR oauth_sub = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).hasSize(1);
+    }
   }
 
   // ── new tests: single equality + LIMIT 1 ───────────────────────────


### PR DESCRIPTION
… (#33)

## What
<!-- 무엇을 변경했는지 -->
- Unified `hasUniqueIndexOn` and `hasCompositeUniqueIndexCoveredBy` into a single `hasUniqueIndexCoveredBy(table, Set<String>)` method in IndexMetadata
- Merged single/composite unique index check paths in UnboundedResultSetDetector
- Added subquery stripping to prevent inner query columns from being falsely extracted
- Scoped OR check to WHERE clause only (previously checked entire SQL)
- Cleaned up fully-qualified class names to proper imports

## Why
<!-- 왜 필요한지 -->
UnboundedResultSetDetector only handled single-column unique index lookups, causing false positives on queries like `WHERE oauth_provider=? AND oauth_sub=?` where (oauth_provider, oauth_sub) forms a composite unique key. 
These queries are guaranteed to return at most one row and should not trigger unbounded-result-set warnings.


## Checklist
- [x] `./gradlew build` passes
- [ ] Tests added (true positive + false positive)
- [ ] False positive test suites still pass
- [ ] Commit messages follow conventional commits
