### PR TITLE
chore: add release-please version marker

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
-version=0.1.0
+# x-release-please-version
+version=0.2.0
 group=io.github.haroya01


### PR DESCRIPTION
Enables release-please to auto-bump gradle.properties version on future releases.