### PR TITLE
feat: exclude @BeforeEach/@AfterEach queries from detection (#35)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
@@ -38,6 +38,7 @@ public class QueryAuditConfig {
   private final int writeAmplificationThreshold;
   private final long slowQueryWarningMs;
   private final long slowQueryErrorMs;
+  private final boolean includeSetupQueries;
 
   private QueryAuditConfig(Builder builder) {
     this.enabled = builder.enabled;
@@ -60,6 +61,7 @@ public class QueryAuditConfig {
     this.writeAmplificationThreshold = builder.writeAmplificationThreshold;
     this.slowQueryWarningMs = builder.slowQueryWarningMs;
     this.slowQueryErrorMs = builder.slowQueryErrorMs;
+    this.includeSetupQueries = builder.includeSetupQueries;
   }
 
   public static Builder builder() {
@@ -182,6 +184,14 @@ public class QueryAuditConfig {
     return slowQueryErrorMs;
   }
 
+  /**
+   * Returns whether setup/teardown lifecycle phase queries should be included in analysis.
+   * Default is {@code false} — only TEST-phase queries are analyzed.
+   */
+  public boolean isIncludeSetupQueries() {
+    return includeSetupQueries;
+  }
+
   public boolean isSuppressed(String issueCode, String table, String column) {
     if (suppressPatterns.isEmpty()) {
       return false;
@@ -233,6 +243,7 @@ public class QueryAuditConfig {
     private int writeAmplificationThreshold = 6;
     private long slowQueryWarningMs = 500;
     private long slowQueryErrorMs = 3000;
+    private boolean includeSetupQueries = false;
 
     public Builder enabled(boolean enabled) {
       this.enabled = enabled;
@@ -351,6 +362,11 @@ public class QueryAuditConfig {
 
     public Builder slowQueryErrorMs(long slowQueryErrorMs) {
       this.slowQueryErrorMs = slowQueryErrorMs;
+      return this;
+    }
+
+    public Builder includeSetupQueries(boolean includeSetupQueries) {
+      this.includeSetupQueries = includeSetupQueries;
       return this;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
@@ -5,6 +5,7 @@ import io.queryaudit.core.baseline.BaselineEntry;
 import io.queryaudit.core.config.QueryAuditConfig;
 import io.queryaudit.core.model.IndexMetadata;
 import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.LifecyclePhase;
 import io.queryaudit.core.model.QueryAuditReport;
 import io.queryaudit.core.model.QueryRecord;
 import io.queryaudit.core.model.Severity;
@@ -275,14 +276,24 @@ public class QueryAuditAnalyzer {
           testName, List.of(), List.of(), queries != null ? queries : List.of(), 0, 0, 0L);
     }
 
-    // Filter out suppressed queries
+    // Filter out suppressed queries (used for stats: total count, unique patterns, exec time)
     List<QueryRecord> filteredQueries =
         queries.stream().filter(q -> !config.isQuerySuppressed(q.sql())).toList();
 
-    // Collect all issues from all rules
+    // For detection, further filter by lifecycle phase.
+    // By default only TEST-phase queries are analyzed; setup/teardown queries are excluded
+    // to prevent false positives from test infrastructure (e.g., deleteAll, repeated save).
+    List<QueryRecord> detectableQueries =
+        config.isIncludeSetupQueries()
+            ? filteredQueries
+            : filteredQueries.stream()
+                .filter(q -> q.phase() == LifecyclePhase.TEST)
+                .toList();
+
+    // Collect all issues from all rules (only against detectable queries)
     List<Issue> allIssues = new ArrayList<>();
     for (DetectionRule rule : rules) {
-      List<Issue> ruleIssues = rule.evaluate(filteredQueries, indexMetadata);
+      List<Issue> ruleIssues = rule.evaluate(detectableQueries, indexMetadata);
       allIssues.addAll(ruleIssues);
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/UnboundedResultSetDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/UnboundedResultSetDetector.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,6 +85,25 @@ public class UnboundedResultSetDetector implements DetectionRule {
   private static final Pattern SINGLE_EQUALITY_PATTERN =
       Pattern.compile("\\bWHERE\\s+(?:\\w+\\.)?(\\w+)\\s*=\\s*\\?\\s*$", Pattern.CASE_INSENSITIVE);
 
+  /**
+   * Extracts column names from equality conditions: {@code (alias.)column = ?}. Used to collect
+   * all equality columns in a WHERE clause for unique index checks.
+   */
+  private static final Pattern EQUALITY_COLUMN_PATTERN =
+      Pattern.compile("(?:\\w+\\.)?(\\w+)\\s*=\\s*\\?", Pattern.CASE_INSENSITIVE);
+
+  /** Matches OR — unique index check is unsafe when OR is present in the WHERE clause. */
+  private static final Pattern OR_PATTERN =
+      Pattern.compile("\\bOR\\b", Pattern.CASE_INSENSITIVE);
+
+  /** Extracts the WHERE clause from a SQL statement. */
+  private static final Pattern WHERE_CLAUSE_PATTERN =
+      Pattern.compile("\\bWHERE\\b(.+)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+  /** Matches parenthesized subqueries to strip before column extraction. */
+  private static final Pattern SUBQUERY_PATTERN =
+      Pattern.compile("\\([^()]*\\bSELECT\\b[^()]*\\)", Pattern.CASE_INSENSITIVE);
+
   /** Matches a single equality condition followed by LIMIT 1. */
   private static final Pattern SINGLE_EQUALITY_LIMIT1_PATTERN =
       Pattern.compile(
@@ -148,18 +168,20 @@ public class UnboundedResultSetDetector implements DetectionRule {
         continue;
       }
 
-      // Check index metadata: if the query has a single equality condition
-      // on a column with a unique index, skip it.
+      // Check index metadata: if all columns of a unique index (single or composite)
+      // appear as AND-connected equality conditions, the result is at most one row.
       List<String> tables = SqlParser.extractTableNames(sql);
       String table = tables.isEmpty() ? null : tables.get(0);
 
-      Matcher singleEqMatcher = SINGLE_EQUALITY_PATTERN.matcher(sql);
-      if (singleEqMatcher.find()) {
-        String column = singleEqMatcher.group(1);
-        if (indexMetadata != null
-            && table != null
-            && indexMetadata.hasUniqueIndexOn(table, column)) {
-          continue;
+      if (indexMetadata != null && table != null) {
+        String whereClause = extractWhereClause(sql);
+        if (whereClause != null && !OR_PATTERN.matcher(whereClause).find()) {
+          String cleaned = stripSubqueries(whereClause);
+          Set<String> eqColumns = extractEqualityColumns(cleaned);
+          if (!eqColumns.isEmpty()
+              && indexMetadata.hasUniqueIndexCoveredBy(table, eqColumns)) {
+            continue;
+          }
         }
       }
 
@@ -183,5 +205,28 @@ public class UnboundedResultSetDetector implements DetectionRule {
     }
 
     return issues;
+  }
+
+  private static String extractWhereClause(String sql) {
+    Matcher m = WHERE_CLAUSE_PATTERN.matcher(sql);
+    return m.find() ? m.group(1).trim() : null;
+  }
+
+  /** Removes parenthesized subqueries so that inner columns are not extracted. */
+  private static String stripSubqueries(String whereClause) {
+    String result = whereClause;
+    while (SUBQUERY_PATTERN.matcher(result).find()) {
+      result = SUBQUERY_PATTERN.matcher(result).replaceAll("");
+    }
+    return result;
+  }
+
+  private static Set<String> extractEqualityColumns(String whereClause) {
+    Set<String> columns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    Matcher m = EQUALITY_COLUMN_PATTERN.matcher(whereClause);
+    while (m.find()) {
+      columns.add(m.group(1));
+    }
+    return columns;
   }
 }

--- a/query-audit-core/src/main/java/io/queryaudit/core/interceptor/QueryInterceptor.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/interceptor/QueryInterceptor.java
@@ -1,6 +1,8 @@
 package io.queryaudit.core.interceptor;
 
+import io.queryaudit.core.model.LifecyclePhase;
 import io.queryaudit.core.model.QueryRecord;
+import io.queryaudit.core.parser.SqlParser;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +67,7 @@ public class QueryInterceptor implements QueryExecutionListener {
   private volatile boolean active = false;
   private volatile int maxQueries = DEFAULT_MAX_QUERIES;
   private volatile boolean capacityWarningLogged = false;
+  private volatile LifecyclePhase currentPhase = LifecyclePhase.TEST;
 
   // SQL string pool: identical SQL strings share the same object reference,
   // saving memory when the same query pattern appears many times (e.g., N+1).
@@ -104,14 +107,29 @@ public class QueryInterceptor implements QueryExecutionListener {
         }
         String pooledSql = poolString(sqlPool, sql);
         String stackTrace = poolString(stackTracePool, captureStackTrace());
+        String normalized = SqlParser.normalize(pooledSql);
+        int stackHash = stackTrace == null ? 0 : stackTrace.hashCode();
         recordedQueries.add(
             new QueryRecord(
                 pooledSql,
+                normalized,
                 execInfo.getElapsedTime() * 1_000_000L,
                 System.currentTimeMillis(),
-                stackTrace));
+                stackTrace,
+                stackHash,
+                currentPhase));
       }
     }
+  }
+
+  /**
+   * Sets the current lifecycle phase. Queries recorded after this call will be
+   * tagged with the given phase.
+   *
+   * @param phase the lifecycle phase (SETUP, TEST, or TEARDOWN)
+   */
+  public void setPhase(LifecyclePhase phase) {
+    this.currentPhase = phase;
   }
 
   public void start() {
@@ -119,6 +137,7 @@ public class QueryInterceptor implements QueryExecutionListener {
     sqlPool.clear();
     stackTracePool.clear();
     capacityWarningLogged = false;
+    currentPhase = LifecyclePhase.TEST;
     active = true;
   }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/IndexMetadata.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/IndexMetadata.java
@@ -1,8 +1,12 @@
 package io.queryaudit.core.model;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -35,40 +39,46 @@ public class IndexMetadata {
 
   /**
    * Returns {@code true} if the given column on the given table has a UNIQUE (or PRIMARY KEY)
-   * index. A unique single-column index guarantees at most one row for an equality predicate, so
-   * queries filtered on such a column do not need a LIMIT clause.
-   */
-  /**
-   * Returns {@code true} if the given column on the given table has a UNIQUE (or PRIMARY KEY)
-   * single-column index. A unique single-column index guarantees at most one row for an equality
-   * predicate, so queries filtered on such a column do not need a LIMIT clause.
+   * single-column index. Convenience delegate to {@link #hasUniqueIndexCoveredBy(String, Set)}.
    */
   public boolean hasUniqueIndexOn(String table, String column) {
-    if (table == null || column == null) {
+    if (column == null) {
+      return false;
+    }
+    return hasUniqueIndexCoveredBy(table, Set.of(column));
+  }
+
+  /**
+   * Returns {@code true} if there exists a UNIQUE (or PRIMARY KEY) index on the given table
+   * whose columns are all contained in the provided set of equality columns. Handles both
+   * single-column and composite unique indexes — when all columns of such an index appear as
+   * equality conditions, the query is guaranteed to return at most one row.
+   */
+  public boolean hasUniqueIndexCoveredBy(String table, Set<String> columns) {
+    if (table == null || columns == null || columns.isEmpty()) {
       return false;
     }
     List<IndexInfo> indexes = indexesByTable.get(table);
     if (indexes == null) {
       return false;
     }
-    // Collect unique index names that contain the target column at position 1
-    java.util.Set<String> candidateIndexNames =
-        indexes.stream()
-            .filter(
-                idx ->
-                    !idx.nonUnique()
-                        && idx.seqInIndex() == 1
-                        && idx.columnName() != null
-                        && idx.columnName().equalsIgnoreCase(column)
-                        && idx.indexName() != null)
-            .map(IndexInfo::indexName)
-            .collect(java.util.stream.Collectors.toSet());
 
-    // Verify that at least one candidate index is a single-column index
-    for (String indexName : candidateIndexNames) {
-      long columnsInIndex =
-          indexes.stream().filter(idx -> indexName.equals(idx.indexName())).count();
-      if (columnsInIndex == 1) {
+    // Group unique index entries by index name
+    Map<String, List<IndexInfo>> uniqueIndexes =
+        indexes.stream()
+            .filter(idx -> !idx.nonUnique() && idx.indexName() != null)
+            .collect(Collectors.groupingBy(IndexInfo::indexName));
+
+    // Check if any unique index has all its columns covered by the equality columns
+    for (List<IndexInfo> indexEntries : uniqueIndexes.values()) {
+      boolean allCovered =
+          indexEntries.stream()
+              .allMatch(
+                  idx ->
+                      idx.columnName() != null
+                          && columns.stream()
+                              .anyMatch(col -> col.equalsIgnoreCase(idx.columnName())));
+      if (allCovered) {
         return true;
       }
     }
@@ -123,11 +133,11 @@ public class IndexMetadata {
       return other;
     }
 
-    Map<String, List<IndexInfo>> merged = new java.util.HashMap<>();
+    Map<String, List<IndexInfo>> merged = new HashMap<>();
 
     // Copy all entries from this (primary source)
     for (Map.Entry<String, List<IndexInfo>> entry : this.indexesByTable.entrySet()) {
-      merged.put(entry.getKey(), new java.util.ArrayList<>(entry.getValue()));
+      merged.put(entry.getKey(), new ArrayList<>(entry.getValue()));
     }
 
     // Add entries from other, skipping index names that already exist in primary
@@ -136,15 +146,15 @@ public class IndexMetadata {
       List<IndexInfo> otherIndexes = entry.getValue();
 
       if (!merged.containsKey(table)) {
-        merged.put(table, new java.util.ArrayList<>(otherIndexes));
+        merged.put(table, new ArrayList<>(otherIndexes));
       } else {
         List<IndexInfo> existing = merged.get(table);
-        java.util.Set<String> existingNames =
+        Set<String> existingNames =
             existing.stream()
                 .map(IndexInfo::indexName)
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .map(String::toLowerCase)
-                .collect(java.util.stream.Collectors.toSet());
+                .collect(Collectors.toSet());
 
         for (IndexInfo info : otherIndexes) {
           String name = info.indexName();

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/LifecyclePhase.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/LifecyclePhase.java
@@ -1,0 +1,22 @@
+package io.queryaudit.core.model;
+
+/**
+ * Represents the JUnit 5 test lifecycle phase during which a query was captured.
+ *
+ * <p>Used to distinguish test infrastructure queries (fixture setup/teardown)
+ * from production code path queries executed during the actual test method.
+ *
+ * @author haroya
+ * @since 0.2.0
+ */
+public enum LifecyclePhase {
+
+  /** Queries captured during {@code @BeforeEach} user methods. */
+  SETUP,
+
+  /** Queries captured during the actual {@code @Test} method execution. */
+  TEST,
+
+  /** Queries captured during {@code @AfterEach} user methods. */
+  TEARDOWN
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/QueryRecord.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/QueryRecord.java
@@ -16,7 +16,8 @@ public record QueryRecord(
     long executionTimeNanos,
     long timestamp,
     String stackTrace,
-    int fullStackHash) {
+    int fullStackHash,
+    LifecyclePhase phase) {
 
   public QueryRecord(String sql, long executionTimeNanos, long timestamp, String stackTrace) {
     this(
@@ -25,12 +26,26 @@ public record QueryRecord(
         executionTimeNanos,
         timestamp,
         stackTrace,
-        stackTrace == null ? 0 : stackTrace.hashCode());
+        stackTrace == null ? 0 : stackTrace.hashCode(),
+        LifecyclePhase.TEST);
   }
 
   public QueryRecord(
       String sql, long executionTimeNanos, long timestamp, String stackTrace, int fullStackHash) {
-    this(sql, SqlParser.normalize(sql), executionTimeNanos, timestamp, stackTrace, fullStackHash);
+    this(sql, SqlParser.normalize(sql), executionTimeNanos, timestamp, stackTrace, fullStackHash,
+        LifecyclePhase.TEST);
+  }
+
+  /** Canonical constructor with all fields including phase. */
+  public QueryRecord(
+      String sql,
+      String normalizedSql,
+      long executionTimeNanos,
+      long timestamp,
+      String stackTrace,
+      int fullStackHash) {
+    this(sql, normalizedSql, executionTimeNanos, timestamp, stackTrace, fullStackHash,
+        LifecyclePhase.TEST);
   }
 
   /**

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/UnboundedResultSetDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/UnboundedResultSetDetectorTest.java
@@ -353,6 +353,141 @@ class UnboundedResultSetDetectorTest {
 
       assertThat(issues).hasSize(1);
     }
+
+    // ── Issue #33: composite unique index false positives ──────────────
+
+    @Test
+    void noIssueWhenAllColumnsOfCompositeUniqueIndexUsed() {
+      // UNIQUE(oauth_provider, oauth_sub) — both columns in WHERE → at most 1 row
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql = "SELECT * FROM users WHERE oauth_provider = ? AND oauth_sub = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void noIssueWhenCompositeUniqueColumnsInDifferentOrder() {
+      // WHERE clause order doesn't need to match index column order
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql = "SELECT * FROM users WHERE oauth_sub = ? AND oauth_provider = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void noIssueWhenThreeColumnCompositeUniqueIndexFullyMatched() {
+      // UNIQUE(tenant_id, region, code) — all three in WHERE
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "warehouses",
+                  List.of(
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "tenant_id", 1, false, 10),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "region", 2, false, 100),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "code", 3, false, 1000))));
+
+      String sql =
+          "SELECT * FROM warehouses WHERE tenant_id = ? AND region = ? AND code = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void flagsWhenCompositeUniqueIndexPartiallyMatched() {
+      // UNIQUE(tenant_id, region, code) — only 2 of 3 columns → not guaranteed single row
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "warehouses",
+                  List.of(
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "tenant_id", 1, false, 10),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "region", 2, false, 100),
+                      new IndexInfo("warehouses", "uk_tenant_region_code", "code", 3, false, 1000))));
+
+      String sql = "SELECT * FROM warehouses WHERE tenant_id = ? AND region = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).hasSize(1);
+    }
+
+    @Test
+    void noIssueWhenCompositeUniqueWithAliasedColumns() {
+      // Aliased table: u.oauth_provider, u.oauth_sub
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql = "SELECT * FROM users u WHERE u.oauth_provider = ? AND u.oauth_sub = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    void doesNotExtractColumnsFromSubqueries() {
+      // "user_id = ?" in the scalar subquery should not be counted as a main WHERE equality column.
+      // UNIQUE(oauth_provider, user_id) exists, but only oauth_provider is in the outer WHERE.
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_provider_uid", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_provider_uid", "user_id", 2, false, 1000))));
+
+      String sql =
+          "SELECT * FROM users WHERE oauth_provider = ? "
+              + "AND status = (SELECT status FROM defaults WHERE user_id = ?)";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).hasSize(1);
+    }
+
+    @Test
+    void flagsWhenOrInWhereClause() {
+      // OR breaks uniqueness guarantee even if all composite columns appear
+      IndexMetadata metadata =
+          new IndexMetadata(
+              Map.of(
+                  "users",
+                  List.of(
+                      new IndexInfo("users", "uk_oauth", "oauth_provider", 1, false, 100),
+                      new IndexInfo("users", "uk_oauth", "oauth_sub", 2, false, 1000))));
+
+      String sql =
+          "SELECT * FROM users WHERE oauth_provider = ? OR oauth_sub = ?";
+
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+      assertThat(issues).hasSize(1);
+    }
   }
 
   // ── new tests: single equality + LIMIT 1 ───────────────────────────

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAudit.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAudit.java
@@ -46,4 +46,11 @@ public @interface QueryAudit {
    * false (must be opted in).
    */
   boolean autoOpenReport() default false;
+
+  /**
+   * Whether to include {@code @BeforeEach}/{@code @AfterEach} lifecycle queries in analysis.
+   * Defaults to {@code false} — only queries from the {@code @Test} method are analyzed.
+   * Set to {@code true} to analyze all lifecycle phases.
+   */
+  boolean includeSetupQueries() default false;
 }

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -8,6 +8,7 @@ import io.queryaudit.core.detector.QueryAuditAnalyzer;
 import io.queryaudit.core.interceptor.LazyLoadTracker;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import io.queryaudit.core.model.*;
+import io.queryaudit.core.model.LifecyclePhase;
 import io.queryaudit.core.regression.QueryCountBaseline;
 import io.queryaudit.core.regression.QueryCountRegressionDetector;
 import io.queryaudit.core.regression.QueryCounts;
@@ -37,7 +38,12 @@ import org.junit.jupiter.api.extension.*;
  * @since 0.2.0
  */
 public class QueryAuditExtension
-    implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+    implements BeforeAllCallback,
+        BeforeEachCallback,
+        BeforeTestExecutionCallback,
+        AfterTestExecutionCallback,
+        AfterEachCallback,
+        AfterAllCallback {
 
   private static final ExtensionContext.Namespace NAMESPACE =
       ExtensionContext.Namespace.create(QueryAuditExtension.class);
@@ -100,11 +106,34 @@ public class QueryAuditExtension
     QueryInterceptor interceptor = getInterceptor(context);
     if (interceptor != null) {
       interceptor.start();
+      interceptor.setPhase(LifecyclePhase.SETUP);
     }
 
     LazyLoadTracker tracker = getLazyLoadTracker(context);
     if (tracker != null) {
       tracker.start();
+    }
+  }
+
+  // ── BeforeTestExecutionCallback ─────────────────────────────────────
+  // Runs AFTER @BeforeEach methods, BEFORE the @Test method.
+
+  @Override
+  public void beforeTestExecution(ExtensionContext context) {
+    QueryInterceptor interceptor = getInterceptor(context);
+    if (interceptor != null) {
+      interceptor.setPhase(LifecyclePhase.TEST);
+    }
+  }
+
+  // ── AfterTestExecutionCallback ──────────────────────────────────────
+  // Runs AFTER the @Test method, BEFORE @AfterEach methods.
+
+  @Override
+  public void afterTestExecution(ExtensionContext context) {
+    QueryInterceptor interceptor = getInterceptor(context);
+    if (interceptor != null) {
+      interceptor.setPhase(LifecyclePhase.TEARDOWN);
     }
   }
 
@@ -402,6 +431,8 @@ public class QueryAuditExtension
       if (!annotation.baselinePath().isEmpty()) {
         builder.baselinePath(annotation.baselinePath());
       }
+
+      builder.includeSetupQueries(annotation.includeSetupQueries());
     }
 
     DetectNPlusOne detectNPlusOne = null;

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/LifecyclePhaseExclusionTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/LifecyclePhaseExclusionTest.java
@@ -1,0 +1,666 @@
+package io.queryaudit.junit5.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.config.QueryAuditConfig;
+import io.queryaudit.core.detector.QueryAuditAnalyzer;
+import io.queryaudit.core.interceptor.QueryInterceptor;
+import io.queryaudit.core.model.IndexMetadata;
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.LifecyclePhase;
+import io.queryaudit.core.model.QueryAuditReport;
+import io.queryaudit.core.model.QueryRecord;
+import io.queryaudit.junit5.EnableQueryInspector;
+import io.queryaudit.junit5.QueryAudit;
+import io.queryaudit.junit5.integration.entity.Member;
+import io.queryaudit.junit5.integration.entity.Team;
+import io.queryaudit.junit5.integration.repository.MemberRepository;
+import io.queryaudit.junit5.integration.repository.TeamRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Tests verifying that test lifecycle queries ({@code @BeforeEach} / {@code @AfterEach})
+ * should be excluded from query-audit detection to prevent false positives.
+ *
+ * <p>Issue #35: {@code deleteAll()} in setup triggers {@code update-without-where} (ERROR),
+ * and repeated {@code save()} triggers {@code repeated-single-insert} (WARNING).
+ * These are test infrastructure, not production code paths.
+ *
+ * <h3>Test Groups</h3>
+ * <ul>
+ *   <li><b>FalsePositiveProof</b> — Proves false positives exist with the current approach
+ *       (capturing all queries between start/stop). These tests PASS now.</li>
+ *   <li><b>DesiredBehavior</b> — Defines the expected behavior after lifecycle phase
+ *       awareness is implemented. These tests FAIL until the feature is implemented.</li>
+ * </ul>
+ */
+@SpringBootTest(classes = TestApplication.class)
+@EnableQueryInspector
+@Transactional
+class LifecyclePhaseExclusionTest {
+
+  @Autowired TeamRepository teamRepository;
+  @Autowired MemberRepository memberRepository;
+  @Autowired QueryInterceptor queryInterceptor;
+  @Autowired EntityManager entityManager;
+
+  // ── Group 1: Proving false positives exist (PASS now) ──────────────
+
+  @Nested
+  @DisplayName("False Positive Proof — current behavior captures setup queries")
+  class FalsePositiveProof {
+
+    @Test
+    @DisplayName("deleteAllInBatch() in @BeforeEach triggers update-without-where false positive")
+    void deleteAllInSetupTriggersUpdateWithoutWhere() {
+      // Simulate what a typical @BeforeEach does: clean up before test
+      // deleteAllInBatch() generates bare "DELETE FROM table" without WHERE
+      queryInterceptor.start();
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report = analyzer.analyze("FalsePositiveProof", "deleteAll", queries, null);
+
+      // PROVES THE PROBLEM: deleteAll() triggers ERROR-level update-without-where
+      List<Issue> updateWithoutWhere =
+          report.getConfirmedIssues().stream()
+              .filter(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE)
+              .toList();
+
+      assertThat(updateWithoutWhere)
+          .as("deleteAll() in @BeforeEach should trigger update-without-where (proving false positive exists)")
+          .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("repeated save() in @BeforeEach triggers repeated-single-insert false positive")
+    void repeatedSaveInSetupTriggersRepeatedSingleInsert() {
+      // Simulate what a typical @BeforeEach does: create test fixtures
+      queryInterceptor.start();
+      for (int i = 0; i < 5; i++) {
+        Team team = new Team("Team " + i);
+        teamRepository.save(team);
+      }
+      entityManager.flush();
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report =
+          analyzer.analyze("FalsePositiveProof", "repeatedSave", queries, null);
+
+      // PROVES THE PROBLEM: repeated save() triggers repeated-single-insert
+      List<Issue> repeatedInsert =
+          report.getConfirmedIssues().stream()
+              .filter(i -> i.type() == IssueType.REPEATED_SINGLE_INSERT)
+              .toList();
+
+      // Also check INFO-level in case severity differs
+      List<Issue> repeatedInsertInfo =
+          report.getInfoIssues().stream()
+              .filter(i -> i.type() == IssueType.REPEATED_SINGLE_INSERT)
+              .toList();
+
+      assertThat(repeatedInsert.size() + repeatedInsertInfo.size())
+          .as("Repeated save() in @BeforeEach should trigger repeated-single-insert (proving false positive exists)")
+          .isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("Combined setup pattern: deleteAll + repeated save produces multiple false positives")
+    void combinedSetupPatternProducesMultipleFalsePositives() {
+      // This is the realistic scenario described in the issue
+      queryInterceptor.start();
+
+      // Cleanup phase (typical @BeforeEach)
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+
+      // Fixture creation phase (typical @BeforeEach)
+      for (int i = 0; i < 5; i++) {
+        Team team = new Team("Team " + i);
+        teamRepository.save(team);
+        for (int j = 0; j < 3; j++) {
+          Member member =
+              new Member("Member " + i + "-" + j, "m" + i + j + "@test.com", "ACTIVE");
+          member.setTeam(team);
+          memberRepository.save(member);
+        }
+      }
+      entityManager.flush();
+      entityManager.clear();
+
+      // Actual test: a simple query
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report =
+          analyzer.analyze("FalsePositiveProof", "combined", queries, null);
+
+      // Count false positives from setup
+      long setupFalsePositives =
+          report.getConfirmedIssues().stream()
+              .filter(
+                  i ->
+                      i.type() == IssueType.UPDATE_WITHOUT_WHERE
+                          || i.type() == IssueType.REPEATED_SINGLE_INSERT)
+              .count();
+
+      assertThat(setupFalsePositives)
+          .as("Combined setup pattern should produce multiple false positives from test infrastructure")
+          .isGreaterThanOrEqualTo(2);
+    }
+  }
+
+  // ── Group 2: Desired behavior after implementation (FAIL until implemented) ──
+
+  @Nested
+  @DisplayName("Desired Behavior — lifecycle phase awareness")
+  class DesiredBehavior {
+
+    @BeforeEach
+    void setUpFixtures() {
+      for (int i = 0; i < 5; i++) {
+        Team team = new Team("Team " + i);
+        teamRepository.save(team);
+        for (int j = 0; j < 3; j++) {
+          Member member =
+              new Member("Member " + i + "-" + j, "m" + i + j + "@test.com", "ACTIVE");
+          member.setTeam(team);
+          memberRepository.save(member);
+        }
+      }
+      entityManager.flush();
+      entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("QueryInterceptor should support lifecycle phase tracking")
+    void interceptorSupportsPhaseTracking() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      memberRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+
+      // All queries should have a phase assigned
+      assertThat(queries).allSatisfy(q -> assertThat(q.phase()).isNotNull());
+
+      // Setup queries should be tagged as SETUP
+      List<QueryRecord> setupQueries =
+          queries.stream().filter(q -> q.phase() == LifecyclePhase.SETUP).toList();
+      assertThat(setupQueries)
+          .as("deleteAllInBatch() queries should be tagged as SETUP")
+          .isNotEmpty();
+
+      // Test queries should be tagged as TEST
+      List<QueryRecord> testQueries =
+          queries.stream().filter(q -> q.phase() == LifecyclePhase.TEST).toList();
+      assertThat(testQueries)
+          .as("findByStatus() queries should be tagged as TEST")
+          .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Analyzer should exclude SETUP-phase queries from detection by default")
+    void analyzerExcludesSetupPhaseQueries() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      // Setup: deleteAllInBatch + repeated save → would trigger false positives
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+      for (int i = 0; i < 5; i++) {
+        teamRepository.save(new Team("T" + i));
+      }
+      entityManager.flush();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      // Test: a clean query with no issues
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report =
+          analyzer.analyze("DesiredBehavior", "excludeSetup", queries, null);
+
+      // After the fix: setup-phase false positives should NOT appear
+      assertThat(report.getConfirmedIssues())
+          .as("SETUP-phase queries should be excluded from confirmed issues")
+          .noneMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE)
+          .noneMatch(i -> i.type() == IssueType.REPEATED_SINGLE_INSERT);
+    }
+
+    @Test
+    @DisplayName("Analyzer should still detect issues in TEST-phase queries")
+    void analyzerStillDetectsTestPhaseIssues() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      // These happen during the test method — should be detected
+      memberRepository.deleteAllInBatch(); // update-without-where: legitimate detection
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report =
+          analyzer.analyze("DesiredBehavior", "detectTestPhase", queries, null);
+
+      // TEST-phase update-without-where should still be detected
+      assertThat(report.getConfirmedIssues())
+          .as("TEST-phase queries should still trigger detection rules")
+          .anyMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+
+    @Test
+    @DisplayName("TEARDOWN-phase queries should also be excluded by default")
+    void teardownPhaseQueriesExcluded() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.setPhase(LifecyclePhase.TEARDOWN);
+
+      // Cleanup in @AfterEach — should not trigger detection
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report =
+          analyzer.analyze("DesiredBehavior", "excludeTeardown", queries, null);
+
+      assertThat(report.getConfirmedIssues())
+          .as("TEARDOWN-phase queries should be excluded from detection")
+          .noneMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+
+    @Test
+    @DisplayName("Default phase should be TEST when not explicitly set")
+    void defaultPhaseIsTest() {
+      queryInterceptor.start();
+      // No explicit setPhase() call — should default to TEST for backward compatibility
+
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+
+      assertThat(queries)
+          .as("When no phase is set, queries should default to TEST phase")
+          .allSatisfy(q -> assertThat(q.phase()).isEqualTo(LifecyclePhase.TEST));
+    }
+
+    @Test
+    @DisplayName("includeSetupQueries config should analyze all phases when enabled")
+    void includeSetupQueriesAnalyzesAllPhases() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      memberRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+
+      // With includeSetupQueries = true, setup queries should be analyzed
+      QueryAuditConfig config =
+          QueryAuditConfig.builder().includeSetupQueries(true).failOnDetection(false).build();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer(config);
+      QueryAuditReport report =
+          analyzer.analyze("DesiredBehavior", "includeSetup", queries, null);
+
+      // When includeSetupQueries is enabled, setup-phase issues should be detected
+      assertThat(report.getConfirmedIssues())
+          .as("With includeSetupQueries=true, setup-phase issues should be detected")
+          .anyMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+
+    @Test
+    @DisplayName("Report should include query count from all phases but only detect issues in TEST phase")
+    void reportCountsAllQueriesButDetectsOnlyTestPhase() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      // 2 setup queries (member first due to FK constraint)
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      // 1 test query
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> allQueries = queryInterceptor.getRecordedQueries();
+      long setupCount = allQueries.stream().filter(q -> q.phase() == LifecyclePhase.SETUP).count();
+      long testCount = allQueries.stream().filter(q -> q.phase() == LifecyclePhase.TEST).count();
+
+      assertThat(setupCount).as("Should have captured setup queries").isGreaterThanOrEqualTo(2);
+      assertThat(testCount).as("Should have captured test queries").isGreaterThanOrEqualTo(1);
+
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report =
+          analyzer.analyze("DesiredBehavior", "countAll", allQueries, null);
+
+      // Total count includes all phases (for reporting transparency)
+      assertThat(report.getTotalQueryCount())
+          .as("Total query count should include ALL phases")
+          .isEqualTo(allQueries.size());
+
+      // But detection should only run on TEST-phase queries
+      assertThat(report.getConfirmedIssues())
+          .as("Detection should only run on TEST-phase queries")
+          .noneMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+  }
+
+  // ── Group 3: Extension auto-phase — verifies Extension lifecycle callbacks ──
+
+  @Nested
+  @DisplayName("Extension Auto-Phase — Extension automatically tags lifecycle phases")
+  @QueryAudit(
+      failOnDetection = true,
+      failOn = {IssueType.UPDATE_WITHOUT_WHERE, IssueType.REPEATED_SINGLE_INSERT})
+  class ExtensionAutoPhase {
+
+    /**
+     * The Extension's beforeEach() starts the interceptor with SETUP phase,
+     * then beforeTestExecution() switches to TEST before the @Test method runs.
+     * If the Extension does NOT manage phases correctly, deleteAllInBatch() in
+     * @BeforeEach would be tagged as TEST and trigger update-without-where,
+     * causing failOnDetection=true to throw an AssertionError.
+     *
+     * <p>This test passing IS the assertion: it proves the Extension auto-excludes
+     * @BeforeEach queries from detection.
+     */
+    @BeforeEach
+    void setupWithProblematicQueries() {
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+      for (int i = 0; i < 5; i++) {
+        Team team = new Team("Team " + i);
+        teamRepository.save(team);
+      }
+      entityManager.flush();
+      entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("@BeforeEach queries auto-excluded — failOnDetection=true does not throw")
+    void setupQueriesAutoExcludedByExtension() {
+      // Clean query in TEST phase — no issues expected
+      memberRepository.findByStatus("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("@BeforeEach with deleteAll + repeated save does not produce false positives")
+    void noFalsePositivesFromSetupFixtures() {
+      // Another clean query — the @BeforeEach above runs every time,
+      // and its deleteAll + repeated save must not trigger detection.
+      List<Team> teams = teamRepository.findAll();
+      assertThat(teams).hasSize(5);
+    }
+  }
+
+  // ── Group 4: Extension auto-phase with @AfterEach ──
+
+  @Nested
+  @DisplayName("Extension Auto-Phase Teardown — @AfterEach queries also excluded")
+  @QueryAudit(
+      failOnDetection = true,
+      failOn = {IssueType.UPDATE_WITHOUT_WHERE, IssueType.REPEATED_SINGLE_INSERT})
+  class ExtensionAutoTeardown {
+
+    @BeforeEach
+    void createFixtures() {
+      Team team = new Team("TeardownTest");
+      teamRepository.save(team);
+      entityManager.flush();
+      entityManager.clear();
+    }
+
+    @AfterEach
+    void teardownWithProblematicQueries() {
+      // deleteAllInBatch() in @AfterEach would trigger update-without-where
+      // if captured as TEST phase.
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("@AfterEach queries auto-excluded — failOnDetection=true does not throw")
+    void teardownQueriesAutoExcludedByExtension() {
+      teamRepository.findAll();
+    }
+  }
+
+  // ── Group 5: includeSetupQueries annotation opt-in ─────────────────────
+
+  @Nested
+  @DisplayName("Include Setup Queries — annotation opt-in analyzes all phases")
+  class IncludeSetupQueriesAnnotation {
+
+    @Test
+    @DisplayName("includeSetupQueries=true via annotation — @BeforeEach issues ARE detected")
+    void setupQueriesDetectedWhenOptedIn() {
+      // Simulate Extension behavior: tag queries with SETUP phase
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+
+      // With includeSetupQueries=true (as @QueryAudit annotation would set),
+      // SETUP-phase queries should be analyzed and issues detected.
+      QueryAuditConfig config =
+          QueryAuditConfig.builder().includeSetupQueries(true).failOnDetection(false).build();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer(config);
+      QueryAuditReport report =
+          analyzer.analyze("IncludeSetup", "optIn", queries, null);
+
+      assertThat(report.getConfirmedIssues())
+          .as("With includeSetupQueries=true, SETUP-phase update-without-where should be detected")
+          .anyMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+
+    @Test
+    @DisplayName("includeSetupQueries=false (default) — same queries, @BeforeEach issues excluded")
+    void setupQueriesExcludedByDefault() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+
+      // Default config: includeSetupQueries=false → SETUP excluded
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report =
+          analyzer.analyze("IncludeSetup", "default", queries, null);
+
+      assertThat(report.getConfirmedIssues())
+          .as("With default config, SETUP-phase update-without-where should be excluded")
+          .noneMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+  }
+
+  // ── Group 6: Edge cases ───────────────────────────────────────────────
+
+  @Nested
+  @DisplayName("Edge Cases — boundary conditions and combined filters")
+  class EdgeCases {
+
+    @Test
+    @DisplayName("SETUP and TEST both have issues — only TEST-phase issues detected")
+    void mixedPhaseIssuesOnlyTestDetected() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      // SETUP: would trigger update-without-where (should be excluded)
+      memberRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      // TEST: also triggers update-without-where (should be detected)
+      teamRepository.deleteAllInBatch();
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report = analyzer.analyze("Edge", "mixed", queries, null);
+
+      // TEST-phase update-without-where should still be detected
+      assertThat(report.getConfirmedIssues())
+          .as("TEST-phase issues should still be detected even when SETUP has same issue type")
+          .anyMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+
+    @Test
+    @DisplayName("All queries in SETUP phase — clean report with no confirmed issues")
+    void allSetupQueriesProduceCleanReport() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      memberRepository.deleteAllInBatch();
+      teamRepository.deleteAllInBatch();
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      assertThat(queries).as("Queries should be captured").isNotEmpty();
+
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report = analyzer.analyze("Edge", "allSetup", queries, null);
+
+      assertThat(report.getConfirmedIssues())
+          .as("All-SETUP report should have no confirmed issues")
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("start() resets phase back to TEST")
+    void startResetsPhase() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      // Calling start() again should reset phase to TEST
+      queryInterceptor.start();
+
+      memberRepository.findByStatus("ACTIVE");
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      assertThat(queries)
+          .as("After start() reset, queries should default to TEST phase")
+          .allSatisfy(q -> assertThat(q.phase()).isEqualTo(LifecyclePhase.TEST));
+    }
+
+    @Test
+    @DisplayName("Suppress filter and phase filter work together")
+    void suppressAndPhaseFilterCombined() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      // SETUP query — excluded by phase filter
+      memberRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      // TEST query — excluded by suppress filter
+      teamRepository.deleteAllInBatch();
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+
+      // Suppress update-without-where — so even TEST-phase won't trigger it
+      QueryAuditConfig config =
+          QueryAuditConfig.builder().addSuppressPattern("update-without-where").build();
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer(config);
+      QueryAuditReport report = analyzer.analyze("Edge", "combined", queries, null);
+
+      assertThat(report.getConfirmedIssues())
+          .as("Both suppress and phase filters should work together")
+          .noneMatch(i -> i.type() == IssueType.UPDATE_WITHOUT_WHERE);
+    }
+
+    @Test
+    @DisplayName("Phase filter does not affect query count in report (all non-suppressed counted)")
+    void phaseFilterDoesNotAffectQueryCount() {
+      queryInterceptor.start();
+      queryInterceptor.setPhase(LifecyclePhase.SETUP);
+
+      memberRepository.deleteAllInBatch();
+
+      queryInterceptor.setPhase(LifecyclePhase.TEST);
+
+      memberRepository.findByStatus("ACTIVE");
+
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      int totalCaptured = queries.size();
+
+      QueryAuditAnalyzer analyzer = new QueryAuditAnalyzer();
+      QueryAuditReport report = analyzer.analyze("Edge", "count", queries, null);
+
+      // totalQueryCount should include ALL phases (not just TEST)
+      assertThat(report.getTotalQueryCount())
+          .as("Query count should include all phases for transparency")
+          .isEqualTo(totalCaptured);
+    }
+  }
+}


### PR DESCRIPTION
(#35)

## What
<!-- 무엇을 변경했는지 -->
Add lifecycle phase awareness (SETUP/TEST/TEARDOWN) to auto-exclude test infrastructure queries from detection. 
Queries are tagged via Extension callbacks and only TEST-phase queries are analyzed by default.

- LifecyclePhase enum + QueryRecord phase field
- BeforeTestExecution/AfterTestExecution callbacks in Extension
- Phase filtering in QueryAuditAnalyzer
- @QueryAudit(includeSetupQueries) annotation opt-in

## Why
<!-- 왜 필요한지 -->
deleteAll() in @BeforeEach triggered update-without-where (151 false positives),
repeated save() triggered repeated-single-insert (23 false positives).
These are test infrastructure, not production code paths.


## Checklist
- [ ] `./gradlew build` passes
- [ ] Tests added (true positive + false positive)
- [ ] False positive test suites still pass
- [ ] Commit messages follow conventional commits
