### PR TITLE
fix: split N_PLUS_ONE into separate issue types for SQL-level and Hib…

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/NPlusOneDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/NPlusOneDetector.java
@@ -59,7 +59,7 @@ public class NPlusOneDetector implements DetectionRule {
 
       issues.add(
           new Issue(
-              IssueType.N_PLUS_ONE,
+              IssueType.N_PLUS_ONE_SUSPECT,
               Severity.INFO,
               entry.getValue().get(0).sql(),
               table,

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
@@ -10,6 +10,8 @@ import static io.queryaudit.core.model.Severity.*;
  */
 public enum IssueType {
   N_PLUS_ONE("n-plus-one", "N+1 Query detected", ERROR),
+  N_PLUS_ONE_SUSPECT(
+      "n-plus-one-suspect", "N+1 Query suspected (SQL-level heuristic)", INFO),
   SELECT_ALL("select-all", "SELECT * usage", INFO),
   WHERE_FUNCTION("where-function", "Function usage in WHERE clause disables index", ERROR),
   OR_ABUSE("or-abuse", "Excessive OR conditions in WHERE clause", WARNING),

--- a/query-audit-core/src/main/java/io/queryaudit/core/ranking/ImpactScorer.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/ranking/ImpactScorer.java
@@ -94,7 +94,7 @@ public final class ImpactScorer {
 
   static int patternScore(IssueType type) {
     return switch (type) {
-      case N_PLUS_ONE -> 50;
+      case N_PLUS_ONE, N_PLUS_ONE_SUSPECT -> 50;
       case MISSING_JOIN_INDEX -> 40;
       case FOR_UPDATE_WITHOUT_INDEX -> 40;
       case MISSING_WHERE_INDEX -> 30;

--- a/query-audit-core/src/test/java/io/queryaudit/core/ImprovementVerificationTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/ImprovementVerificationTest.java
@@ -557,7 +557,7 @@ class ImprovementVerificationTest {
 
       List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
       assertThat(issues).hasSize(1);
-      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE);
+      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE_SUSPECT);
     }
   }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/RobustnessTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/RobustnessTest.java
@@ -603,21 +603,21 @@ class RobustnessTest {
                   .count())
           .isEqualTo(0);
 
-      // At threshold (3 consecutive queries with null stacks): SQL-level N+1 is now INFO
+      // At threshold (3 consecutive queries with null stacks): SQL-level N+1 suspect is INFO
       List<QueryRecord> threeQueries = createRepeatedQueriesNoStack(sql, 3);
       QueryAuditReport r3 = analyzer.analyze("test", threeQueries, null);
       assertThat(
               r3.getInfoIssues().stream()
-                  .filter(i -> i.type().getCode().equals("n-plus-one"))
+                  .filter(i -> i.type().getCode().equals("n-plus-one-suspect"))
                   .count())
           .isGreaterThan(0);
 
-      // At threshold+2 (5 queries with null stacks): SQL-level N+1 is INFO
+      // At threshold+2 (5 queries with null stacks): SQL-level N+1 suspect is INFO
       List<QueryRecord> fiveQueries = createRepeatedQueriesNoStack(sql, 5);
       QueryAuditReport r5 = analyzer.analyze("test", fiveQueries, null);
       assertThat(
               r5.getInfoIssues().stream()
-                  .filter(i -> i.type().getCode().equals("n-plus-one"))
+                  .filter(i -> i.type().getCode().equals("n-plus-one-suspect"))
                   .count())
           .isGreaterThan(0);
     }
@@ -1300,11 +1300,11 @@ class RobustnessTest {
                 "stack"));
       }
       QueryAuditReport report = analyzer.analyze("n+1-test", queries, null);
-      // SQL-level N+1 is now INFO (Hibernate-level is authoritative)
+      // SQL-level N+1 suspect is INFO (Hibernate-level is authoritative)
       assertThat(report.getInfoIssues()).isNotEmpty();
       assertThat(
               report.getInfoIssues().stream()
-                  .anyMatch(i -> i.type().getCode().equals("n-plus-one")))
+                  .anyMatch(i -> i.type().getCode().equals("n-plus-one-suspect")))
           .isTrue();
     }
   }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/AcademicBenchmarkTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/AcademicBenchmarkTest.java
