### PR TITLE
fix: write HTML report once after all test classes complete (#41)

### DIFF
--- a/query-audit-core/src/test/java/io/queryaudit/core/reporter/HtmlReportAggregatorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/reporter/HtmlReportAggregatorTest.java
@@ -1,0 +1,122 @@
+package io.queryaudit.core.reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryAuditReport;
+import io.queryaudit.core.model.Severity;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class HtmlReportAggregatorTest {
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    HtmlReportAggregator.getInstance().reset();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static QueryAuditReport dummyReport(String testClass, String testName) {
+    Issue issue =
+        new Issue(
+            IssueType.N_PLUS_ONE,
+            Severity.ERROR,
+            "SELECT * FROM orders WHERE user_id = ?",
+            "orders",
+            null,
+            "Repeated query detected 5 times",
+            "Use JOIN FETCH or batch loading");
+    return new QueryAuditReport(
+        testClass, testName, List.of(issue), List.of(), List.of(), List.of(), 1, 5, 100_000L);
+  }
+
+  // ── Tests ────────────────────────────────────────────────────────
+
+  @Nested
+  @DisplayName("Issue #41: singleton accumulation behavior")
+  class SingletonAccumulation {
+
+    /**
+     * The aggregator is a singleton that accumulates reports without resetting.
+     * Calling writeReport() at intermediate points produces incomplete HTML files
+     * because later test classes haven't added their reports yet.
+     *
+     * <p>This is why writeReport should only be called once, after ALL test classes finish.
+     * The fix is in QueryAuditExtension (ReportFinalizer), not in the aggregator itself.
+     */
+    @Test
+    @DisplayName("intermediate writes produce incomplete reports — only final write has all data")
+    void intermediateWritesAreIncomplete() throws IOException {
+      HtmlReportAggregator aggregator = HtmlReportAggregator.getInstance();
+
+      // Class 1: 2 tests
+      aggregator.addReport(dummyReport("ClassA", "test1"));
+      aggregator.addReport(dummyReport("ClassA", "test2"));
+
+      Path dir1 = tempDir.resolve("intermediate1");
+      aggregator.writeReport(dir1);
+
+      // Class 2: 1 test
+      aggregator.addReport(dummyReport("ClassB", "test3"));
+
+      Path dir2 = tempDir.resolve("intermediate2");
+      aggregator.writeReport(dir2);
+
+      // Class 3: 1 test
+      aggregator.addReport(dummyReport("ClassC", "test4"));
+
+      Path dirFinal = tempDir.resolve("final");
+      aggregator.writeReport(dirFinal);
+
+      // Intermediate report 1 is missing ClassB and ClassC data
+      String html1 = Files.readString(dir1.resolve("index.html"));
+      assertThat(html1).doesNotContain("ClassB");
+      assertThat(html1).doesNotContain("ClassC");
+
+      // Intermediate report 2 is missing ClassC data
+      String html2 = Files.readString(dir2.resolve("index.html"));
+      assertThat(html2).doesNotContain("ClassC");
+
+      // Only the final report has everything
+      String htmlFinal = Files.readString(dirFinal.resolve("index.html"));
+      assertThat(htmlFinal).contains("ClassA").contains("ClassB").contains("ClassC");
+    }
+
+    @Test
+    @DisplayName("single writeReport after all addReport calls produces complete report")
+    void singleWriteProducesCompleteReport() throws IOException {
+      HtmlReportAggregator aggregator = HtmlReportAggregator.getInstance();
+
+      // Simulate multiple test classes adding reports
+      aggregator.addReport(dummyReport("OrderServiceTest", "testCreateOrder"));
+      aggregator.addReport(dummyReport("OrderServiceTest", "testDeleteOrder"));
+      aggregator.addReport(dummyReport("UserServiceTest", "testFindUser"));
+      aggregator.addReport(dummyReport("PaymentServiceTest", "testCharge"));
+
+      // One single write at the very end — the correct behavior after fix
+      Path outputDir = tempDir.resolve("output");
+      aggregator.writeReport(outputDir);
+
+      String html = Files.readString(outputDir.resolve("index.html"));
+      assertThat(html)
+          .contains("OrderServiceTest")
+          .contains("UserServiceTest")
+          .contains("PaymentServiceTest");
+
+      assertThat(aggregator.getReports())
+          .as("All 4 reports present in singleton")
+          .hasSize(4);
+    }
+  }
+}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -281,43 +281,87 @@ public class QueryAuditExtension
 
     writeCountBaselineIfRequested(context);
 
-    HtmlReportAggregator aggregator = HtmlReportAggregator.getInstance();
-    if (aggregator.getReports().isEmpty()) {
-      return;
+    // Register a ReportFinalizer in the root context store so that
+    // writeReport + openReportInBrowser runs exactly once after ALL test classes finish,
+    // instead of once per test class (see issue #41).
+    boolean autoOpen = shouldAutoOpenReport(context);
+    ExtensionContext root = context.getRoot();
+    ReportFinalizer finalizer =
+        (ReportFinalizer)
+            root.getStore(NAMESPACE)
+                .getOrComputeIfAbsent(
+                    ReportFinalizer.class.getName(),
+                    key -> new ReportFinalizer(this));
+    if (autoOpen) {
+      finalizer.enableAutoOpen();
+    }
+  }
+
+  /**
+   * Registered once in the root {@link ExtensionContext.Store} via {@code getOrComputeIfAbsent}.
+   * JUnit calls {@link #close()} exactly once when the root context is torn down — after all
+   * test classes have completed.
+   */
+  static final class ReportFinalizer implements ExtensionContext.Store.CloseableResource {
+
+    private final QueryAuditExtension extension;
+    private volatile boolean autoOpen;
+
+    ReportFinalizer(QueryAuditExtension extension) {
+      this.extension = extension;
     }
 
-    try {
-      java.nio.file.Path outputDir = java.nio.file.Path.of("build", "reports", "query-audit");
-      aggregator.writeReport(outputDir);
-      java.nio.file.Path reportPath = outputDir.toAbsolutePath().resolve("index.html");
+    void enableAutoOpen() {
+      this.autoOpen = true;
+    }
 
-      // Summary line — visible even without opening the report
-      long totalErrors = aggregator.getReports().stream()
-              .mapToLong(r -> r.getErrors().size()).sum();
-      long totalWarnings = aggregator.getReports().stream()
-              .mapToLong(r -> r.getWarnings().size()).sum();
-      int totalQueries = aggregator.getReports().stream()
-              .mapToInt(r -> r.getTotalQueryCount()).sum();
-      int totalTests = aggregator.getReports().size();
-
-      // Summary + clickable link on its own line (IDE auto-detects file:// URLs)
-      String summary = "[QueryAudit] " + totalTests + " tests, " + totalQueries + " queries"
-              + (totalErrors > 0 ? ", " + totalErrors + " ERROR" + (totalErrors > 1 ? "S" : "") : "")
-              + (totalWarnings > 0 ? ", " + totalWarnings + " WARNING" + (totalWarnings > 1 ? "S" : "") : "")
-              + (totalErrors == 0 && totalWarnings == 0 ? " — all clean" : "");
-      System.out.println();
-      System.out.println(summary);
-      System.out.println("[QueryAudit] file://" + reportPath.toAbsolutePath());
-      System.out.println();
-
-      // Write JSON report alongside HTML
-      writeJsonReport(aggregator.getReports(), outputDir);
-
-      if (shouldAutoOpenReport(context)) {
-        openReportInBrowser(reportPath);
+    @Override
+    public void close() {
+      HtmlReportAggregator aggregator = HtmlReportAggregator.getInstance();
+      if (aggregator.getReports().isEmpty()) {
+        return;
       }
-    } catch (Exception e) {
-      System.err.println("[QueryAudit] Failed to write HTML report: " + e.getMessage());
+
+      try {
+        java.nio.file.Path outputDir = java.nio.file.Path.of("build", "reports", "query-audit");
+        aggregator.writeReport(outputDir);
+        java.nio.file.Path reportPath = outputDir.toAbsolutePath().resolve("index.html");
+
+        // Summary line — visible even without opening the report
+        long totalErrors =
+            aggregator.getReports().stream().mapToLong(r -> r.getErrors().size()).sum();
+        long totalWarnings =
+            aggregator.getReports().stream().mapToLong(r -> r.getWarnings().size()).sum();
+        int totalQueries =
+            aggregator.getReports().stream().mapToInt(r -> r.getTotalQueryCount()).sum();
+        int totalTests = aggregator.getReports().size();
+
+        String summary =
+            "[QueryAudit] "
+                + totalTests
+                + " tests, "
+                + totalQueries
+                + " queries"
+                + (totalErrors > 0
+                    ? ", " + totalErrors + " ERROR" + (totalErrors > 1 ? "S" : "")
+                    : "")
+                + (totalWarnings > 0
+                    ? ", " + totalWarnings + " WARNING" + (totalWarnings > 1 ? "S" : "")
+                    : "")
+                + (totalErrors == 0 && totalWarnings == 0 ? " — all clean" : "");
+        System.out.println();
+        System.out.println(summary);
+        System.out.println("[QueryAudit] file://" + reportPath.toAbsolutePath());
+        System.out.println();
+
+        extension.writeJsonReport(aggregator.getReports(), outputDir);
+
+        if (autoOpen) {
+          extension.openReportInBrowser(reportPath);
+        }
+      } catch (Exception e) {
+        System.err.println("[QueryAudit] Failed to write HTML report: " + e.getMessage());
+      }
     }
   }
 

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/QueryAuditExtensionAfterAllTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/QueryAuditExtensionAfterAllTest.java
@@ -1,0 +1,190 @@
+package io.queryaudit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryAuditReport;
+import io.queryaudit.core.model.Severity;
+import io.queryaudit.core.reporter.HtmlReportAggregator;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+@DisplayName("QueryAuditExtension — afterAll report finalization (issue #41)")
+class QueryAuditExtensionAfterAllTest {
+
+  private static final ExtensionContext.Namespace NAMESPACE =
+      ExtensionContext.Namespace.create(QueryAuditExtension.class);
+
+  @BeforeEach
+  void setUp() {
+    HtmlReportAggregator.getInstance().reset();
+  }
+
+
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  private static QueryAuditReport dummyReport(String testClass, String testName) {
+    Issue issue =
+        new Issue(
+            IssueType.N_PLUS_ONE,
+            Severity.ERROR,
+            "SELECT * FROM orders WHERE user_id = ?",
+            "orders",
+            null,
+            "Repeated query detected",
+            "Use JOIN FETCH");
+    return new QueryAuditReport(
+        testClass, testName, List.of(issue), List.of(), List.of(), List.of(), 1, 5, 100_000L);
+  }
+
+  /**
+   * Creates a mock ExtensionContext for a top-level test class.
+   * Uses a real Class object to avoid Mockito's inability to mock Class.
+   */
+  @SuppressWarnings("unchecked")
+  private static ExtensionContext mockContext(
+      Class<?> testClass, ExtensionContext root, ExtensionContext.Store rootStore) {
+    ExtensionContext ctx = mock(ExtensionContext.class);
+
+    when(ctx.getRequiredTestClass()).thenReturn((Class) testClass);
+    when(ctx.getRoot()).thenReturn(root);
+    when(ctx.getTestMethod()).thenReturn(Optional.empty());
+    when(ctx.getParent()).thenReturn(Optional.of(root));
+
+    ExtensionContext.Store classStore = mock(ExtensionContext.Store.class);
+    when(ctx.getStore(NAMESPACE)).thenReturn(classStore);
+
+    return ctx;
+  }
+
+  /**
+   * Creates a store backed by a real ConcurrentHashMap so that
+   * getOrComputeIfAbsent behaves correctly across multiple calls.
+   */
+  private static ExtensionContext.Store createRootStore() {
+    java.util.Map<Object, Object> backingMap = new java.util.concurrent.ConcurrentHashMap<>();
+
+    ExtensionContext.Store store = mock(ExtensionContext.Store.class);
+
+    when(store.getOrComputeIfAbsent(anyString(), any()))
+        .thenAnswer(
+            invocation -> {
+              String key = invocation.getArgument(0);
+              java.util.function.Function<Object, Object> factory = invocation.getArgument(1);
+              return backingMap.computeIfAbsent(key, factory);
+            });
+
+    when(store.get(anyString())).thenAnswer(inv -> backingMap.get(inv.getArgument(0)));
+
+    return store;
+  }
+
+  // ── Tests ────────────────────────────────────────────────────────
+
+  @Nested
+  @DisplayName("ReportFinalizer is registered once via getOrComputeIfAbsent")
+  class FinalizerRegistration {
+
+    @Test
+    @DisplayName("multiple afterAll calls register only one ReportFinalizer in root store")
+    void multipleAfterAllCalls_registerOneFinalizer() {
+      ExtensionContext.Store rootStore = createRootStore();
+      ExtensionContext root = mock(ExtensionContext.class);
+      when(root.getStore(NAMESPACE)).thenReturn(rootStore);
+
+      QueryAuditExtension extension = new QueryAuditExtension();
+
+      // Use top-level JDK classes (getEnclosingClass() == null) to pass the nested-class guard
+      Class<?>[] fakeClasses = {String.class, Integer.class, Long.class};
+      String[] classNames = {"String", "Integer", "Long"};
+
+      for (int i = 0; i < fakeClasses.length; i++) {
+        ExtensionContext ctx = mockContext(fakeClasses[i], root, rootStore);
+        HtmlReportAggregator.getInstance().addReport(dummyReport(classNames[i], "test1"));
+        extension.afterAll(ctx);
+      }
+
+      // getOrComputeIfAbsent called 3 times (once per afterAll)
+      verify(rootStore, times(3))
+          .getOrComputeIfAbsent(eq(QueryAuditExtension.ReportFinalizer.class.getName()), any());
+
+      // But only one ReportFinalizer instance exists
+      Object finalizer = rootStore.get(QueryAuditExtension.ReportFinalizer.class.getName());
+      assertThat(finalizer)
+          .as("Only one ReportFinalizer should be registered")
+          .isInstanceOf(QueryAuditExtension.ReportFinalizer.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("ReportFinalizer.close() writes report exactly once")
+  class FinalizerClose {
+
+    @Test
+    @DisplayName("close() writes complete report with all accumulated data")
+    void closeWritesCompleteReport() throws Exception {
+      HtmlReportAggregator aggregator = HtmlReportAggregator.getInstance();
+      aggregator.addReport(dummyReport("ClassA", "test1"));
+      aggregator.addReport(dummyReport("ClassB", "test2"));
+      aggregator.addReport(dummyReport("ClassC", "test3"));
+
+      QueryAuditExtension extension = new QueryAuditExtension();
+      QueryAuditExtension.ReportFinalizer finalizer =
+          new QueryAuditExtension.ReportFinalizer(extension);
+
+      finalizer.close();
+
+      assertThat(aggregator.getReports()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("close() does nothing when no reports accumulated")
+    void closeWithNoReports_doesNothing() throws Exception {
+      QueryAuditExtension extension = new QueryAuditExtension();
+      QueryAuditExtension.ReportFinalizer finalizer =
+          new QueryAuditExtension.ReportFinalizer(extension);
+
+      finalizer.close();
+
+      assertThat(HtmlReportAggregator.getInstance().getReports()).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Nested test classes skip afterAll report logic")
+  class NestedClassHandling {
+
+    // A real inner class (has enclosing class)
+    class InnerTestClass {}
+
+    @Test
+    @SuppressWarnings("unchecked")
+    @DisplayName("afterAll returns early for @Nested inner classes")
+    void nestedClassSkipsReportFinalization() {
+      ExtensionContext.Store rootStore = createRootStore();
+      ExtensionContext root = mock(ExtensionContext.class);
+      when(root.getStore(NAMESPACE)).thenReturn(rootStore);
+
+      QueryAuditExtension extension = new QueryAuditExtension();
+
+      ExtensionContext ctx = mock(ExtensionContext.class);
+      when(ctx.getRequiredTestClass()).thenReturn((Class) InnerTestClass.class);
+
+      HtmlReportAggregator.getInstance().addReport(dummyReport("Outer", "test1"));
+
+      extension.afterAll(ctx);
+
+      // Root store should NOT have been accessed — no finalizer registered
+      verify(ctx, never()).getRoot();
+    }
+  }
+}


### PR DESCRIPTION
#41 

## What     
Replace per-class `writeReport()` + `openReportInBrowser()` in `afterAll()` with a single
`ReportFinalizer` (CloseableResource) registered in the root ExtensionContext store.                                        
                                                                                                                              
## Why                                                                                                                      
`afterAll()` runs once per test class, but `HtmlReportAggregator` is a singleton.                                           
This caused the HTML report to be written and opened in the browser N times for N test classes.                             
By deferring to `CloseableResource.close()`, JUnit invokes it exactly once when the root context                            
is torn down — producing a single complete report and opening one browser tab.                                              
                                                                                                                              
## Checklist                                                                                                                
- [x] `./gradlew build` passes                                                                                              
- [x] Tests added (true positive + false positive)
- [x] False positive test suites still pass
- [x] Commit messages follow conventional commits   