### PR TITLE
chore: add one-shot manual publish workflow

### DIFF
--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -1,0 +1,28 @@
+name: Manual Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and Test
+        run: ./gradlew build test
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish-manual.yml` with a `workflow_dispatch` trigger so 0.2.0 can be published to Maven Central after the marker fix.
- One-shot: delete after running.

## Why
The 0.2.0 publish via `release-please.yml` uploaded 0.1.0 artifacts (marker was missing). Main now has `version=0.2.0`, but `release-please.yml`'s publish job only runs when release-please creates a release — and it already did for 0.2.0. No dispatch hook exists to re-trigger it.

## Test plan
- [ ] Merge this PR
- [ ] Actions tab → "Manual Publish" → Run workflow on `main`
- [ ] Verify 0.2.0 lands on Maven Central
- [ ] Delete this workflow file