### PR TITLE
fix(junit5): call QueryAuditDataSourceStore.clear() in afterAll

### DIFF
--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -328,6 +328,12 @@ public class QueryAuditExtension
       return;
     }
 
+    // Release the ThreadLocal holder that beforeAll populated when we had to wrap the
+    // DataSource ourselves. Without this, long-lived test worker threads (Gradle reuses them)
+    // retain the QueryInterceptorHolder for their entire lifetime, leaking recorded queries
+    // and potentially serving a stale holder to a subsequent test class (issue #100).
+    QueryAuditDataSourceStore.clear();
+
     writeCountBaselineIfRequested(context);
 
     // Register a ReportFinalizer in the root context store so that

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/QueryAuditDataSourceStoreClearTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/QueryAuditDataSourceStoreClearTest.java
@@ -1,0 +1,80 @@
+package io.queryaudit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.queryaudit.core.interceptor.QueryInterceptor;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Regression for issue #100 — {@link QueryAuditDataSourceStore#clear()} must be invoked in
+ * {@link QueryAuditExtension#afterAll(ExtensionContext)} so the ThreadLocal holder is released
+ * instead of living for the lifetime of the Gradle test worker thread.
+ */
+@DisplayName("QueryAuditDataSourceStore.clear() is called on afterAll (issue #100)")
+class QueryAuditDataSourceStoreClearTest {
+
+  @Test
+  @DisplayName("afterAll removes the ThreadLocal holder regardless of whether one was set")
+  void afterAllClearsThreadLocalHolder() {
+    // Pre-populate the ThreadLocal as beforeAll/hookInterceptor would.
+    QueryAuditDataSourceStore.set(
+        mock(DataSource.class), mock(DataSource.class), new QueryInterceptor());
+    assertThat(QueryAuditDataSourceStore.get()).as("precondition: holder is present").isNotNull();
+
+    QueryAuditExtension extension = new QueryAuditExtension();
+    extension.afterAll(topLevelContext());
+
+    assertThat(QueryAuditDataSourceStore.get())
+        .as("afterAll must clear the ThreadLocal holder")
+        .isNull();
+  }
+
+  @Test
+  @DisplayName("afterAll on a @Nested inner class does not clear the outer-class holder")
+  void nestedAfterAllLeavesOuterHolderIntact() {
+    QueryAuditDataSourceStore.set(
+        mock(DataSource.class), mock(DataSource.class), new QueryInterceptor());
+
+    QueryAuditExtension extension = new QueryAuditExtension();
+    extension.afterAll(nestedInnerContext());
+
+    // The outer test class's afterAll is what clears; nested inner classes must not touch it.
+    assertThat(QueryAuditDataSourceStore.get()).isNotNull();
+    QueryAuditDataSourceStore.clear();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ExtensionContext topLevelContext() {
+    ExtensionContext ctx = mock(ExtensionContext.class);
+    when(ctx.getRequiredTestClass()).thenReturn((Class) String.class); // no enclosing class
+    ExtensionContext root = mock(ExtensionContext.class);
+    when(ctx.getRoot()).thenReturn(root);
+    when(ctx.getTestMethod()).thenReturn(Optional.empty());
+    ExtensionContext.Store store = mock(ExtensionContext.Store.class);
+    when(ctx.getStore(org.mockito.ArgumentMatchers.any(ExtensionContext.Namespace.class)))
+        .thenReturn(store);
+    when(root.getStore(org.mockito.ArgumentMatchers.any(ExtensionContext.Namespace.class)))
+        .thenReturn(store);
+    when(store.getOrComputeIfAbsent(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(inv -> mock(QueryAuditExtension.ReportFinalizer.class));
+    return ctx;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ExtensionContext nestedInnerContext() {
+    ExtensionContext ctx = mock(ExtensionContext.class);
+    // InnerClass has enclosing (this test class) — triggers the early-return guard.
+    when(ctx.getRequiredTestClass()).thenReturn((Class) InnerClass.class);
+    return ctx;
+  }
+
+  class InnerClass {}
+}


### PR DESCRIPTION
## Summary
- `QueryAuditDataSourceStore` exposed a `clear()` method that called `HOLDER.remove()`, but nothing in the codebase ever invoked it — the `set(...)` call in `DataSourceResolver.hookInterceptor` ran on `beforeAll` and then the `QueryInterceptorHolder` sat in the thread's `ThreadLocalMap` for the worker's entire lifetime (#100).
- Gradle/IDE test runners reuse worker threads across test classes, so the leak both pins the recorded-queries list indefinitely and can let a later test class see a stale holder from a previous class until its own `set()` overwrites it.
- `QueryAuditExtension.afterAll(...)` now invokes `QueryAuditDataSourceStore.clear()` before the rest of the finalization pipeline, matching the existing `HibernateIntegration.unregisterTracker` pattern added for #101. The existing `@Nested` inner-class early-return guard (`getEnclosingClass() != null`) keeps nested contexts from touching the outer class's holder.

## Test plan
- [x] New `QueryAuditDataSourceStoreClearTest`:
  - Prepopulates the ThreadLocal, runs `afterAll` with a top-level class context, asserts the holder is cleared.
  - Runs `afterAll` with a `@Nested`-style inner class context, asserts the outer class's holder survives.
- [x] `./gradlew test` passes locally across all modules.

Closes #100