### PR TITLE
fix: skip string literals in removeSubqueries

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
@@ -1233,6 +1233,44 @@ public final class SqlParser {
 
     for (int i = 0; i < sql.length(); i++) {
       char c = sql.charAt(i);
+
+      // Skip single-quoted string literals so embedded keywords like '(SELECT' are not
+      // mistaken for subquery starts (mirrors the approach used in stripComments).
+      if (c == '\'') {
+        if (!inSubquery) {
+          sb.append(c);
+        }
+        i++;
+        while (i < sql.length()) {
+          char inner = sql.charAt(i);
+          if (inner == '\\' && i + 1 < sql.length()) {
+            if (!inSubquery) {
+              sb.append(inner);
+              sb.append(sql.charAt(i + 1));
+            }
+            i += 2;
+          } else if (inner == '\'' && i + 1 < sql.length() && sql.charAt(i + 1) == '\'') {
+            if (!inSubquery) {
+              sb.append('\'');
+              sb.append('\'');
+            }
+            i += 2;
+          } else if (inner == '\'') {
+            if (!inSubquery) {
+              sb.append(inner);
+            }
+            i++;
+            break;
+          } else {
+            if (!inSubquery) {
+              sb.append(inner);
+            }
+            i++;
+          }
+        }
+        continue;
+      }
+
       if (c == '(') {
         // Check if this opens a subquery
         int ahead = i + 1;

--- a/query-audit-core/src/test/java/io/queryaudit/core/parser/SqlParserTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/parser/SqlParserTest.java
@@ -831,4 +831,35 @@ class SqlParserTest {
       assertThat(SqlParser.hasWhereClause(null)).isFalse();
     }
   }
+
+  // ── removeSubqueries ───────────────────────────────────────────────
+
+  @Nested
+  class RemoveSubqueries {
+
+    @Test
+    void removesActualSubquery() {
+      String sql = "SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)";
+      String result = SqlParser.removeSubqueries(sql);
+      assertThat(result).contains("(?)");
+      assertThat(result).doesNotContain("SELECT user_id");
+    }
+
+    @Test
+    void preservesStringLiteralContainingSelectKeyword() {
+      String sql =
+          "SELECT * FROM logs WHERE message = 'Error in (SELECT query failed)' AND status = 'active'";
+      String result = SqlParser.removeSubqueries(sql);
+      assertThat(result).contains("AND status = 'active'");
+      assertThat(result).contains("'Error in (SELECT query failed)'");
+    }
+
+    @Test
+    void preservesEscapedQuoteInsideStringLiteral() {
+      String sql =
+          "SELECT * FROM t WHERE col = 'it''s a (SELECT trick)' AND x = 1";
+      String result = SqlParser.removeSubqueries(sql);
+      assertThat(result).contains("AND x = 1");
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes `SqlParser.removeSubqueries()` to respect single-quoted string literal boundaries, preventing SQL keywords like `(SELECT` inside quoted strings from being incorrectly treated as subquery starts
- Adds string-literal-aware scanning (mirroring the existing `stripComments()` approach) that skips escaped quotes and doubled quotes
- Adds unit tests covering: actual subquery removal, string literals containing `(SELECT`, and escaped quotes inside literals

Closes #54

## Test plan
- [ ] `SqlParserTest.RemoveSubqueries.removesActualSubquery`
- [ ] `SqlParserTest.RemoveSubqueries.preservesStringLiteralContainingSelectKeyword`
- [ ] `SqlParserTest.RemoveSubqueries.preservesEscapedQuoteInsideStringLiteral`

🤖 Generated with [Claude Code](https://claude.com/claude-code)