### PR TITLE
fix(core): prevent false positive DISTINCT warning on PK when JOIN is…

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/DistinctMisuseDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/DistinctMisuseDetector.java
@@ -1,12 +1,5 @@
 package io.queryaudit.core.detector;
 
-import io.queryaudit.core.model.IndexInfo;
-import io.queryaudit.core.model.IndexMetadata;
-import io.queryaudit.core.model.Issue;
-import io.queryaudit.core.model.IssueType;
-import io.queryaudit.core.model.QueryRecord;
-import io.queryaudit.core.model.Severity;
-import io.queryaudit.core.parser.EnhancedSqlParser;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -14,6 +7,14 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import io.queryaudit.core.model.IndexInfo;
+import io.queryaudit.core.model.IndexMetadata;
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryRecord;
+import io.queryaudit.core.model.Severity;
+import io.queryaudit.core.parser.EnhancedSqlParser;
 
 /**
  * Detects potentially unnecessary DISTINCT usage:
@@ -104,7 +105,7 @@ public class DistinctMisuseDetector implements DetectionRule {
       }
 
       // (c) DISTINCT on primary key column
-      if (indexMetadata != null && !indexMetadata.isEmpty()) {
+      if (!hasJoin && indexMetadata != null && !indexMetadata.isEmpty()) {
         List<String> distinctCols = extractDistinctColumnNames(sql);
         List<String> tables = EnhancedSqlParser.extractTableNames(sql);
         String table = tables.isEmpty() ? null : tables.get(0);


### PR DESCRIPTION
Prevents false positive warnings when `DISTINCT` is used on a Primary Key column in a query that involves `JOIN` operations.

## Approved Issue
Closes #127

## What
- Modified `DistinctMisuseDetector` to check for the absence of `JOIN` before flagging `DISTINCT` on Primary Key columns.
- Logic: If a `JOIN` is present, `DISTINCT` is considered valid (not redundant) due to potential one-to-many cardinality duplicates.

## Why
In relational queries, joining a parent table with a child table results in multiple rows for the same parent ID. In these cases, `DISTINCT` is necessary even if the PK is selected.

## Checklist
- [x] `./gradlew build` passes
- [x] False positive for #127 is resolved
- [x] Commit messages follow conventional commits