### PR TITLE
ci: run MySQL and PostgreSQL integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,28 @@ jobs:
             **/build/reports/tests/
             **/build/test-results/
           retention-days: 14
+
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Integration Test
+        run: ./gradlew :query-audit-mysql:integrationTest :query-audit-postgresql:integrationTest
+
+      - name: Upload integration test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports
+          path: |
+            **/build/reports/tests/integrationTest/
+            **/build/test-results/integrationTest/
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Add `integration-test` job to `.github/workflows/ci.yml` that runs `:query-audit-mysql:integrationTest` and `:query-audit-postgresql:integrationTest` via Testcontainers on `ubuntu-latest`.
- Previously these tasks were defined but never invoked by any workflow, so `MySqlIndexMetadataProvider` / `PostgreSqlIndexMetadataProvider` (and the ExplainAnalyzer suites) were never exercised in PR checks.

## Test plan
- [x] Verified locally: `./gradlew :query-audit-mysql:integrationTest :query-audit-postgresql:integrationTest` passes (~31s) against Docker-backed Testcontainers.
- [x] CI green on this PR's `integration-test` job.

Closes #105