@@ -639,7 +639,7 @@ class AcademicBenchmarkTest {
       List<Issue> bad = detector.evaluate(badQueries, EMPTY_INDEX);
       List<Issue> good = detector.evaluate(goodQueries, EMPTY_INDEX);
 
-      assertAntiPatternDetected(bad, IssueType.N_PLUS_ONE, good);
+      assertAntiPatternDetected(bad, IssueType.N_PLUS_ONE_SUSPECT, good);
     }
 
     @Test
@@ -715,7 +715,7 @@ class AcademicBenchmarkTest {
       List<Issue> bad = detector.evaluate(badQueries, EMPTY_INDEX);
       List<Issue> good = detector.evaluate(goodQueries, EMPTY_INDEX);
 
-      assertAntiPatternDetected(bad, IssueType.N_PLUS_ONE, good);
+      assertAntiPatternDetected(bad, IssueType.N_PLUS_ONE_SUSPECT, good);
     }
 
     @Test

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
@@ -186,7 +186,7 @@ class ComprehensiveFalsePositiveTest {
       List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
 
       assertThat(issues).hasSize(1);
-      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE);
+      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE_SUSPECT);
       assertThat(issues.get(0).severity()).isEqualTo(Severity.INFO);
     }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/DetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/DetectorTest.java
@@ -40,7 +40,7 @@ class DetectorTest {
 
       List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
       assertThat(issues).hasSize(1);
-      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE);
+      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE_SUSPECT);
       assertThat(issues.get(0).severity()).isEqualTo(Severity.INFO);
       assertThat(issues.get(0).detail()).contains("5 times");
     }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/NPlusOneVerificationTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/NPlusOneVerificationTest.java
@@ -96,7 +96,7 @@ class NPlusOneVerificationTest {
 
       assertThat(issues).hasSize(1);
       assertThat(issues.get(0).severity()).isEqualTo(Severity.INFO);
-      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE);
+      assertThat(issues.get(0).type()).isEqualTo(IssueType.N_PLUS_ONE_SUSPECT);
       assertThat(issues.get(0).detail()).contains("5 times");
     }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/QueryAuditAnalyzerTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/QueryAuditAnalyzerTest.java
@@ -44,7 +44,7 @@ class QueryAuditAnalyzerTest {
     assertThat(report.getInfoIssues()).anyMatch(i -> i.type() == IssueType.SELECT_ALL);
 
     // N+1: SQL-level detection is now INFO (Hibernate-level is authoritative)
-    assertThat(report.getInfoIssues()).anyMatch(i -> i.type() == IssueType.N_PLUS_ONE);
+    assertThat(report.getInfoIssues()).anyMatch(i -> i.type() == IssueType.N_PLUS_ONE_SUSPECT);
   }
 
   @Test

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/RealWorldCorpusBenchmarkTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/RealWorldCorpusBenchmarkTest.java
@@ -791,7 +791,7 @@ class RealWorldCorpusBenchmarkTest {
       allIssues.addAll(report.getConfirmedIssues());
       allIssues.addAll(report.getInfoIssues());
 
-      assertThat(allIssues.stream().filter(i -> i.type() == IssueType.N_PLUS_ONE).toList())
+      assertThat(allIssues.stream().filter(i -> i.type() == IssueType.N_PLUS_ONE_SUSPECT).toList())
           .as("N+1 pattern should be detected")
           .isNotEmpty();
     }
