### PR TITLE
feat(core): add GitHubActionsReporter with auto-activation under GITHUB_ACTIONS

### DIFF
--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -89,6 +89,43 @@ jobs:
     This ensures reports are uploaded even when tests fail, so you can review the
     QueryAudit output in the build artifacts.
 
+### Inline PR annotations + step summary
+
+When running on GitHub Actions (detected via the runner's `GITHUB_ACTIONS=true`
+environment variable) QueryAudit additionally emits
+[workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)
+alongside the normal console output:
+
+- Each `ERROR` issue becomes an `::error` annotation — shown inline on the PR's
+  "Files changed" tab when the source location is known.
+- `WARNING` → `::warning`, `INFO` → `::notice`.
+- A Markdown table and the top N issues per severity are appended to the job's
+  step summary (the page you land on from the PR check's "Details" link).
+
+No workflow changes are required beyond the standard `./gradlew test` step — the
+reporter auto-activates in CI and stays silent locally. If you want a PR-scoped
+signal on top of the inline annotations, pair it with a comment action that
+reads the JSON report:
+
+```yaml
+      - name: Post QueryAudit summary as PR comment
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'build/reports/query-audit/query-audit.json';
+            if (!fs.existsSync(path)) return;
+            const json = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const body = `**QueryAudit**: ${json.summary.confirmedIssues} confirmed, ${json.summary.infoIssues} info`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+```
+
 ### With PostgreSQL
 
 ```yaml

--- a/query-audit-core/src/main/java/io/queryaudit/core/reporter/GitHubActionsReporter.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/reporter/GitHubActionsReporter.java
@@ -1,0 +1,257 @@
+package io.queryaudit.core.reporter;
+
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.QueryAuditReport;
+import io.queryaudit.core.model.Severity;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Emits a {@link QueryAuditReport} in GitHub Actions' workflow-command format (issue #85):
+ *
+ * <ul>
+ *   <li>One {@code ::error} / {@code ::warning} / {@code ::notice} line per issue on
+ *       {@code System.out}, which the Actions runner parses into inline PR annotations.
+ *   <li>A Markdown summary appended to the file pointed at by {@code $GITHUB_STEP_SUMMARY}
+ *       when that environment variable is set, so users see a single "N confirmed, M info"
+ *       block at the top of the job page.
+ * </ul>
+ *
+ * <p>When {@code Issue.sourceLocation} is populated (format: {@code fqcn.method:line}), this
+ * reporter parses the file-and-line hint into the {@code file=...,line=...} portion of the
+ * command. Without it the annotation still fires but anchors to the workflow file — slightly
+ * less useful, but never silent.
+ *
+ * @author haroya
+ * @since 0.3.0
+ */
+public class GitHubActionsReporter implements Reporter {
+
+  // Matches stack-frame-style source locations like
+  //   "com.example.OrderService.findOrders:42"
+  // The leading part is the fully-qualified class + method; the trailing ":digits" is the line.
+  private static final Pattern SOURCE_LOCATION =
+      Pattern.compile("^(?<fqcn>[A-Za-z_][\\w.$]*?)\\.(?<method>[A-Za-z_$][\\w$]*)" + ":(?<line>\\d+)$");
+
+  private final PrintStream out;
+  private final Path summaryPath;
+
+  public GitHubActionsReporter() {
+    this(System.out, resolveSummaryPathFromEnv());
+  }
+
+  public GitHubActionsReporter(PrintStream out, Path summaryPath) {
+    this.out = out;
+    this.summaryPath = summaryPath;
+  }
+
+  @Override
+  public void report(QueryAuditReport report) {
+    if (report == null) {
+      return;
+    }
+    emitAnnotations(report);
+    if (summaryPath != null) {
+      appendSummary(report);
+    }
+  }
+
+  private void emitAnnotations(QueryAuditReport report) {
+    List<Issue> errors = report.getErrors();
+    if (errors != null) {
+      for (Issue i : errors) {
+        emit("error", i, report);
+      }
+    }
+    List<Issue> warnings = report.getWarnings();
+    if (warnings != null) {
+      for (Issue i : warnings) {
+        emit("warning", i, report);
+      }
+    }
+    List<Issue> infos = report.getInfoIssues();
+    if (infos != null) {
+      for (Issue i : infos) {
+        emit("notice", i, report);
+      }
+    }
+  }
+
+  private void emit(String level, Issue issue, QueryAuditReport report) {
+    StringBuilder props = new StringBuilder();
+    Location loc = parseLocation(issue.sourceLocation());
+    if (loc != null) {
+      append(props, "file=" + escapeProp(loc.file));
+      append(props, "line=" + loc.line);
+    }
+    append(props, "title=" + escapeProp(titleFor(issue, report)));
+
+    StringBuilder sb = new StringBuilder("::");
+    sb.append(level);
+    // Per GitHub workflow-command syntax, a space separates the command name from its properties.
+    if (props.length() > 0) {
+      sb.append(' ').append(props);
+    }
+    sb.append("::");
+    sb.append(escapeBody(messageFor(issue)));
+
+    out.println(sb);
+  }
+
+  private static void append(StringBuilder props, String kv) {
+    if (props.length() > 0) {
+      props.append(',');
+    }
+    props.append(kv);
+  }
+
+  private static String titleFor(Issue issue, QueryAuditReport report) {
+    String type = issue.type() != null ? issue.type().getCode() : "query-audit";
+    String testClass = report.getTestClass();
+    return testClass != null ? testClass + " — " + type : type;
+  }
+
+  private static String messageFor(Issue issue) {
+    StringBuilder body = new StringBuilder();
+    if (issue.detail() != null) {
+      body.append(issue.detail());
+    } else {
+      body.append(issue.type() != null ? issue.type().getDescription() : "issue");
+    }
+    if (issue.suggestion() != null && !issue.suggestion().isEmpty()) {
+      body.append("\n\nSuggestion: ").append(issue.suggestion());
+    }
+    if (issue.query() != null) {
+      body.append("\n\nQuery: ").append(issue.query());
+    }
+    return body.toString();
+  }
+
+  private void appendSummary(QueryAuditReport report) {
+    int errorCount = safeSize(report.getErrors());
+    int warningCount = safeSize(report.getWarnings());
+    int infoCount = safeSize(report.getInfoIssues());
+
+    StringBuilder md = new StringBuilder();
+    md.append("### query-audit — ")
+        .append(report.getTestClass() != null ? report.getTestClass() : "report")
+        .append("\n\n");
+    md.append("| Severity | Count |\n");
+    md.append("| --- | ---: |\n");
+    md.append("| ERROR | ").append(errorCount).append(" |\n");
+    md.append("| WARNING | ").append(warningCount).append(" |\n");
+    md.append("| INFO | ").append(infoCount).append(" |\n\n");
+
+    if (errorCount + warningCount + infoCount > 0) {
+      md.append("<details><summary>Top issues</summary>\n\n");
+      appendTopIssues(md, "ERROR", report.getErrors());
+      appendTopIssues(md, "WARNING", report.getWarnings());
+      appendTopIssues(md, "INFO", report.getInfoIssues());
+      md.append("\n</details>\n");
+    }
+
+    try {
+      Files.writeString(
+          summaryPath, md.toString(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    } catch (IOException e) {
+      // $GITHUB_STEP_SUMMARY may be unset or unwritable on a non-Actions runner; fall back to
+      // stderr so users still get the data, without failing the analysis.
+      System.err.println("[QueryAudit] Could not write GitHub step summary: " + e.getMessage());
+    }
+  }
+
+  private static void appendTopIssues(StringBuilder md, String level, List<Issue> issues) {
+    if (issues == null || issues.isEmpty()) {
+      return;
+    }
+    md.append("\n**").append(level).append("**\n\n");
+    int limit = Math.min(issues.size(), 5);
+    for (int i = 0; i < limit; i++) {
+      Issue issue = issues.get(i);
+      md.append("- `")
+          .append(issue.type() != null ? issue.type().getCode() : "query-audit")
+          .append("`");
+      if (issue.table() != null) {
+        md.append(" on `").append(issue.table()).append("`");
+      }
+      if (issue.detail() != null) {
+        md.append(" — ").append(firstLine(issue.detail()));
+      }
+      md.append("\n");
+    }
+    if (issues.size() > limit) {
+      md.append("- _…and ").append(issues.size() - limit).append(" more_\n");
+    }
+  }
+
+  private static String firstLine(String s) {
+    int nl = s.indexOf('\n');
+    return nl < 0 ? s : s.substring(0, nl);
+  }
+
+  private static int safeSize(List<?> list) {
+    return list == null ? 0 : list.size();
+  }
+
+  // ── Location parsing ──────────────────────────────────────────────────
+
+  static Location parseLocation(String sourceLocation) {
+    if (sourceLocation == null || sourceLocation.isEmpty()) {
+      return null;
+    }
+    Matcher m = SOURCE_LOCATION.matcher(sourceLocation.trim());
+    if (!m.matches()) {
+      return null;
+    }
+    String fqcn = m.group("fqcn");
+    int lastDot = fqcn.lastIndexOf('.');
+    if (lastDot < 0) {
+      return null; // no package: can't construct a path we trust
+    }
+    String pkg = fqcn.substring(0, lastDot).replace('.', '/');
+    String simpleClass = fqcn.substring(lastDot + 1);
+    // Strip inner/nested class markers for the source-file guess.
+    int innerMarker = simpleClass.indexOf('$');
+    if (innerMarker >= 0) {
+      simpleClass = simpleClass.substring(0, innerMarker);
+    }
+    // Default to Maven/Gradle standard main sources. Consumers can still rely on the annotation
+    // firing without a file when this guess doesn't match their layout.
+    String file = "src/main/java/" + pkg + "/" + simpleClass + ".java";
+    try {
+      return new Location(file, Integer.parseInt(m.group("line")));
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /** Package-private for testability. */
+  record Location(String file, int line) {}
+
+  // ── Escaping (GitHub workflow commands) ───────────────────────────────
+
+  /** Property values must have these three characters percent-encoded. */
+  private static String escapeProp(String s) {
+    if (s == null) return "";
+    return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A").replace(",", "%2C");
+  }
+
+  /** Command bodies use the same encoding but keep commas. */
+  private static String escapeBody(String s) {
+    if (s == null) return "";
+    return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A");
+  }
+
+  // ── Env bootstrap ─────────────────────────────────────────────────────
+
+  private static Path resolveSummaryPathFromEnv() {
+    String v = System.getenv("GITHUB_STEP_SUMMARY");
+    return (v == null || v.isEmpty()) ? null : Path.of(v);
+  }
+}

--- a/query-audit-core/src/test/java/io/queryaudit/core/reporter/GitHubActionsReporterTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/reporter/GitHubActionsReporterTest.java
@@ -1,0 +1,154 @@
+package io.queryaudit.core.reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryAuditReport;
+import io.queryaudit.core.model.Severity;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("GitHubActionsReporter — workflow-command output (issue #85)")
+class GitHubActionsReporterTest {
+
+  @TempDir Path tempDir;
+
+  private ByteArrayOutputStream stdout;
+  private PrintStream stdoutPrinter;
+
+  @BeforeEach
+  void setUp() {
+    stdout = new ByteArrayOutputStream();
+    stdoutPrinter = new PrintStream(stdout, true);
+  }
+
+  private static Issue issue(
+      IssueType type, Severity severity, String detail, String sourceLocation) {
+    return new Issue(
+        type, severity, "select * from t", "t", null, detail, "fix it", sourceLocation);
+  }
+
+  private QueryAuditReport reportOf(List<Issue> confirmed, List<Issue> info) {
+    return new QueryAuditReport(
+        "OrderServiceTest",
+        "findOrders",
+        confirmed,
+        info,
+        List.of(),
+        List.of(),
+        1,
+        1,
+        100_000L);
+  }
+
+  @Test
+  @DisplayName("emits ::error / ::warning / ::notice per severity bucket")
+  void emitsOneLinePerIssueAtCorrectLevel() {
+    GitHubActionsReporter reporter = new GitHubActionsReporter(stdoutPrinter, null);
+    Issue err = issue(IssueType.N_PLUS_ONE, Severity.ERROR, "N+1 hit", null);
+    Issue warn = issue(IssueType.OR_ABUSE, Severity.WARNING, "too many ORs", null);
+    Issue info = issue(IssueType.SELECT_ALL, Severity.INFO, "SELECT *", null);
+
+    reporter.report(reportOf(List.of(err, warn), List.of(info)));
+
+    String out = stdout.toString();
+    assertThat(out).contains("::error ");
+    assertThat(out).contains("::warning ");
+    assertThat(out).contains("::notice ");
+    assertThat(out).contains("N+1 hit");
+    assertThat(out).contains("too many ORs");
+    assertThat(out).contains("SELECT *");
+  }
+
+  @Test
+  @DisplayName("parses sourceLocation into file=/line= when it matches FQCN.method:line")
+  void parsesSourceLocationWhenWellFormed() {
+    GitHubActionsReporter reporter = new GitHubActionsReporter(stdoutPrinter, null);
+    Issue i =
+        issue(
+            IssueType.MISSING_WHERE_INDEX,
+            Severity.ERROR,
+            "no idx",
+            "com.example.OrderService.findOrders:42");
+
+    reporter.report(reportOf(List.of(i), List.of()));
+
+    String line = stdout.toString();
+    assertThat(line).contains("file=src/main/java/com/example/OrderService.java");
+    assertThat(line).contains("line=42");
+  }
+
+  @Test
+  @DisplayName("omits file=/line= when sourceLocation is null or malformed")
+  void skipsFileLineWhenSourceLocationMissing() {
+    GitHubActionsReporter reporter = new GitHubActionsReporter(stdoutPrinter, null);
+    reporter.report(
+        reportOf(
+            List.of(issue(IssueType.N_PLUS_ONE, Severity.ERROR, "no loc", null)), List.of()));
+    reporter.report(
+        reportOf(
+            List.of(issue(IssueType.N_PLUS_ONE, Severity.ERROR, "bad loc", "not-a-location")),
+            List.of()));
+
+    String out = stdout.toString();
+    assertThat(out).doesNotContain("file=");
+    assertThat(out).doesNotContain("line=");
+  }
+
+  @Test
+  @DisplayName("escapes %, newline, carriage return in the body")
+  void escapesPercentAndNewlinesInBody() {
+    GitHubActionsReporter reporter = new GitHubActionsReporter(stdoutPrinter, null);
+    Issue i = issue(IssueType.N_PLUS_ONE, Severity.ERROR, "100% broken\nline two", null);
+
+    reporter.report(reportOf(List.of(i), List.of()));
+
+    String out = stdout.toString();
+    assertThat(out).contains("100%25 broken%0Aline two");
+    assertThat(out).doesNotContain("100% broken");
+  }
+
+  @Test
+  @DisplayName("appends a Markdown summary to $GITHUB_STEP_SUMMARY when the path is provided")
+  void writesMarkdownSummaryWhenPathProvided() throws Exception {
+    Path summary = tempDir.resolve("summary.md");
+    GitHubActionsReporter reporter = new GitHubActionsReporter(stdoutPrinter, summary);
+
+    reporter.report(
+        reportOf(
+            List.of(issue(IssueType.N_PLUS_ONE, Severity.ERROR, "N+1", null)),
+            List.of(issue(IssueType.SELECT_ALL, Severity.INFO, "SELECT *", null))));
+
+    String md = Files.readString(summary);
+    assertThat(md).contains("query-audit — OrderServiceTest");
+    assertThat(md).contains("| ERROR | 1 |");
+    assertThat(md).contains("| INFO | 1 |");
+    assertThat(md).contains("n-plus-one");
+    assertThat(md).contains("select-all");
+  }
+
+  @Test
+  @DisplayName("parseLocation handles inner-class FQCNs by stripping the $Inner segment")
+  void parseLocationStripsInnerClass() {
+    GitHubActionsReporter.Location loc =
+        GitHubActionsReporter.parseLocation("com.example.OrderService$Inner.doWork:99");
+
+    assertThat(loc).isNotNull();
+    assertThat(loc.file()).isEqualTo("src/main/java/com/example/OrderService.java");
+    assertThat(loc.line()).isEqualTo(99);
+  }
+
+  @Test
+  @DisplayName("parseLocation returns null for inputs without a package")
+  void parseLocationReturnsNullWithoutPackage() {
+    assertThat(GitHubActionsReporter.parseLocation("NoPackageClass.method:10")).isNull();
+  }
+}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -14,6 +14,7 @@ import io.queryaudit.core.regression.QueryCountBaseline;
 import io.queryaudit.core.regression.QueryCountRegressionDetector;
 import io.queryaudit.core.regression.QueryCounts;
 import io.queryaudit.core.reporter.ConsoleReporter;
+import io.queryaudit.core.reporter.GitHubActionsReporter;
 import io.queryaudit.core.reporter.HtmlReportAggregator;
 import io.queryaudit.core.reporter.JsonReporter;
 import java.awt.Desktop;
@@ -212,6 +213,14 @@ public class QueryAuditExtension
     ConsoleReporter reporter =
         new ConsoleReporter(System.out, ConsoleReporter.detectColorSupport(), baseline);
     reporter.report(report);
+
+    // When running inside GitHub Actions, also emit workflow-command annotations + a step
+    // summary so issues surface as inline PR comments and a job-page overview (issue #85).
+    // Detection is env-driven (GITHUB_ACTIONS is set to "true" by the runner), so no config
+    // change is needed to get the behavior in CI — and it stays silent locally.
+    if ("true".equals(System.getenv("GITHUB_ACTIONS"))) {
+      new GitHubActionsReporter().report(report);
+    }
 
     // Accumulate for HTML report
     HtmlReportAggregator.getInstance().addReport(report);


### PR DESCRIPTION
## Summary
Adds a reporter that emits GitHub Actions' [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) so issues surface as inline PR annotations (`Files changed` tab) and a job-level step summary. Auto-activates when `GITHUB_ACTIONS=true` is present (set by the runner itself), so nothing changes locally and no extra config is required in CI.

### What it emits
- `::error`, `::warning`, `::notice` per issue on `stdout` — the runner parses these into annotations.
- `file=/line=` derived from `Issue.sourceLocation` when it matches the `com.example.Foo.method:42` stack-frame shape. Otherwise the annotation still fires but anchors to the workflow file instead of silently dropping.
- A Markdown table and a collapsible "top N per severity" block appended to the file at `$GITHUB_STEP_SUMMARY`.
- Bodies and property values are escaped per the spec (`%`, CR, LF — plus `,` in property values).

### Wiring
`QueryAuditExtension` runs the new reporter after `ConsoleReporter` when `GITHUB_ACTIONS=true`. Console output is unchanged.

### Docs
`docs/guide/ci-cd.md` gains a section explaining the auto-behavior and a reference `github-script` snippet users can drop into their workflow to post a PR comment from the existing JSON report.

### Scope notes
- Intentionally does not ship as a Marketplace Action — the issue explicitly scopes that out. This PR is the reporter output + opt-in doc.
- Does not change `Issue.sourceLocation` population (tracked separately per the issue) — the reporter degrades gracefully when it's null.

## Test plan
- [x] New `GitHubActionsReporterTest` covers: correct level per severity, source-location parsing (inner class variant included), fall-through when location is null/malformed, body escaping, Markdown summary written to the temp path.
- [x] `./gradlew test` passes locally across all modules.
- [ ] First run on CI will exercise the live end-to-end path; no runner state touched today.

Closes #85