### PR TITLE
fix(core): detector bug cluster — 8 issues, one commit each

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/CollectionManagementDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/CollectionManagementDetector.java
@@ -9,9 +9,14 @@ import io.queryaudit.core.parser.EnhancedSqlParser;
 import io.queryaudit.core.parser.SqlParser;
 import io.queryaudit.core.parser.WhereColumnReference;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Detects the DELETE-all + re-INSERT pattern that occurs with unidirectional {@code @OneToMany} or
@@ -30,6 +35,14 @@ import java.util.Set;
 public class CollectionManagementDetector implements DetectionRule {
 
   private static final int DEFAULT_MIN_INSERTS = 2;
+
+  /**
+   * Upper bound on the WHERE column cardinality we consider a "collection delete" shape. Simple
+   * FK is 1; a composite owner key (e.g. parent_id + discriminator) is typically 2–3. Beyond
+   * that the DELETE is almost certainly not a Hibernate collection DELETE, so we stay silent to
+   * avoid false positives on unrelated bulk DELETEs.
+   */
+  private static final int MAX_WHERE_COLUMNS_FOR_COLLECTION = 4;
 
   private final int minInserts;
 
@@ -62,9 +75,23 @@ public class CollectionManagementDetector implements DetectionRule {
         continue;
       }
 
-      // Extract WHERE columns from the DELETE
+      // Extract WHERE columns from the DELETE. Collection DELETEs typically filter by the owner
+      // key, which may be a single FK column or a small composite — e.g. Hibernate @MapsId with
+      // a discriminator like (parent_id = ?, child_kind = ?) (issue #94). Allow up to a small
+      // composite cardinality so these patterns are still caught.
       List<WhereColumnReference> whereColumns = EnhancedSqlParser.extractWhereColumnsWithOperators(sql);
-      if (whereColumns.size() != 1) {
+      if (whereColumns.isEmpty() || whereColumns.size() > MAX_WHERE_COLUMNS_FOR_COLLECTION) {
+        continue;
+      }
+
+      // For composite WHERE (>1 columns), require that every subsequent INSERT carries the
+      // same (column, value) pairs as the DELETE WHERE. This distinguishes a true collection
+      // DELETE (owner-key filter, INSERTs reinsert under the same owner) from a specific-row
+      // DELETE followed by unrelated INSERTs on the same table.
+      Map<String, String> deleteWherePairs =
+          whereColumns.size() > 1 ? extractWhereEqualityPairs(sql) : Map.of();
+      if (whereColumns.size() > 1 && deleteWherePairs.size() != whereColumns.size()) {
+        // Couldn't confirm every WHERE column is a simple col = literal/? equality; bail out.
         continue;
       }
 
@@ -75,6 +102,13 @@ public class CollectionManagementDetector implements DetectionRule {
         if (SqlParser.isInsertQuery(nextSql)) {
           String insertTable = SqlParser.extractInsertTable(nextSql);
           if (deleteTable.equalsIgnoreCase(insertTable)) {
+            if (!deleteWherePairs.isEmpty()
+                && !insertMatchesDeleteWhereValues(nextSql, deleteWherePairs)) {
+              // Composite WHERE values didn't carry over to this INSERT — not a collection
+              // DELETE shape, don't flag anything for this DELETE.
+              insertCount = 0;
+              break;
+            }
             insertCount++;
           } else {
             break;
@@ -86,6 +120,15 @@ public class CollectionManagementDetector implements DetectionRule {
 
       if (insertCount >= minInserts) {
         flaggedTables.add(deleteTable.toLowerCase());
+        StringBuilder cols = new StringBuilder();
+        for (int k = 0; k < whereColumns.size(); k++) {
+          if (k > 0) cols.append(", ");
+          cols.append(whereColumns.get(k).columnName());
+        }
+        String whereLabel =
+            whereColumns.size() == 1
+                ? "a single FK column '" + whereColumns.get(0).columnName() + "'"
+                : "composite owner key (" + cols + ")";
         issues.add(
             new Issue(
                 IssueType.COLLECTION_DELETE_REINSERT,
@@ -97,9 +140,9 @@ public class CollectionManagementDetector implements DetectionRule {
                     + insertCount
                     + " re-INSERTs detected on table '"
                     + deleteTable
-                    + "'. The DELETE has a single FK column '"
-                    + whereColumns.get(0).columnName()
-                    + "' in WHERE, followed by "
+                    + "'. The DELETE has "
+                    + whereLabel
+                    + " in WHERE, followed by "
                     + insertCount
                     + " INSERTs.",
                 "DELETE-all + re-INSERT pattern on table '"
@@ -110,5 +153,60 @@ public class CollectionManagementDetector implements DetectionRule {
     }
 
     return issues;
+  }
+
+  private static final Pattern WHERE_EQUALITY_PAIR =
+      Pattern.compile(
+          "(?i)(?:\\w+\\.)?(\\w+)\\s*=\\s*('[^']*'|\\?|-?\\d+)");
+
+  private static final Pattern INSERT_COLS_VALUES =
+      Pattern.compile(
+          "(?i)INSERT\\s+INTO\\s+\\w+\\s*\\(([^)]+)\\)\\s+VALUES\\s*\\(([^)]+)\\)");
+
+  /**
+   * Extracts {@code column -> value} pairs from a DELETE's WHERE clause where each condition is
+   * a simple {@code col = literal-or-?} equality joined by AND. Returns an empty map if the
+   * WHERE contains anything more complex (so the caller bails out of the composite path).
+   */
+  private static Map<String, String> extractWhereEqualityPairs(String sql) {
+    String where = EnhancedSqlParser.extractWhereBody(sql);
+    if (where == null) {
+      return Map.of();
+    }
+    Map<String, String> out = new LinkedHashMap<>();
+    Matcher m = WHERE_EQUALITY_PAIR.matcher(where);
+    while (m.find()) {
+      out.put(m.group(1).toLowerCase(), m.group(2).trim());
+    }
+    return out;
+  }
+
+  private static boolean insertMatchesDeleteWhereValues(
+      String insertSql, Map<String, String> deleteWherePairs) {
+    Matcher m = INSERT_COLS_VALUES.matcher(insertSql);
+    if (!m.find()) {
+      return false;
+    }
+    String[] colTokens = m.group(1).split(",");
+    String[] valTokens = m.group(2).split(",");
+    if (colTokens.length != valTokens.length) {
+      return false;
+    }
+    Map<String, String> insertColToVal = new HashMap<>();
+    for (int i = 0; i < colTokens.length; i++) {
+      insertColToVal.put(colTokens[i].trim().toLowerCase(), valTokens[i].trim());
+    }
+    for (Map.Entry<String, String> entry : deleteWherePairs.entrySet()) {
+      String actual = insertColToVal.get(entry.getKey());
+      if (actual == null) {
+        return false;
+      }
+      // ? in the DELETE matches any value in the INSERT (both came from parameterized SQL);
+      // otherwise the literal must match exactly (case-insensitive for string-equality).
+      if (!"?".equals(entry.getValue()) && !actual.equalsIgnoreCase(entry.getValue())) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/CompositeIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/CompositeIndexDetector.java
@@ -35,6 +35,7 @@ public class CompositeIndexDetector implements DetectionRule {
     List<Issue> issues = new ArrayList<>();
 
     if (indexMetadata == null || indexMetadata.isEmpty()) {
+      MetadataSkipLog.warnEmptyMetadataOnce("CompositeIndexDetector");
       return issues;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/ImplicitTypeConversionDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/ImplicitTypeConversionDetector.java
@@ -26,22 +26,50 @@ import java.util.regex.Pattern;
  */
 public class ImplicitTypeConversionDetector implements DetectionRule {
 
-  /** Suffixes/substrings in column names that strongly suggest a string type. */
-  private static final Set<String> STRING_COLUMN_INDICATORS =
+  /**
+   * Tokens (in the snake_case or camelCase-ends-with sense) in column names that strongly suggest
+   * a string type. Matched at three positions:
+   *
+   * <ul>
+   *   <li>as an entire {@code _}-separated segment (e.g. {@code user_name}, {@code email_address})
+   *   <li>as the end of a non-separated identifier (e.g. {@code ucode}, {@code firstname})
+   *   <li>as the beginning of a non-separated identifier (e.g. {@code codebook})
+   * </ul>
+   */
+  private static final Set<String> STRING_COLUMN_TOKENS =
       Set.of(
-          "_name",
-          "_email",
-          "_phone",
-          "_code",
-          "_token",
-          "_key",
-          "_slug",
-          "_handle",
-          "_address",
-          "_title",
-          "_url",
-          "_path",
-          "_type");
+          "name",
+          "email",
+          "phone",
+          "code",
+          "token",
+          "key",
+          "slug",
+          "handle",
+          "address",
+          "title",
+          "url",
+          "path",
+          "type",
+          "description",
+          "desc",
+          "note",
+          "comment",
+          "text",
+          "content",
+          "message",
+          "label",
+          "tag",
+          "remark");
+
+  /**
+   * Tokens that strongly suggest a numeric/identifier column. If a column ends with one of these,
+   * we trust the numeric hint even if another token earlier in the name would otherwise match.
+   * Without this guard, {@code description_id} (FK INT column) would be flagged because it
+   * contains the {@code description} token.
+   */
+  private static final Set<String> NUMERIC_COLUMN_TOKENS =
+      Set.of("id", "count", "num", "no", "seq", "order", "size", "length");
 
   /**
    * Pattern to match: column_name = bare_number in a WHERE context. Captures group(1) = column
@@ -109,13 +137,35 @@ public class ImplicitTypeConversionDetector implements DetectionRule {
   }
 
   /** Check if the column name suggests a string type based on known indicators. */
-  private boolean isStringColumn(String columnName) {
+  // Package-private for testability.
+  boolean isStringColumn(String columnName) {
     String lower = columnName.toLowerCase();
-    for (String indicator : STRING_COLUMN_INDICATORS) {
-      if (lower.contains(indicator)) {
+
+    // If the last snake_case segment is a numeric hint (e.g. *_id, *_count, *_order), bail out
+    // before the string-token check. This prevents false positives on FK-style column names
+    // whose leading segment happens to look string-like (e.g. "description_id").
+    int lastUnderscore = lower.lastIndexOf('_');
+    if (lastUnderscore >= 0) {
+      String lastSegment = lower.substring(lastUnderscore + 1);
+      if (NUMERIC_COLUMN_TOKENS.contains(lastSegment)) {
+        return false;
+      }
+    }
+
+    // Match as any _-separated segment.
+    for (String segment : lower.split("_")) {
+      if (STRING_COLUMN_TOKENS.contains(segment)) {
         return true;
       }
     }
+
+    // Match as end or start of a non-separated identifier (ucode, firstname, codebook).
+    for (String token : STRING_COLUMN_TOKENS) {
+      if (lower.endsWith(token) || lower.startsWith(token)) {
+        return true;
+      }
+    }
+
     return false;
   }
 }

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/LikeWildcardDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/LikeWildcardDetector.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -23,12 +22,17 @@ import java.util.regex.Pattern;
  */
 public class LikeWildcardDetector implements DetectionRule {
 
-  /**
-   * Matches LIKE followed by a string literal starting with '%'. Covers: LIKE '%...', LIKE '%...%',
-   * etc. Parameterized queries (LIKE ?) are intentionally skipped.
-   */
+  /** Matches LIKE (optionally NOT/I) followed by a string literal starting with '%'. */
   private static final Pattern LIKE_LEADING_WILDCARD =
-      Pattern.compile("\\bLIKE\\s+'%", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("\\b(?:NOT\\s+)?I?LIKE\\s+'%", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Matches LIKE against a bound parameter (e.g. {@code LIKE ?}). Runtime bindings that start
+   * with {@code %} also cause a full-table scan, but we cannot confirm that statically — this
+   * case is reported at INFO severity as a suggestive heads-up (issue #91).
+   */
+  private static final Pattern LIKE_PARAMETERIZED =
+      Pattern.compile("\\b(?:NOT\\s+)?I?LIKE\\s+\\?", Pattern.CASE_INSENSITIVE);
 
   @Override
   public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
@@ -47,11 +51,17 @@ public class LikeWildcardDetector implements DetectionRule {
         continue;
       }
 
-      Matcher matcher = LIKE_LEADING_WILDCARD.matcher(sql);
-      if (matcher.find()) {
-        List<String> tables = EnhancedSqlParser.extractTableNames(sql);
-        String table = tables.isEmpty() ? null : tables.get(0);
+      boolean hasLeadingWildcard = LIKE_LEADING_WILDCARD.matcher(sql).find();
+      boolean hasParameterizedLike = LIKE_PARAMETERIZED.matcher(sql).find();
 
+      if (!hasLeadingWildcard && !hasParameterizedLike) {
+        continue;
+      }
+
+      List<String> tables = EnhancedSqlParser.extractTableNames(sql);
+      String table = tables.isEmpty() ? null : tables.get(0);
+
+      if (hasLeadingWildcard) {
         issues.add(
             new Issue(
                 IssueType.LIKE_LEADING_WILDCARD,
@@ -64,7 +74,25 @@ public class LikeWildcardDetector implements DetectionRule {
                 "Leading wildcard (LIKE '%...') prevents B-tree index usage and causes a full table scan. "
                     + "Use a fulltext index (MATCH ... AGAINST), or move the search to the application layer.",
                 query.stackTrace()));
+        // If the query also has a parameterized LIKE, we've already warned — don't duplicate.
+        continue;
       }
+
+      // Parameterized LIKE only — runtime value unknown, so INFO severity.
+      issues.add(
+          new Issue(
+              IssueType.LIKE_LEADING_WILDCARD,
+              Severity.INFO,
+              normalized,
+              table,
+              null,
+              "Parameterized LIKE detected"
+                  + (table != null ? " on table '" + table + "'" : "")
+                  + "; if the runtime binding starts with '%' a full table scan occurs",
+              "Parameterized LIKE (LIKE ?) cannot be checked statically for a leading '%'. If the "
+                  + "binding may be prefixed with '%', prefer a fulltext index (MATCH ... AGAINST) "
+                  + "or push the search to the application layer / a dedicated search engine.",
+              query.stackTrace()));
     }
 
     return issues;

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/MergeableQueriesDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/MergeableQueriesDetector.java
@@ -148,19 +148,43 @@ public class MergeableQueriesDetector implements DetectionRule {
 
   /**
    * Extracts a normalized representation of the JOIN structure from a SQL query. Queries with
-   * different JOINs (e.g., different tables or JOIN types) should not be considered mergeable.
+   * different JOINs — different tables, different JOIN types, <b>or different ON conditions</b> —
+   * should not be considered mergeable (issue #97).
    */
-  private static final Pattern JOIN_CLAUSE =
+  // Matches the JOIN keyword itself (with optional qualifier). Used only to locate segment
+  // starts; the segment content runs until the next JOIN or terminating clause boundary below.
+  private static final Pattern JOIN_KEYWORD =
       Pattern.compile(
-          "\\b(?:LEFT\\s+(?:OUTER\\s+)?|RIGHT\\s+(?:OUTER\\s+)?|INNER\\s+|FULL\\s+(?:OUTER\\s+)?|CROSS\\s+)?JOIN\\s+\\w+",
+          "\\b(?:LEFT\\s+(?:OUTER\\s+)?|RIGHT\\s+(?:OUTER\\s+)?|INNER\\s+|FULL\\s+(?:OUTER\\s+)?|CROSS\\s+)?JOIN\\b",
           Pattern.CASE_INSENSITIVE);
 
+  private static final Pattern CLAUSE_BOUNDARY =
+      Pattern.compile("\\b(?:WHERE|GROUP|ORDER|LIMIT|HAVING|UNION)\\b", Pattern.CASE_INSENSITIVE);
+
   private String extractJoinStructure(String sql) {
+    List<int[]> joinStarts = new ArrayList<>();
+    Matcher joinMatcher = JOIN_KEYWORD.matcher(sql);
+    while (joinMatcher.find()) {
+      joinStarts.add(new int[] {joinMatcher.start(), joinMatcher.end()});
+    }
+    if (joinStarts.isEmpty()) {
+      return "";
+    }
+
     StringBuilder sb = new StringBuilder();
-    Matcher m = JOIN_CLAUSE.matcher(sql);
-    while (m.find()) {
-      if (sb.length() > 0) sb.append(",");
-      sb.append(m.group().toLowerCase().replaceAll("\\s+", " ").trim());
+    for (int i = 0; i < joinStarts.size(); i++) {
+      int segStart = joinStarts.get(i)[0];
+      int segEnd;
+      if (i + 1 < joinStarts.size()) {
+        segEnd = joinStarts.get(i + 1)[0];
+      } else {
+        Matcher cm = CLAUSE_BOUNDARY.matcher(sql);
+        segEnd = cm.find(joinStarts.get(i)[1]) ? cm.start() : sql.length();
+      }
+      if (sb.length() > 0) {
+        sb.append(",");
+      }
+      sb.append(sql.substring(segStart, segEnd).trim().replaceAll("\\s+", " ").toLowerCase());
     }
     return sb.toString();
   }

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/MetadataSkipLog.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/MetadataSkipLog.java
@@ -1,0 +1,42 @@
+package io.queryaudit.core.detector;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Warns, at most once per detector per JVM, when an index-metadata-dependent detector disables
+ * itself because the metadata is missing or empty. Without this trail users had no way to tell
+ * why a rule wasn't firing — the detectors just silently returned (issue #96).
+ *
+ * <p>The skip itself is still safe behavior (we can't analyze what we can't see); this class
+ * only adds a one-line heads-up to {@code System.err} so the gap becomes observable.
+ *
+ * @author haroya
+ * @since 0.3.0
+ */
+final class MetadataSkipLog {
+
+  private static final Set<String> WARNED = ConcurrentHashMap.newKeySet();
+
+  private MetadataSkipLog() {}
+
+  /**
+   * Emit a single warning line for {@code detectorName} if this is the first time the JVM has
+   * seen the metadata-missing skip for that detector. Subsequent calls for the same detector are
+   * no-ops.
+   */
+  static void warnEmptyMetadataOnce(String detectorName) {
+    if (WARNED.add(detectorName)) {
+      System.err.println(
+          "[QueryAudit] IndexMetadata is empty — "
+              + detectorName
+              + " is disabled. This detector requires index metadata, typically collected by the "
+              + "Spring Boot starter or a database-specific IndexMetadataProvider (MySQL/PostgreSQL).");
+    }
+  }
+
+  // @VisibleForTesting — reset the per-JVM warned set so tests can assert on output.
+  static void resetForTesting() {
+    WARNED.clear();
+  }
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/MissingIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/MissingIndexDetector.java
@@ -78,6 +78,7 @@ public class MissingIndexDetector implements DetectionRule {
     List<Issue> issues = new ArrayList<>();
 
     if (indexMetadata == null || indexMetadata.isEmpty()) {
+      MetadataSkipLog.warnEmptyMetadataOnce("MissingIndexDetector");
       return issues;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/MissingIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/MissingIndexDetector.java
@@ -158,10 +158,13 @@ public class MissingIndexDetector implements DetectionRule {
             continue;
           }
 
-          // Improvement 3: Skip LIKE operator columns — LikeWildcardDetector handles
-          // leading-wildcard LIKE, and for non-leading-wildcard LIKE we cannot determine
-          // from normalized SQL whether a B-tree index would help. Avoid misleading advice.
-          if (isLikeOperator(colWithOp.operator())) {
+          // Skip LIKE only when the column is compared against a leading-wildcard literal —
+          // those are handled by LikeWildcardDetector and a B-tree index wouldn't help. For
+          // prefix LIKEs ({@code LIKE 'foo%'}) and parameterized {@code LIKE ?} the column can
+          // still benefit from a B-tree, so fall through to the missing-index check
+          // (issue #92).
+          if (isLikeOperator(colWithOp.operator())
+              && isLeadingWildcardLike(sql, col.columnName())) {
             continue;
           }
 
@@ -376,6 +379,21 @@ public class MissingIndexDetector implements DetectionRule {
     if (operator == null) return false;
     String op = operator.trim().toUpperCase();
     return "LIKE".equals(op) || "NOT LIKE".equals(op) || "ILIKE".equals(op);
+  }
+
+  /**
+   * Returns true when the raw SQL contains a {@code <column> LIKE '%...'} form — i.e. a literal
+   * that starts with a leading wildcard for the given column. The scan is textual and tolerates
+   * an optional table qualifier, {@code NOT} / {@code I} prefix, and intervening whitespace.
+   */
+  private static boolean isLeadingWildcardLike(String sql, String column) {
+    if (sql == null || column == null) return false;
+    java.util.regex.Pattern p =
+        java.util.regex.Pattern.compile(
+            "(?i)(?:\\w+\\.)?\\b"
+                + java.util.regex.Pattern.quote(column)
+                + "\\b\\s+(?:NOT\\s+)?I?LIKE\\s+'%");
+    return p.matcher(sql).find();
   }
 
   /**

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/NonDeterministicPaginationDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/NonDeterministicPaginationDetector.java
@@ -52,6 +52,7 @@ public class NonDeterministicPaginationDetector implements DetectionRule {
 
     // Cannot determine uniqueness without index metadata
     if (indexMetadata == null || indexMetadata.isEmpty()) {
+      MetadataSkipLog.warnEmptyMetadataOnce("NonDeterministicPaginationDetector");
       return issues;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetector.java
@@ -143,9 +143,10 @@ public class OrderByLimitWithoutIndexDetector implements DetectionRule {
   }
 
   /**
-   * Checks if a non-primary index exists on the column. Separated from isPrimaryKey to avoid
-   * redundancy: PRIMARY indexes are handled by isPrimaryKey, while this checks only secondary
-   * indexes.
+   * Checks if a non-primary index can satisfy ORDER BY on the column. Only the leading column
+   * (seqInIndex == 1) of a non-primary index is usable for ORDER BY without a filesort — a
+   * non-leading composite column still requires a full sort even though the column appears in
+   * the index.
    */
   private boolean hasNonPrimaryIndexOn(IndexMetadata metadata, String table, String column) {
     List<IndexInfo> indexes = metadata.getIndexesForTable(table);
@@ -153,6 +154,7 @@ public class OrderByLimitWithoutIndexDetector implements DetectionRule {
         .anyMatch(
             idx ->
                 !"PRIMARY".equalsIgnoreCase(idx.indexName())
+                    && idx.seqInIndex() == 1
                     && idx.columnName() != null
                     && idx.columnName().equalsIgnoreCase(column));
   }
@@ -163,6 +165,7 @@ public class OrderByLimitWithoutIndexDetector implements DetectionRule {
         .anyMatch(
             idx ->
                 "PRIMARY".equalsIgnoreCase(idx.indexName())
+                    && idx.seqInIndex() == 1
                     && idx.columnName() != null
                     && idx.columnName().equalsIgnoreCase(column));
   }

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetector.java
@@ -45,6 +45,7 @@ public class OrderByLimitWithoutIndexDetector implements DetectionRule {
     List<Issue> issues = new ArrayList<>();
 
     if (indexMetadata == null || indexMetadata.isEmpty()) {
+      MetadataSkipLog.warnEmptyMetadataOnce("OrderByLimitWithoutIndexDetector");
       return issues;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/RedundantFilterDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/RedundantFilterDetector.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -235,22 +236,55 @@ public class RedundantFilterDetector implements DetectionRule {
   }
 
   /**
-   * Checks whether a given column+operator combination appears in more than one OR branch. If it
-   * does, the duplicates are intentional (e.g., bidirectional queries) and not redundant.
+   * Checks whether a given column+operator combination appears in more than one OR branch with
+   * <b>genuinely different</b> right-hand-side values. Duplicates that span branches but compare
+   * the column to the same literal (e.g. {@code id = 1 OR id = 1}) are tautologies, not a
+   * bidirectional pattern, and must still be reported as redundant (issue #93).
+   *
+   * <p>When the RHS is a parameter placeholder ({@code ?}) we cannot tell apart runtime values,
+   * so we conservatively treat those cases as legitimately different branches to avoid false
+   * positives on parameterized queries.
    */
+  // Captures everything after the operator up to the next boolean keyword or closing paren so
+  // the RHS comparison sees, e.g., "1" rather than "1 AND".
+  private static final Pattern RHS_TERMINATOR =
+      Pattern.compile("\\s+(?:AND|OR)\\b|[)]|$", Pattern.CASE_INSENSITIVE);
+
   private boolean appearsInDifferentOrBranches(
       String column, String operator, List<String> orBranches) {
     Pattern colPattern =
         Pattern.compile(
-            "(?:(?:\\w+)\\.)?\\b" + Pattern.quote(column) + "\\b\\s*" + Pattern.quote(operator),
+            "(?:(?:\\w+)\\.)?\\b"
+                + Pattern.quote(column)
+                + "\\b\\s*"
+                + Pattern.quote(operator)
+                + "\\s*",
             Pattern.CASE_INSENSITIVE);
 
+    Set<String> distinctRhs = new LinkedHashSet<>();
     int branchesWithMatch = 0;
     for (String branch : orBranches) {
-      if (colPattern.matcher(branch).find()) {
+      Matcher m = colPattern.matcher(branch);
+      if (m.find()) {
         branchesWithMatch++;
+        distinctRhs.add(extractRhs(branch, m.end()));
       }
     }
-    return branchesWithMatch > 1;
+    if (branchesWithMatch < 2) {
+      return false;
+    }
+    // Parameter placeholder: runtime values unknown, treat conservatively as different branches.
+    if (distinctRhs.contains("?")) {
+      return true;
+    }
+    // Different literal values → genuinely different conditions; identical literal → tautology.
+    return distinctRhs.size() > 1;
+  }
+
+  private static String extractRhs(String branch, int fromIndex) {
+    String tail = branch.substring(fromIndex);
+    Matcher terminator = RHS_TERMINATOR.matcher(tail);
+    int end = terminator.find() ? terminator.start() : tail.length();
+    return tail.substring(0, end).trim().toLowerCase();
   }
 }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/AdversarialFalsePositiveTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/AdversarialFalsePositiveTest.java
@@ -1495,11 +1495,17 @@ class AdversarialFalsePositiveTest {
       assertThat(issues).isEmpty();
     }
 
+    // Post-#91: parameterized LIKE now emits an INFO-level suggestive warning because
+    // the runtime binding may begin with '%'. Kept the class's false-positive framing by
+    // asserting nothing WARNING-level slips through.
     @Test
-    void likeWithParameterShouldNotTrigger() {
+    void likeWithParameterEmitsInfoOnly() {
       List<Issue> issues =
           detector.evaluate(List.of(record("SELECT * FROM users WHERE name LIKE ?")), EMPTY_INDEX);
-      assertThat(issues).isEmpty();
+      assertThat(issues).allSatisfy(
+          i ->
+              assertThat(i.severity())
+                  .isEqualTo(io.queryaudit.core.model.Severity.INFO));
     }
 
     @Test

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/CollectionManagementDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/CollectionManagementDetectorTest.java
@@ -109,6 +109,41 @@ class CollectionManagementDetectorTest {
 
       assertThat(issues).hasSize(1);
     }
+
+    // Regression for #94: composite-key FK DELETE (owner key spans more than one column) used
+    // to be silently skipped because of the `whereColumns.size() != 1` guard.
+    @Test
+    @DisplayName("Detects composite-key FK DELETE + re-INSERT pattern (issue #94)")
+    void detectsCompositeKeyFkDeleteReinsert() {
+      List<QueryRecord> queries =
+          List.of(
+              record("DELETE FROM parent_child WHERE parent_id = 1 AND child_kind = 'A'"),
+              record("INSERT INTO parent_child (parent_id, child_kind, val) VALUES (1, 'A', 10)"),
+              record("INSERT INTO parent_child (parent_id, child_kind, val) VALUES (1, 'A', 20)"));
+
+      List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
+
+      assertThat(issues).hasSize(1);
+      assertThat(issues.get(0).type()).isEqualTo(IssueType.COLLECTION_DELETE_REINSERT);
+      assertThat(issues.get(0).table()).isEqualTo("parent_child");
+      assertThat(issues.get(0).detail()).contains("composite owner key");
+      assertThat(issues.get(0).detail()).contains("parent_id");
+      assertThat(issues.get(0).detail()).contains("child_kind");
+    }
+
+    @Test
+    @DisplayName("Detects composite-key FK DELETE + re-INSERT with parameterized values")
+    void detectsCompositeKeyFkDeleteReinsertParameterized() {
+      List<QueryRecord> queries =
+          List.of(
+              record("DELETE FROM parent_child WHERE parent_id = ? AND child_kind = ?"),
+              record("INSERT INTO parent_child (parent_id, child_kind, val) VALUES (?, ?, ?)"),
+              record("INSERT INTO parent_child (parent_id, child_kind, val) VALUES (?, ?, ?)"));
+
+      List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
+
+      assertThat(issues).hasSize(1);
+    }
   }
 
   // ── Negative: No issues ─────────────────────────────────────────────
@@ -118,8 +153,12 @@ class CollectionManagementDetectorTest {
   class NegativeCases {
 
     @Test
-    @DisplayName("No issue when DELETE has multiple WHERE columns (composite key)")
-    void noIssueWithMultipleWhereColumns() {
+    @DisplayName("No issue when composite WHERE values don't carry over to INSERTs (specific-row DELETE)")
+    void noIssueWhenCompositeWhereValuesDontCarryOver() {
+      // WHERE constrains a SPECIFIC row (member_id = 10) that does not appear in any of the
+      // subsequent INSERT value lists. This is a specific-row DELETE followed by unrelated
+      // INSERTs, not a collection DELETE-all. See issue #94 for the composite-key case that
+      // SHOULD be flagged.
       List<QueryRecord> queries =
           List.of(
               record("DELETE FROM team_members WHERE team_id = 1 AND member_id = 10"),

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
@@ -566,12 +566,18 @@ class ComprehensiveFalsePositiveTest {
     }
 
     @Test
-    @DisplayName("TN: LIKE ? (parameterized, can't know) should not detect")
-    void tn_parameterizedLike() {
+    @DisplayName("Post-#91: LIKE ? (parameterized) emits an INFO-level suggestive warning")
+    void parameterizedLike_emitsInfo() {
       String sql = "SELECT * FROM users WHERE name LIKE ?";
       List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
 
-      assertThat(issuesOfType(issues, IssueType.LIKE_LEADING_WILDCARD)).isEmpty();
+      // Still LIKE_LEADING_WILDCARD type, but never WARNING for the parameter-only form —
+      // the runtime binding is unknown so the detector speaks at INFO.
+      assertThat(issuesOfType(issues, IssueType.LIKE_LEADING_WILDCARD))
+          .allSatisfy(
+              i ->
+                  assertThat(i.severity())
+                      .isEqualTo(io.queryaudit.core.model.Severity.INFO));
     }
   }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/EdgeCaseDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/EdgeCaseDetectorTest.java
@@ -795,11 +795,14 @@ class EdgeCaseDetectorTest {
     }
 
     // --- Test 45: LIKE ? (parameterized) ---
+    // Post-#91: parameterized LIKE is reported at INFO severity because the runtime binding
+    // may begin with '%'. See LikeWildcardDetectorTest#infoIssueForParameterizedLike.
     @Test
-    void likeParameterized_shouldNotDetect() {
+    void likeParameterized_emitsInfo() {
       List<Issue> issues =
           detector.evaluate(List.of(record("SELECT * FROM users WHERE name LIKE ?")), EMPTY_INDEX);
-      assertThat(issues).isEmpty();
+      assertThat(issues).hasSize(1);
+      assertThat(issues.get(0).severity()).isEqualTo(io.queryaudit.core.model.Severity.INFO);
     }
 
     // --- Test 46: LIKE '%' ---

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ImplicitTypeConversionDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ImplicitTypeConversionDetectorTest.java
@@ -219,4 +219,58 @@ class ImplicitTypeConversionDetectorTest {
     assertThat(issues).hasSize(1);
     assertThat(issues.get(0).column()).isEqualTo("user_name");
   }
+
+  // Regression for #95: the pre-fix detector only matched the `_indicator` form, so columns
+  // whose name fused the indicator to another token (ucode, firstname, codebook) and standalone
+  // string-typed column names (name, email) slipped through.
+
+  @Test
+  void detectsFusedSuffixColumn_ucode() {
+    String sql = "SELECT * FROM users WHERE ucode = 42";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).column()).isEqualTo("ucode");
+  }
+
+  @Test
+  void detectsFusedSuffixColumn_firstname() {
+    String sql = "SELECT * FROM users WHERE firstname = 5";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).column()).isEqualTo("firstname");
+  }
+
+  @Test
+  void detectsStandaloneIndicatorColumn_name() {
+    String sql = "SELECT * FROM users WHERE name = 7";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).column()).isEqualTo("name");
+  }
+
+  @Test
+  void noIssueForFkStyleIntColumn_descriptionId() {
+    // A FK-style numeric column ending in _id should NOT be flagged even though the
+    // leading 'description' token would otherwise match the string indicator set.
+    String sql = "SELECT * FROM items WHERE description_id = 1";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void noIssueForCountColumn_commentCount() {
+    String sql = "SELECT * FROM posts WHERE comment_count = 5";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+
+    assertThat(issues).isEmpty();
+  }
 }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/LikeWildcardDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/LikeWildcardDetectorTest.java
@@ -80,4 +80,41 @@ class LikeWildcardDetectorTest {
 
     assertThat(issues).isEmpty();
   }
+
+  // Regression for #91: parameterized LIKE used to be silently ignored, so a runtime binding of
+  // '%foo' would full-scan without any detector emitting a warning. Now emitted at INFO because
+  // the actual value cannot be confirmed statically.
+  @Test
+  void infoIssueForParameterizedLike() {
+    String sql = "SELECT * FROM users WHERE name LIKE ?";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).type()).isEqualTo(IssueType.LIKE_LEADING_WILDCARD);
+    assertThat(issues.get(0).severity()).isEqualTo(Severity.INFO);
+    assertThat(issues.get(0).detail()).contains("Parameterized LIKE");
+  }
+
+  @Test
+  void noDuplicateWhenBothLiteralAndParameterizedLikePresent() {
+    // Literal leading wildcard takes precedence — WARNING only, no additional INFO row.
+    String sql =
+        "SELECT * FROM users WHERE name LIKE '%foo' OR email LIKE ?";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).severity()).isEqualTo(Severity.WARNING);
+  }
+
+  @Test
+  void detectsNotLikeLeadingWildcard() {
+    String sql = "SELECT * FROM users WHERE name NOT LIKE '%foo'";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).severity()).isEqualTo(Severity.WARNING);
+  }
 }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/MergeableQueriesDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/MergeableQueriesDetectorTest.java
@@ -177,4 +177,20 @@ class MergeableQueriesDetectorTest {
     assertThat(issues).hasSize(1);
     assertThat(issues.get(0).type()).isEqualTo(IssueType.MERGEABLE_QUERIES);
   }
+
+  // Regression for #97: queries that join the SAME table but with DIFFERENT ON conditions used
+  // to be bucketed together because extractJoinStructure only looked at "JOIN <table>".
+  // Rewriting them with an IN clause is impossible, so they must not be grouped/flagged.
+  @Test
+  void noIssueForSameJoinTableButDifferentOnConditions() {
+    List<QueryRecord> queries =
+        List.of(
+            record("SELECT o.id FROM orders o JOIN users u ON u.id = o.user_id WHERE o.status = 'A'"),
+            record("SELECT o.id FROM orders o JOIN users u ON u.id = o.reviewer_id WHERE o.status = 'B'"),
+            record("SELECT o.id FROM orders o JOIN users u ON u.id = o.approver_id WHERE o.status = 'C'"));
+
+    List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
+
+    assertThat(issues).isEmpty();
+  }
 }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/MetadataSkipLogTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/MetadataSkipLogTest.java
@@ -1,0 +1,85 @@
+package io.queryaudit.core.detector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.IndexMetadata;
+import io.queryaudit.core.model.QueryRecord;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for issue #96 — metadata-dependent detectors must log a one-shot warning when they
+ * disable themselves due to empty/null {@link IndexMetadata}, so users have a trail to follow
+ * when a rule mysteriously stops firing.
+ */
+@DisplayName("MetadataSkipLog — warn-once contract (issue #96)")
+class MetadataSkipLogTest {
+
+  private static final IndexMetadata EMPTY = new IndexMetadata(Map.of());
+
+  private PrintStream originalErr;
+  private ByteArrayOutputStream capturedErr;
+
+  @BeforeEach
+  void setUp() {
+    originalErr = System.err;
+    capturedErr = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(capturedErr));
+    MetadataSkipLog.resetForTesting();
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.setErr(originalErr);
+    MetadataSkipLog.resetForTesting();
+  }
+
+  private static QueryRecord record(String sql) {
+    return new QueryRecord(sql, 0L, System.currentTimeMillis(), "");
+  }
+
+  @Test
+  @DisplayName("first empty-metadata invocation emits a warning; subsequent calls stay silent")
+  void warnsOncePerDetector() {
+    OrderByLimitWithoutIndexDetector detector = new OrderByLimitWithoutIndexDetector();
+    QueryRecord q = record("SELECT * FROM t ORDER BY x LIMIT 10");
+
+    detector.evaluate(List.of(q), EMPTY);
+    detector.evaluate(List.of(q), EMPTY);
+    detector.evaluate(List.of(q), null);
+
+    String err = capturedErr.toString();
+    assertThat(err).contains("IndexMetadata is empty");
+    assertThat(err).contains("OrderByLimitWithoutIndexDetector");
+    // Only one occurrence of the warning despite three empty-metadata calls.
+    int occurrences = err.split("OrderByLimitWithoutIndexDetector", -1).length - 1;
+    assertThat(occurrences).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("each distinct detector gets its own warning the first time it skips")
+  void warnsSeparatelyPerDetector() {
+    OrderByLimitWithoutIndexDetector d1 = new OrderByLimitWithoutIndexDetector();
+    CompositeIndexDetector d2 = new CompositeIndexDetector();
+    MissingIndexDetector d3 = new MissingIndexDetector();
+    NonDeterministicPaginationDetector d4 = new NonDeterministicPaginationDetector();
+    QueryRecord q = record("SELECT * FROM t WHERE x = 1 ORDER BY id LIMIT 10");
+
+    d1.evaluate(List.of(q), EMPTY);
+    d2.evaluate(List.of(q), EMPTY);
+    d3.evaluate(List.of(q), EMPTY);
+    d4.evaluate(List.of(q), EMPTY);
+
+    String err = capturedErr.toString();
+    assertThat(err).contains("OrderByLimitWithoutIndexDetector");
+    assertThat(err).contains("CompositeIndexDetector");
+    assertThat(err).contains("MissingIndexDetector");
+    assertThat(err).contains("NonDeterministicPaginationDetector");
+  }
+}

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/MissingIndexDetectorLikeTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/MissingIndexDetectorLikeTest.java
@@ -1,0 +1,74 @@
+package io.queryaudit.core.detector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.IndexInfo;
+import io.queryaudit.core.model.IndexMetadata;
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryRecord;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #92 — MissingIndexDetector used to skip all LIKE operator columns,
+ * which combined with LikeWildcardDetector's leading-wildcard-only scope meant that
+ * non-leading-wildcard LIKE and parameterized LIKE fell through both detectors.
+ */
+@DisplayName("MissingIndexDetector — LIKE handling (issue #92)")
+class MissingIndexDetectorLikeTest {
+
+  private static QueryRecord record(String sql) {
+    return new QueryRecord(sql, 0L, System.currentTimeMillis(), "");
+  }
+
+  private final MissingIndexDetector detector = new MissingIndexDetector();
+
+  // users table with NO index on `email`.
+  private final IndexMetadata noEmailIndex =
+      new IndexMetadata(
+          Map.of(
+              "users",
+              List.of(new IndexInfo("users", "PRIMARY", "id", 1, false, 10000))));
+
+  @Test
+  @DisplayName("flags prefix-only LIKE on an unindexed column")
+  void flagsPrefixOnlyLikeOnUnindexedColumn() {
+    String sql = "SELECT * FROM users WHERE email LIKE 'foo%'";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), noEmailIndex);
+
+    assertThat(issues)
+        .extracting(Issue::type)
+        .contains(IssueType.MISSING_WHERE_INDEX);
+    assertThat(issues)
+        .extracting(Issue::column)
+        .contains("email");
+  }
+
+  @Test
+  @DisplayName("flags parameterized LIKE on an unindexed column")
+  void flagsParameterizedLikeOnUnindexedColumn() {
+    String sql = "SELECT * FROM users WHERE email LIKE ?";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), noEmailIndex);
+
+    assertThat(issues)
+        .extracting(Issue::column)
+        .contains("email");
+  }
+
+  @Test
+  @DisplayName("skips leading-wildcard LIKE (handled by LikeWildcardDetector)")
+  void skipsLeadingWildcardLike() {
+    String sql = "SELECT * FROM users WHERE email LIKE '%foo'";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), noEmailIndex);
+
+    assertThat(issues)
+        .filteredOn(i -> i.column() != null && i.column().equals("email"))
+        .isEmpty();
+  }
+}

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetectorTest.java
@@ -39,6 +39,47 @@ class OrderByLimitWithoutIndexDetectorTest {
     assertThat(issues.get(0).detail()).contains("filesort");
   }
 
+  // Regression for #98: ORDER BY on a non-leading composite column still requires a filesort.
+  // The detector used to consider such a column "indexed" because it appeared in the index at all.
+  @Test
+  void flagsOrderByOnNonLeadingCompositeColumn() {
+    IndexMetadata metadata =
+        new IndexMetadata(
+            Map.of(
+                "orders",
+                List.of(
+                    new IndexInfo("orders", "PRIMARY", "id", 1, false, 10000),
+                    // composite index (status, created_at) — created_at is at seqInIndex=2
+                    new IndexInfo("orders", "idx_status_created", "status", 1, true, 10000),
+                    new IndexInfo("orders", "idx_status_created", "created_at", 2, true, 10000))));
+
+    String sql = "SELECT id FROM orders ORDER BY created_at DESC LIMIT 10";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).column()).isEqualTo("created_at");
+  }
+
+  @Test
+  void noIssueWhenOrderByIsLeadingCompositeColumn() {
+    IndexMetadata metadata =
+        new IndexMetadata(
+            Map.of(
+                "orders",
+                List.of(
+                    new IndexInfo("orders", "PRIMARY", "id", 1, false, 10000),
+                    new IndexInfo("orders", "idx_status_created", "status", 1, true, 10000),
+                    new IndexInfo("orders", "idx_status_created", "created_at", 2, true, 10000))));
+
+    // ORDER BY on the leading column of the composite index — genuinely index-satisfiable.
+    String sql = "SELECT id FROM orders ORDER BY status LIMIT 10";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+    assertThat(issues).isEmpty();
+  }
+
   @Test
   void noIssueWhenOrderByColumnHasIndex() {
     IndexMetadata metadata =

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/RedundantFilterDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/RedundantFilterDetectorTest.java
@@ -133,6 +133,28 @@ class RedundantFilterDetectorTest {
     assertThat(issues).isEmpty();
   }
 
+  // Regression for #93: a pure tautology like `id = 1 OR id = 1` used to be suppressed by the
+  // "different OR branches" skip, even though the literal RHS is identical in every branch.
+  @Test
+  void detectsTautologyWithIdenticalLiteralAcrossOrBranches() {
+    String sql = "SELECT * FROM users WHERE (id = 1 OR id = 1) AND status = 'active'";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).column()).isEqualTo("id");
+  }
+
+  @Test
+  void noIssueForDistinctLiteralsAcrossOrBranches() {
+    // Not a tautology — id = 1 OR id = 2 are genuinely different conditions.
+    String sql = "SELECT * FROM users WHERE id = 1 OR id = 2";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+    assertThat(issues).isEmpty();
+  }
+
   @Test
   void stillDetectsRedundantWithinSameOrBranch() {
     // Duplicate within the same AND branch, even though OR exists
@@ -459,10 +481,12 @@ class RedundantFilterDetectorTest {
   @Test
   void mathMutatorOnStartAdvancement() {
     // Kills MathMutator on line 220: start = i + 2 (changed to i + 2 - 1 or i + 2 + 1)
-    // If start were i+1 or i+3, the first char of the next branch would be wrong
-    String sql = "SELECT * FROM t WHERE a = 1 OR a = 1";
+    // If start were i+1 or i+3, the first char of the next branch would be wrong.
+    // Uses distinct literal RHS values so this stays a legitimate different-branches case
+    // even after the #93 tautology fix (identical RHS across branches is now flagged).
+    String sql = "SELECT * FROM t WHERE a = 1 OR a = 2";
     List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
-    // a appears in both OR branches -> not redundant
+    // a appears in different OR branches with different values -> not redundant
     assertThat(issues).isEmpty();
   }
 
@@ -632,10 +656,12 @@ class RedundantFilterDetectorTest {
     List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
     assertThat(issues).hasSize(1);
 
-    // Now with actual OR splitting that matters
-    String sql2 = "SELECT * FROM t WHERE a = 1 OR a = 1";
+    // Now with actual OR splitting that matters. Use distinct RHS values so this still
+    // represents a "legitimately different branches" case after the #93 tautology fix
+    // (identical RHS across branches is now reported as redundant).
+    String sql2 = "SELECT * FROM t WHERE a = 1 OR a = 2";
     List<Issue> issues2 = detector.evaluate(List.of(record(sql2)), EMPTY_INDEX);
-    // a appears in different OR branches -> not redundant
+    // a appears in different OR branches with different values -> not redundant
     assertThat(issues2).isEmpty();
   }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/eval/FalsePositiveAuditTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/eval/FalsePositiveAuditTest.java
@@ -113,6 +113,9 @@ class FalsePositiveAuditTest {
 
   @Test
   void likeWildcardDetector_legitimateQueries() {
+    // Audit focus: WARNING-level issues only. Post-#91, parameterized LIKE (`LIKE ?`) emits
+    // an INFO-level suggestive heads-up because the runtime binding could begin with '%';
+    // those are not false positives for this audit.
     List<String> sqls =
         List.of(
             "select u1_0.id,u1_0.name from users u1_0 where u1_0.name like 'John%'",
@@ -126,7 +129,10 @@ class FalsePositiveAuditTest {
             "update users set last_login=? where id=?",
             "select u1_0.id from users u1_0 where u1_0.name like ?");
     List<Issue> issues = evaluate(new LikeWildcardDetector(), sqls);
-    assertThat(issues).as("LikeWildcardDetector false positives").isEmpty();
+    assertThat(issues)
+        .as("LikeWildcardDetector WARNING-level false positives")
+        .filteredOn(i -> i.severity() == io.queryaudit.core.model.Severity.WARNING)
+        .isEmpty();
   }
 
   // ── UnboundedResultSetDetector ───────────────────────────────────────


### PR DESCRIPTION
Bundles 8 detector-level correctness fixes. One commit per issue; each commit stands on its own and includes regression tests. Grouped in a single PR by user request for reviewability across the cluster.

| Issue | Commit | Summary |
|---|---|---|
| #98 | cf33977 | `OrderByLimitWithoutIndexDetector` now requires `seqInIndex == 1` — a column at a non-leading composite position still needs a filesort. |
| #93 | 7581dc8 | `RedundantFilterDetector` detects OR tautologies where the literal RHS is identical across branches (`id = 1 OR id = 1`) while preserving bidirectional `?`-parameterized patterns. |
| #97 | efa960d | `MergeableQueriesDetector` now walks each JOIN keyword and includes the full ON condition in the group key, so same-table joins with different ON clauses no longer merge. |
| #95 | d072775 | `ImplicitTypeConversionDetector` heuristic widened: token-set match as `_`-segment, start, or end; plus a negative-suffix guard so `description_id` / `comment_count` are still skipped. Covers `ucode`, `firstname`, `name`, etc. |
| #91, #92 | 437a794 | `LikeWildcardDetector` handles `NOT LIKE` / `ILIKE` and emits INFO for parameterized `LIKE ?`. `MissingIndexDetector` only skips LIKE columns when the raw SQL shows a leading-wildcard literal for that column — prefix LIKE and `LIKE ?` now fall through to the normal missing-index check. |
| #94 | be98a90 | `CollectionManagementDetector` accepts composite-FK WHERE clauses (up to 4 columns) but requires the WHERE `col = value` pairs to "carry over" into every subsequent INSERT, so specific-row DELETEs followed by unrelated INSERTs are still skipped. |
| #96 | e854878 | New `MetadataSkipLog.warnEmptyMetadataOnce` — the four metadata-dependent detectors (`MissingIndex`, `CompositeIndex`, `OrderByLimitWithoutIndex`, `NonDeterministicPagination`) now emit a one-shot `System.err` heads-up the first time they disable themselves due to empty `IndexMetadata`. |

## Test plan
- [x] Each fix ships with at least one focused regression test (most are nested in the corresponding detector test class).
- [x] A handful of existing tests that pinned the buggy behavior (parameterized LIKE silently skipped; composite-key WHERE always skipped; OR-with-identical-RHS treated as bidirectional) were updated with an explanatory comment pointing at the issue — see the commit bodies.
- [x] `./gradlew test` passes locally across all modules.

Closes #91
Closes #92
Closes #93
Closes #94
Closes #95
Closes #96
Closes #97
Closes #98