@@ -1166,6 +1166,7 @@ class RealWorldCorpusBenchmarkTest {
             IssueType.HAVING_MISUSE,
             IssueType.CORRELATED_SUBQUERY,
             IssueType.N_PLUS_ONE,
+            IssueType.N_PLUS_ONE_SUSPECT,
             IssueType.UNBOUNDED_RESULT_SET,
             IssueType.DML_WITHOUT_INDEX,
             IssueType.COVERING_INDEX_OPPORTUNITY,

--- a/query-audit-core/src/test/java/io/queryaudit/core/eval/Team5SeverityAuditTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/eval/Team5SeverityAuditTest.java
@@ -43,16 +43,14 @@ class Team5SeverityAuditTest {
   }
 
   // -----------------------------------------------------------------------
-  // 1. N_PLUS_ONE (default ERROR) - SQL-level detector emits INFO, LazyLoad emits ERROR
-  // Verdict: CORRECT - IssueType default is ERROR, matching LazyLoad authoritative detection
+  // 1. N_PLUS_ONE (ERROR) - LazyLoad authoritative detection
+  //    N_PLUS_ONE_SUSPECT (INFO) - SQL-level heuristic detection
+  // Verdict: CORRECT - each detector uses its own IssueType with appropriate severity
   // -----------------------------------------------------------------------
   @Test
   void nPlusOne_severityIsError_correct() {
-    // The IssueType default severity is ERROR
     assertThat(IssueType.N_PLUS_ONE.getDefaultSeverity()).isEqualTo(Severity.ERROR);
-    // Note: SQL-level NPlusOneDetector emits INFO (supplementary), but the
-    // authoritative LazyLoadNPlusOneDetector emits ERROR. The IssueType default
-    // is ERROR, which matches the authoritative detector. CORRECT.
+    assertThat(IssueType.N_PLUS_ONE_SUSPECT.getDefaultSeverity()).isEqualTo(Severity.INFO);
   }
 
   // -----------------------------------------------------------------------
@@ -753,7 +751,13 @@ class Team5SeverityAuditTest {
                 "ERROR",
                 "ERROR",
                 "OK",
-                "Authoritative LazyLoad detector correctly uses ERROR"),
+                "Authoritative LazyLoad detector uses ERROR"),
+            new AuditEntry(
+                "N_PLUS_ONE_SUSPECT",
+                "INFO",
+                "INFO",
+                "OK",
+                "SQL-level heuristic detector uses INFO"),
             new AuditEntry(
                 "SELECT_ALL",
                 "INFO",
@@ -1037,6 +1041,6 @@ class Team5SeverityAuditTest {
           .isNotNull();
     }
     // Verify the total count matches what we audited (56 issue types)
-    assertThat(IssueType.values().length).isEqualTo(65);
+    assertThat(IssueType.values().length).isEqualTo(66);
   }
 }

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/QueryAuditJpaIntegrationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/QueryAuditJpaIntegrationTest.java
@@ -88,7 +88,7 @@ class QueryAuditJpaIntegrationTest {
 
       // SQL-level N+1 is now INFO (Hibernate-level LazyLoadTracker is authoritative)
       List<Issue> infoNPlusOne =
-          report.getInfoIssues().stream().filter(i -> i.type() == IssueType.N_PLUS_ONE).toList();
+          report.getInfoIssues().stream().filter(i -> i.type() == IssueType.N_PLUS_ONE_SUSPECT).toList();
 
       // The SQL-level N+1 should be detected as INFO
       assertThat(infoNPlusOne).isNotEmpty();

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/Team6SqlStyleIntegrationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/Team6SqlStyleIntegrationTest.java
@@ -197,7 +197,7 @@ class Team6SqlStyleIntegrationTest {
 
       QueryAuditReport report = analyze("nPlusOne", queryInterceptor.getRecordedQueries());
       assertThat(allIssues(report))
-          .anyMatch(i -> i.type() == IssueType.N_PLUS_ONE);
+          .anyMatch(i -> i.type() == IssueType.N_PLUS_ONE || i.type() == IssueType.N_PLUS_ONE_SUSPECT);
     }
   }
 
@@ -222,7 +222,7 @@ class Team6SqlStyleIntegrationTest {
       QueryAuditReport report = analyze("lazyLoadNPlusOne", queries);
       // SQL-level N+1 detected as INFO
       assertThat(allIssues(report))
-          .anyMatch(i -> i.type() == IssueType.N_PLUS_ONE);
+          .anyMatch(i -> i.type() == IssueType.N_PLUS_ONE || i.type() == IssueType.N_PLUS_ONE_SUSPECT);
     }
   }
 }


### PR DESCRIPTION
#68 

## What
Split the shared `IssueType.N_PLUS_ONE` that was used by both the SQL-level and Hibernate-level detectors.
- `N_PLUS_ONE` (ERROR) — dedicated to `LazyLoadNPlusOneDetector` (confirmed detection based on Hibernate events)
- `N_PLUS_ONE_SUSPECT` (INFO) — dedicated to `NPlusOneDetector` (heuristic detection based on SQL patterns)

## Why
The same `IssueType` had inconsistent severities (ERROR vs INFO), causing user confusion.
When setting `failOn = {N_PLUS_ONE}`, it was unclear whether SQL-level heuristics would also be included.

## Checklist
- [x] `./gradlew build` passes
- [x] Tests added (true positive + false positive)
- [x] False positive test suites still pass
- [x] Commit messages follow conventional commits
