### PR TITLE
fix(core): SqlParser comma-in-literal and quoted schema-qualified tables

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
@@ -221,7 +221,6 @@ public final class SqlParser {
     return sb.toString();
   }
 
-
   // ── normalize ──────────────────────────────────────────────────────
 
   private static final Pattern NUMBERS =
@@ -382,7 +381,8 @@ public final class SqlParser {
   // ── extractDeleteTable ──────────────────────────────────────────────
 
   private static final Pattern DELETE_TABLE =
-      Pattern.compile("^\\s*DELETE\\s+FROM\\s+(?:`(\\w+)`|\"(\\w+)\"|(\\w+))", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "^\\s*DELETE\\s+FROM\\s+(?:`(\\w+)`|\"(\\w+)\"|(\\w+))", Pattern.CASE_INSENSITIVE);
 
   /** Extracts the target table name from a DELETE statement. */
   public static String extractDeleteTable(String sql) {
@@ -397,7 +397,8 @@ public final class SqlParser {
   // ── extractInsertTable ──────────────────────────────────────────────
 
   private static final Pattern INSERT_TABLE =
-      Pattern.compile("^\\s*INSERT\\s+INTO\\s+(?:`(\\w+)`|\"(\\w+)\"|(\\w+))", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "^\\s*INSERT\\s+INTO\\s+(?:`(\\w+)`|\"(\\w+)\"|(\\w+))", Pattern.CASE_INSENSITIVE);
 
   /** Extracts the target table name from an INSERT statement. */
   public static String extractInsertTable(String sql) {
@@ -710,6 +711,9 @@ public final class SqlParser {
     if (body == null) {
       return result;
     }
+    // Replace single-quoted literals with '?' so a comma inside a literal
+    // (e.g. ORDER BY name, 'a,b', created_at) is not treated as a separator.
+    body = replaceStringLiterals(body);
     // Split by commas that are NOT inside parentheses
     List<String> parts = splitByTopLevelCommas(body);
     for (String part : parts) {
@@ -881,8 +885,7 @@ public final class SqlParser {
    */
   private static final Pattern[] JOIN_ON_TERMINATORS = {
     Pattern.compile(
-        "\\b(?:LEFT|RIGHT|INNER|CROSS|FULL)?\\s*(?:OUTER\\s+)?JOIN\\b",
-        Pattern.CASE_INSENSITIVE),
+        "\\b(?:LEFT|RIGHT|INNER|CROSS|FULL)?\\s*(?:OUTER\\s+)?JOIN\\b", Pattern.CASE_INSENSITIVE),
     Pattern.compile("\\bWHERE\\b", Pattern.CASE_INSENSITIVE),
     Pattern.compile("\\bGROUP\\s+BY\\b", Pattern.CASE_INSENSITIVE),
     Pattern.compile("\\bORDER\\s+BY\\b", Pattern.CASE_INSENSITIVE),
@@ -1217,14 +1220,23 @@ public final class SqlParser {
 
   // ── extractTableNames ──────────────────────────────────────────────
 
+  // An identifier segment: backtick-quoted, double-quoted, or bare.
+  private static final String IDENT_SEGMENT = "(?:`\\w+`|\"\\w+\"|\\w+)";
+
+  // schema-qualified name: optional schema segment followed by a table segment.
+  // Each segment may independently be quoted (supports "schema"."table", `s`.`t`,
+  // and mixed forms like "schema".table).
+  private static final String QUALIFIED_NAME =
+      "(" + IDENT_SEGMENT + "(?:\\." + IDENT_SEGMENT + ")?)";
+
   private static final Pattern FROM_TABLE =
       Pattern.compile(
-          "\\bFROM\\s+(?:`(\\w+)`|\"(\\w+)\"|(\\w+(?:\\.\\w+)?))(?:\\s+(?:AS\\s+)?(?:[`\"]?\\w+[`\"]?))?",
+          "\\bFROM\\s+" + QUALIFIED_NAME + "(?:\\s+(?:AS\\s+)?(?:[`\"]?\\w+[`\"]?))?",
           Pattern.CASE_INSENSITIVE);
 
   private static final Pattern JOIN_TABLE =
       Pattern.compile(
-          "\\bJOIN\\s+(?:`(\\w+)`|\"(\\w+)\"|(\\w+(?:\\.\\w+)?))(?:\\s+(?:AS\\s+)?(?:[`\"]?\\w+[`\"]?))?",
+          "\\bJOIN\\s+" + QUALIFIED_NAME + "(?:\\s+(?:AS\\s+)?(?:[`\"]?\\w+[`\"]?))?",
           Pattern.CASE_INSENSITIVE);
 
   public static List<String> extractTableNames(String sql) {
@@ -1238,28 +1250,35 @@ public final class SqlParser {
 
     Matcher fromMatcher = FROM_TABLE.matcher(sql);
     while (fromMatcher.find()) {
-      String table = firstNonNull(fromMatcher.group(1), fromMatcher.group(2), fromMatcher.group(3));
-      // For schema-qualified names like "schema.table", take just the table part
-      if (table != null && table.contains(".")) {
-        table = table.substring(table.lastIndexOf('.') + 1);
-      }
-      if (table != null && !isKeyword(table) && !result.contains(table)) {
-        result.add(table);
-      }
+      addTableFromQualifiedMatch(fromMatcher.group(1), result);
     }
 
     Matcher joinMatcher = JOIN_TABLE.matcher(sql);
     while (joinMatcher.find()) {
-      String table = firstNonNull(joinMatcher.group(1), joinMatcher.group(2), joinMatcher.group(3));
-      if (table != null && table.contains(".")) {
-        table = table.substring(table.lastIndexOf('.') + 1);
-      }
-      if (table != null && !isKeyword(table) && !result.contains(table)) {
-        result.add(table);
-      }
+      addTableFromQualifiedMatch(joinMatcher.group(1), result);
     }
 
     return result;
+  }
+
+  /**
+   * Extracts the table name from a (possibly schema-qualified, possibly quoted) identifier and adds
+   * it to {@code result} if it is a non-keyword not already present. Each segment is unquoted
+   * independently so {@code "schema"."table"}, {@code `schema`.`table`}, and mixed forms all
+   * resolve to the table segment.
+   */
+  private static void addTableFromQualifiedMatch(String qualified, List<String> result) {
+    if (qualified == null) {
+      return;
+    }
+    // A '.' inside a quoted segment would be illegal under our regex (segments are \w+),
+    // so splitting on the last unquoted dot is equivalent to lastIndexOf('.').
+    int dot = qualified.lastIndexOf('.');
+    String tableSegment = dot >= 0 ? qualified.substring(dot + 1) : qualified;
+    String table = unquoteIdentifier(tableSegment);
+    if (table != null && !isKeyword(table) && !result.contains(table)) {
+      result.add(table);
+    }
   }
 
   // ── helpers ─────────────────────────────────────────────────────────

--- a/query-audit-core/src/test/java/io/queryaudit/core/parser/EnhancedOrderGroupByTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/parser/EnhancedOrderGroupByTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies EnhancedSqlParser.extractOrderByColumns / extractGroupByColumns against the
- * issue #102 literal reproducer and common shapes.
+ * Verifies EnhancedSqlParser.extractOrderByColumns / extractGroupByColumns against the issue #102
+ * literal reproducer and common shapes.
  */
 class EnhancedOrderGroupByTest {
 
@@ -20,15 +20,10 @@ class EnhancedOrderGroupByTest {
     List<ColumnReference> regex = SqlParser.extractOrderByColumns(sql);
     List<ColumnReference> enhanced = EnhancedSqlParser.extractOrderByColumns(sql);
 
-    System.out.println("[#102] regex    = " + regex);
-    System.out.println("[#102] enhanced = " + enhanced);
-
-    // Regex buggy baseline: [name, a, b, created_at] — splits the literal at the comma.
-    assertThat(regex).extracting(ColumnReference::columnName)
-        .containsExactly("name", "a", "b", "created_at");
-
-    // Enhanced: literal is opaque → only the two real columns remain.
-    assertThat(enhanced).extracting(ColumnReference::columnName)
+    // Both parsers now treat single-quoted literals as opaque.
+    assertThat(regex).extracting(ColumnReference::columnName).containsExactly("name", "created_at");
+    assertThat(enhanced)
+        .extracting(ColumnReference::columnName)
         .containsExactly("name", "created_at");
   }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/parser/SqlParserStressTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/parser/SqlParserStressTest.java
@@ -935,12 +935,9 @@ class SqlParserStressTest {
 
     @Test
     void schemaQualifiedTable() {
-      // FROM schema.table_name - current regex \bFROM\s+(\w+) captures "schema" not "table_name"
       List<String> tables =
           SqlParser.extractTableNames("SELECT * FROM myschema.users WHERE id = 1");
-      // Current impl captures "myschema" since regex stops at word boundary before dot
-      // This is a known limitation - document actual behavior
-      assertThat(tables).isNotEmpty();
+      assertThat(tables).containsExactly("users");
     }
 
     @Test
@@ -1137,7 +1134,13 @@ class SqlParserStressTest {
     void manyJoinsDoNotCauseBacktracking() {
       StringBuilder sb = new StringBuilder("SELECT * FROM t1 ");
       for (int i = 2; i <= 25; i++) {
-        sb.append("JOIN t").append(i).append(" ON t").append(i).append(".a = t").append(i - 1).append(".a ");
+        sb.append("JOIN t")
+            .append(i)
+            .append(" ON t")
+            .append(i)
+            .append(".a = t")
+            .append(i - 1)
+            .append(".a ");
       }
       sb.append("WHERE t1.status = 'active' AND t1.created > '2020-01-01'");
       String sql = sb.toString();
@@ -1206,8 +1209,13 @@ class SqlParserStressTest {
     void manyJoinsWithFunctionsDoNotCauseBacktracking() {
       StringBuilder sb = new StringBuilder("SELECT * FROM t1 ");
       for (int i = 2; i <= 20; i++) {
-        sb.append("LEFT JOIN t").append(i)
-            .append(" ON LOWER(t").append(i).append(".name) = LOWER(t").append(i - 1).append(".name) ");
+        sb.append("LEFT JOIN t")
+            .append(i)
+            .append(" ON LOWER(t")
+            .append(i)
+            .append(".name) = LOWER(t")
+            .append(i - 1)
+            .append(".name) ");
       }
       sb.append("WHERE t1.active = 1");
       String sql = sb.toString();

--- a/query-audit-core/src/test/java/io/queryaudit/core/parser/SqlParserTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/parser/SqlParserTest.java
@@ -71,10 +71,8 @@ class SqlParserTest {
     @Test
     void preservesDoubleQuotedColumnIdentifiers() {
       String result =
-          SqlParser.normalize(
-              "SELECT \"userId\" FROM \"User\" WHERE \"deletedAt\" IS NULL");
-      assertThat(result)
-          .isEqualTo("select \"userid\" from \"user\" where \"deletedat\" is null");
+          SqlParser.normalize("SELECT \"userId\" FROM \"User\" WHERE \"deletedAt\" IS NULL");
+      assertThat(result).isEqualTo("select \"userid\" from \"user\" where \"deletedat\" is null");
     }
 
     @Test
@@ -97,8 +95,7 @@ class SqlParserTest {
               "SELECT \"userId\" FROM \"User\" WHERE \"deletedAt\" IS NULL AND \"id\" = 42");
       // Verify structure is correct first
       assertThat(q1)
-          .isEqualTo(
-              "select \"userid\" from \"user\" where \"deletedat\" is null and \"id\" = ?");
+          .isEqualTo("select \"userid\" from \"user\" where \"deletedat\" is null and \"id\" = ?");
       // Then verify grouping
       assertThat(q1).isEqualTo(q2);
     }
@@ -115,8 +112,7 @@ class SqlParserTest {
           SqlParser.normalize(
               "SELECT \"userId\" FROM \"User\" WHERE \"name\" = 'John' AND \"age\" > 30");
       assertThat(result)
-          .isEqualTo(
-              "select \"userid\" from \"user\" where \"name\" = ? and \"age\" > ?");
+          .isEqualTo("select \"userid\" from \"user\" where \"name\" = ? and \"age\" > ?");
     }
   }
 
@@ -361,6 +357,26 @@ class SqlParserTest {
     void nullReturnsEmpty() {
       assertThat(SqlParser.extractOrderByColumns(null)).isEmpty();
     }
+
+    // Regression for #102: a comma inside a single-quoted literal used to leak phantom columns.
+    @Test
+    void ignoresCommasInsideStringLiterals() {
+      List<ColumnReference> cols =
+          SqlParser.extractOrderByColumns("SELECT * FROM t ORDER BY name, 'a,b', created_at");
+      assertThat(cols)
+          .extracting(ColumnReference::columnName)
+          .containsExactly("name", "created_at");
+    }
+
+    @Test
+    void ignoresCommasInsideStringLiteralsWithEscapes() {
+      List<ColumnReference> cols =
+          SqlParser.extractOrderByColumns(
+              "SELECT * FROM t ORDER BY name, 'it''s, here', created_at");
+      assertThat(cols)
+          .extracting(ColumnReference::columnName)
+          .containsExactly("name", "created_at");
+    }
   }
 
   // ── extractGroupByColumns ───────────────────────────────────────────
@@ -392,6 +408,15 @@ class SqlParserTest {
     @Test
     void nullReturnsEmpty() {
       assertThat(SqlParser.extractGroupByColumns(null)).isEmpty();
+    }
+
+    // Regression for #102.
+    @Test
+    void ignoresCommasInsideStringLiterals() {
+      List<ColumnReference> cols =
+          SqlParser.extractGroupByColumns(
+              "SELECT status, COUNT(*) FROM t GROUP BY status, 'x,y', role");
+      assertThat(cols).extracting(ColumnReference::columnName).containsExactly("status", "role");
     }
   }
 
@@ -796,6 +821,37 @@ class SqlParserTest {
               "SELECT * FROM \"User\" u JOIN \"UserRole\" ur ON u.\"id\" = ur.\"userId\"");
       assertThat(tables).containsExactlyInAnyOrder("User", "UserRole");
     }
+
+    // Regression for #103: quoted schema-qualified identifiers used to return the schema
+    // name, which made every index-lookup detector silently miss the real table.
+    @Test
+    void doubleQuotedSchemaQualifiedTable() {
+      List<String> tables =
+          SqlParser.extractTableNames("SELECT * FROM \"myschema\".\"mytable\" WHERE id = 1");
+      assertThat(tables).containsExactly("mytable");
+    }
+
+    @Test
+    void backtickQuotedSchemaQualifiedTable() {
+      List<String> tables =
+          SqlParser.extractTableNames("SELECT * FROM `myschema`.`mytable` WHERE id = 1");
+      assertThat(tables).containsExactly("mytable");
+    }
+
+    @Test
+    void mixedQuotedSchemaQualifiedTable() {
+      List<String> tables =
+          SqlParser.extractTableNames("SELECT * FROM \"myschema\".mytable WHERE id = 1");
+      assertThat(tables).containsExactly("mytable");
+    }
+
+    @Test
+    void quotedSchemaQualifiedJoin() {
+      List<String> tables =
+          SqlParser.extractTableNames(
+              "SELECT * FROM \"s\".\"orders\" o JOIN \"s\".\"users\" u ON o.user_id = u.id");
+      assertThat(tables).containsExactlyInAnyOrder("orders", "users");
+    }
   }
 
   // ── PostgreSQL double-quoted identifiers: column extraction (issue #52) ──
@@ -816,8 +872,7 @@ class SqlParserTest {
     @Test
     void extractWhereColumnsWithTableQualifiedDoubleQuote() {
       List<ColumnReference> cols =
-          SqlParser.extractWhereColumns(
-              "SELECT * FROM \"User\" u WHERE u.\"status\" = 'active'");
+          SqlParser.extractWhereColumns("SELECT * FROM \"User\" u WHERE u.\"status\" = 'active'");
       assertThat(cols).extracting(ColumnReference::columnName).containsExactly("status");
     }
 
@@ -836,7 +891,8 @@ class SqlParserTest {
       List<ColumnReference> cols =
           SqlParser.extractOrderByColumns(
               "SELECT * FROM \"User\" ORDER BY \"userName\" ASC, \"createdAt\" DESC");
-      assertThat(cols).extracting(ColumnReference::columnName)
+      assertThat(cols)
+          .extracting(ColumnReference::columnName)
           .containsExactly("userName", "createdAt");
     }
 


### PR DESCRIPTION
## Summary
- **#102**: `extractOrderByColumns` / `extractGroupByColumns` now call `replaceStringLiterals` on the clause body before splitting by commas, so a literal like `'a,b'` no longer leaks phantom columns into the output. Bug impacted `OrderByLimitWithoutIndexDetector`, `NonDeterministicPaginationDetector`, and anything else that groups by the extracted columns.
- **#103**: `extractTableNames` now recognizes fully-quoted schema-qualified forms (`"schema"."table"`, `` `schema`.`table` ``, and mixed) and returns the table segment instead of the schema. Previously every index-lookup detector (`MissingIndexDetector`, `CompositeIndexDetector`, `UnboundedResultSetDetector`, `DmlWithoutIndexDetector`, etc.) silently missed these queries.
- Regex consolidated into a shared `IDENT_SEGMENT` / `QUALIFIED_NAME` helper; `addTableFromQualifiedMatch` centralizes the schema-vs-table split and unquoting.

## Test plan
- [x] New regression tests in `SqlParserTest` for both bugs (literal comma in ORDER BY / GROUP BY including `''` escape form; double-quoted, backtick-quoted, and mixed schema.table forms in FROM and JOIN).
- [x] Updated `EnhancedOrderGroupByTest#issue102_orderByLiteral` — this test used to pin the buggy regex baseline (part of the #99 "known detector gaps" tracking). Both parsers now agree.
- [x] Updated `SqlParserStressTest#schemaQualifiedTable` — was only asserting `isNotEmpty()` with a comment documenting the bug; now asserts the correct table name.
- [x] `./gradlew :query-audit-core:test` passes locally (full suite, ~3.3k tests).

Closes #102
Closes #103