### PR TITLE
ci: list all five published modules in release-please summary

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,6 +55,8 @@ jobs:
           echo "Published to Maven Central:" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           echo "io.github.haroya01:query-audit-core:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "io.github.haroya01:query-audit-junit5:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "io.github.haroya01:query-audit-mysql:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "io.github.haroya01:query-audit-postgresql:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "io.github.haroya01:query-audit-spring-boot-starter:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- \`.github/workflows/release-please.yml\` already publishes all five modules via \`publishAllPublicationsToMavenCentralRepository\`, but the GitHub step summary only listed three: \`query-audit-junit5\` and \`query-audit-postgresql\` were missing.
- Added the two missing modules to the summary block; listed alphabetically for stable output.
- Did not convert the block to a Gradle-driven script (mentioned as long-term option in the issue) — the five-module list is stable and changes rarely enough that the maintenance win would be marginal vs. the added workflow complexity.

## Test plan
- [x] Visual diff: five \`echo\` lines now, matches the five \`query-audit-*\` subprojects on disk.
- [ ] Next release will exercise the step; summary should show all five artifacts.

Closes #106