### PR TITLE
fix(core): exclude temp/staging tables from RepeatedSingleInsertDetector (#129)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
@@ -1,5 +1,6 @@
 package io.queryaudit.core.config;
 
+import io.queryaudit.core.detector.RepeatedSingleInsertDetector;
 import io.queryaudit.core.detector.RepositoryReturnTypeResolver;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import io.queryaudit.core.model.Severity;
@@ -37,6 +38,7 @@ public class QueryAuditConfig {
   private final int tooManyJoinsThreshold;
   private final int excessiveColumnThreshold;
   private final int repeatedInsertThreshold;
+  private final Set<String> repeatedInsertExcludeTables;
   private final int writeAmplificationThreshold;
   private final long slowQueryWarningMs;
   private final long slowQueryErrorMs;
@@ -61,6 +63,8 @@ public class QueryAuditConfig {
     this.tooManyJoinsThreshold = builder.tooManyJoinsThreshold;
     this.excessiveColumnThreshold = builder.excessiveColumnThreshold;
     this.repeatedInsertThreshold = builder.repeatedInsertThreshold;
+    this.repeatedInsertExcludeTables =
+        Collections.unmodifiableSet(new HashSet<>(builder.repeatedInsertExcludeTables));
     this.writeAmplificationThreshold = builder.writeAmplificationThreshold;
     this.slowQueryWarningMs = builder.slowQueryWarningMs;
     this.slowQueryErrorMs = builder.slowQueryErrorMs;
@@ -176,6 +180,16 @@ public class QueryAuditConfig {
     return repeatedInsertThreshold;
   }
 
+  /**
+   * Returns table-name globs (e.g. {@code temp_*}) that the repeated-single-insert detector should
+   * skip. Defaults to {@link RepeatedSingleInsertDetector#DEFAULT_EXCLUDE_TABLES}.
+   *
+   * @since 0.4.0
+   */
+  public Set<String> getRepeatedInsertExcludeTables() {
+    return repeatedInsertExcludeTables;
+  }
+
   public int getWriteAmplificationThreshold() {
     return writeAmplificationThreshold;
   }
@@ -255,6 +269,8 @@ public class QueryAuditConfig {
     private int tooManyJoinsThreshold = 5;
     private int excessiveColumnThreshold = 15;
     private int repeatedInsertThreshold = 3;
+    private Set<String> repeatedInsertExcludeTables =
+        new HashSet<>(RepeatedSingleInsertDetector.DEFAULT_EXCLUDE_TABLES);
     private int writeAmplificationThreshold = 6;
     private long slowQueryWarningMs = 500;
     private long slowQueryErrorMs = 3000;
@@ -285,6 +301,7 @@ public class QueryAuditConfig {
       b.tooManyJoinsThreshold = source.tooManyJoinsThreshold;
       b.excessiveColumnThreshold = source.excessiveColumnThreshold;
       b.repeatedInsertThreshold = source.repeatedInsertThreshold;
+      b.repeatedInsertExcludeTables = new HashSet<>(source.repeatedInsertExcludeTables);
       b.writeAmplificationThreshold = source.writeAmplificationThreshold;
       b.slowQueryWarningMs = source.slowQueryWarningMs;
       b.slowQueryErrorMs = source.slowQueryErrorMs;
@@ -394,6 +411,28 @@ public class QueryAuditConfig {
 
     public Builder repeatedInsertThreshold(int repeatedInsertThreshold) {
       this.repeatedInsertThreshold = repeatedInsertThreshold;
+      return this;
+    }
+
+    /**
+     * Replaces the table-name globs that {@link RepeatedSingleInsertDetector} treats as deliberate
+     * staging tables. Each entry is a case-insensitive glob with {@code *} as the only wildcard
+     * (e.g. {@code "etl_*"}). Pass an empty set to disable the exclusion entirely.
+     *
+     * @since 0.4.0
+     */
+    public Builder repeatedInsertExcludeTables(Set<String> patterns) {
+      this.repeatedInsertExcludeTables = patterns;
+      return this;
+    }
+
+    /**
+     * Adds one extra table-name glob to the repeated-single-insert exclusion list.
+     *
+     * @since 0.4.0
+     */
+    public Builder addRepeatedInsertExcludeTable(String pattern) {
+      this.repeatedInsertExcludeTables.add(pattern);
       return this;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
@@ -150,7 +150,9 @@ public class QueryAuditAnalyzer {
     ruleList.add(new RangeLockDetector());
     ruleList.add(new UpdateWithoutWhereDetector());
     ruleList.add(new DmlWithoutIndexDetector());
-    ruleList.add(new RepeatedSingleInsertDetector(config.getRepeatedInsertThreshold()));
+    ruleList.add(
+        new RepeatedSingleInsertDetector(
+            config.getRepeatedInsertThreshold(), config.getRepeatedInsertExcludeTables()));
     ruleList.add(new InsertSelectAllDetector());
     ruleList.add(new OrderByRandDetector());
     ruleList.add(new NotInSubqueryDetector());

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/RepeatedSingleInsertDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/RepeatedSingleInsertDetector.java
@@ -7,9 +7,11 @@ import io.queryaudit.core.model.QueryRecord;
 import io.queryaudit.core.model.Severity;
 import io.queryaudit.core.parser.SqlParser;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -26,18 +28,68 @@ public class RepeatedSingleInsertDetector implements DetectionRule {
 
   private static final int DEFAULT_THRESHOLD = 3;
 
+  /**
+   * Default table-name globs treated as deliberate staging targets — repeated single-row inserts
+   * into these tables are intentional (test fixtures, ETL stage, session-local temp tables) and the
+   * round-trip / log-flush cost the rule warns about does not apply.
+   */
+  public static final Set<String> DEFAULT_EXCLUDE_TABLES =
+      Set.of("temp_*", "*_temp", "tmp_*", "*_tmp", "staging_*", "*_staging");
+
   private static final Pattern MULTI_ROW_INSERT =
       Pattern.compile(
           "\\bVALUES\\s*\\(.*\\)\\s*,\\s*\\(", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
   private final int threshold;
+  private final List<Pattern> excludeTablePatterns;
 
   public RepeatedSingleInsertDetector() {
-    this(DEFAULT_THRESHOLD);
+    this(DEFAULT_THRESHOLD, DEFAULT_EXCLUDE_TABLES);
   }
 
   public RepeatedSingleInsertDetector(int threshold) {
+    this(threshold, DEFAULT_EXCLUDE_TABLES);
+  }
+
+  public RepeatedSingleInsertDetector(int threshold, Collection<String> excludeTablePatterns) {
     this.threshold = threshold;
+    this.excludeTablePatterns = compileGlobs(excludeTablePatterns);
+  }
+
+  private static List<Pattern> compileGlobs(Collection<String> globs) {
+    if (globs == null || globs.isEmpty()) {
+      return List.of();
+    }
+    List<Pattern> compiled = new ArrayList<>(globs.size());
+    for (String glob : globs) {
+      if (glob == null || glob.isBlank()) {
+        continue;
+      }
+      StringBuilder regex = new StringBuilder("^");
+      for (int i = 0; i < glob.length(); i++) {
+        char c = glob.charAt(i);
+        if (c == '*') {
+          regex.append(".*");
+        } else {
+          regex.append(Pattern.quote(String.valueOf(c)));
+        }
+      }
+      regex.append('$');
+      compiled.add(Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE));
+    }
+    return compiled;
+  }
+
+  private boolean isExcludedTable(String table) {
+    if (table == null || excludeTablePatterns.isEmpty()) {
+      return false;
+    }
+    for (Pattern p : excludeTablePatterns) {
+      if (p.matcher(table).matches()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -64,6 +116,9 @@ public class RepeatedSingleInsertDetector implements DetectionRule {
       }
 
       String table = SqlParser.extractInsertTable(sql);
+      if (isExcludedTable(table)) {
+        continue;
+      }
       groups.computeIfAbsent(normalized, k -> new InsertGroup(table, normalized)).count++;
     }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/RepeatedSingleInsertDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/RepeatedSingleInsertDetectorTest.java
@@ -10,6 +10,7 @@ import io.queryaudit.core.model.Severity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -215,6 +216,55 @@ class RepeatedSingleInsertDetectorTest {
       List<QueryRecord> queries = repeat("INSERT INTO users (name) VALUES (?)", 2);
 
       List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Default excludes temp_*/staging tables (regression for #129)")
+    void defaultExcludesTempStaging() {
+      List<QueryRecord> queries =
+          repeat("INSERT INTO temp_staging VALUES (1, 'a')", 4);
+
+      List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
+
+      assertThat(issues).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Default exclude does not affect non-staging tables")
+    void defaultDoesNotExcludeRegularTable() {
+      List<QueryRecord> queries =
+          repeat("INSERT INTO orders (id, total) VALUES (1, 100)", 4);
+
+      List<Issue> issues = detector.evaluate(queries, EMPTY_INDEX);
+
+      assertThat(issues).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Empty exclude set restores legacy behavior")
+    void emptyExcludeSetWarnsOnTempTable() {
+      RepeatedSingleInsertDetector noExcludes =
+          new RepeatedSingleInsertDetector(3, Set.of());
+
+      List<QueryRecord> queries = repeat("INSERT INTO temp_staging VALUES (1, 'a')", 4);
+
+      List<Issue> issues = noExcludes.evaluate(queries, EMPTY_INDEX);
+
+      assertThat(issues).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Custom exclude pattern matches case-insensitively")
+    void customExcludePatternCaseInsensitive() {
+      RepeatedSingleInsertDetector custom =
+          new RepeatedSingleInsertDetector(3, Set.of("etl_*"));
+
+      List<QueryRecord> queries =
+          repeat("INSERT INTO ETL_LANDING VALUES (1, 'a')", 4);
+
+      List<Issue> issues = custom.evaluate(queries, EMPTY_INDEX);
 
       assertThat(issues).isEmpty();
     }

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
@@ -55,6 +55,8 @@ public class QueryAuditAutoConfiguration {
         .tooManyJoinsThreshold(properties.getTooManyJoins().getThreshold())
         .excessiveColumnThreshold(properties.getExcessiveColumn().getThreshold())
         .repeatedInsertThreshold(properties.getRepeatedInsert().getThreshold())
+        .repeatedInsertExcludeTables(
+            new HashSet<>(properties.getRepeatedInsert().getExcludeTables()))
         .writeAmplificationThreshold(properties.getWriteAmplification().getThreshold())
         .slowQueryWarningMs(properties.getSlowQuery().getWarningMs())
         .slowQueryErrorMs(properties.getSlowQuery().getErrorMs())

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
@@ -297,12 +297,31 @@ public class QueryAuditProperties {
   public static class RepeatedInsert {
     private int threshold = 3;
 
+    /**
+     * Table-name globs (case-insensitive, {@code *} wildcard) the detector treats as deliberate
+     * staging targets — repeated single-row inserts into these are not flagged. Defaults to common
+     * temp/staging conventions; set to an empty list to disable the exclusion.
+     *
+     * @since 0.4.0
+     */
+    private List<String> excludeTables =
+        new ArrayList<>(
+            io.queryaudit.core.detector.RepeatedSingleInsertDetector.DEFAULT_EXCLUDE_TABLES);
+
     public int getThreshold() {
       return threshold;
     }
 
     public void setThreshold(int threshold) {
       this.threshold = threshold;
+    }
+
+    public List<String> getExcludeTables() {
+      return excludeTables;
+    }
+
+    public void setExcludeTables(List<String> excludeTables) {
+      this.excludeTables = excludeTables;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add default glob-based table-name exclusion (`temp_*`, `*_temp`, `tmp_*`, `*_tmp`, `staging_*`, `*_staging`) to `RepeatedSingleInsertDetector`.
- Expose `repeatedInsertExcludeTables` on `QueryAuditConfig` and `query-audit.repeated-insert.exclude-tables` for Spring Boot users.
- Default behavior change: repeated single-row inserts into staging-named tables no longer fail the build.

## Why
The detector currently flags every loop-style INSERT as a confirmed WARNING. For deliberate staging targets (test fixtures, ETL landing, session-local temp tables), the round-trip / log-flush cost the rule warns about does not apply, so the warning is a pure false positive — and on `fail-on-detection`, breaks the build.

## Test plan
- [x] `RepeatedSingleInsertDetectorTest` — new cases for default exclusion, empty override, custom case-insensitive glob.
- [x] Existing `RepeatedSingleInsertDetectorTest` cases still pass.
- [x] Full `:query-audit-core:test` and `:query-audit-spring-boot-starter:test` runs (only unrelated pre-existing failures from other open issues remain).

Closes #129