### PR TITLE
fix(core): resolve schema-qualified table names against unqualified metadata (#128)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/MissingIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/MissingIndexDetector.java
@@ -30,11 +30,17 @@ import java.util.regex.Pattern;
  */
 public class MissingIndexDetector implements DetectionRule {
 
+  // Matches "FROM <table>" with optional schema/database prefixes (e.g. "myschema.users",
+  // "db.schema.users") and an optional alias.
   private static final Pattern FROM_ALIAS =
-      Pattern.compile("\\bFROM\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "\\bFROM\\s+((?:\\w+\\.){0,2}\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?",
+          Pattern.CASE_INSENSITIVE);
 
   private static final Pattern JOIN_ALIAS =
-      Pattern.compile("\\bJOIN\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
+      Pattern.compile(
+          "\\bJOIN\\s+((?:\\w+\\.){0,2}\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?",
+          Pattern.CASE_INSENSITIVE);
 
   // ── Improvement 1: Low cardinality column name patterns ──────────
   private static final Set<String> LOW_CARDINALITY_EXACT_NAMES =
@@ -653,29 +659,42 @@ public class MissingIndexDetector implements DetectionRule {
 
     Matcher fromMatcher = FROM_ALIAS.matcher(sql);
     while (fromMatcher.find()) {
-      String table = fromMatcher.group(1);
-      String alias = fromMatcher.group(2);
-      if (!isKeyword(table)) {
-        aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-        if (alias != null && !isKeyword(alias)) {
-          aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-        }
-      }
+      registerAlias(aliasToTable, fromMatcher.group(1), fromMatcher.group(2));
     }
 
     Matcher joinMatcher = JOIN_ALIAS.matcher(sql);
     while (joinMatcher.find()) {
-      String table = joinMatcher.group(1);
-      String alias = joinMatcher.group(2);
-      if (!isKeyword(table)) {
-        aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-        if (alias != null && !isKeyword(alias)) {
-          aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-        }
-      }
+      registerAlias(aliasToTable, joinMatcher.group(1), joinMatcher.group(2));
     }
 
     return aliasToTable;
+  }
+
+  private static void registerAlias(
+      Map<String, String> aliasToTable, String tableToken, String aliasToken) {
+    if (tableToken == null) {
+      return;
+    }
+    // The token may be schema-qualified ("myschema.users", "db.schema.users"). Drop the prefix so
+    // detectors look up metadata under the canonical bare name; preserve the qualified form too so
+    // `WHERE myschema.users.col` resolves through the same map.
+    String unqualified = stripSchemaPrefix(tableToken).toLowerCase();
+    if (isKeyword(unqualified)) {
+      return;
+    }
+    aliasToTable.put(unqualified, unqualified);
+    String qualified = tableToken.toLowerCase();
+    if (!qualified.equals(unqualified)) {
+      aliasToTable.put(qualified, unqualified);
+    }
+    if (aliasToken != null && !isKeyword(aliasToken)) {
+      aliasToTable.put(aliasToken.toLowerCase(), unqualified);
+    }
+  }
+
+  private static String stripSchemaPrefix(String token) {
+    int lastDot = token.lastIndexOf('.');
+    return lastDot < 0 ? token : token.substring(lastDot + 1);
   }
 
   /**

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/IndexMetadata.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/IndexMetadata.java
@@ -29,12 +29,45 @@ public class IndexMetadata {
     if (table == null) {
       return false;
     }
-    List<IndexInfo> indexes = indexesByTable.get(table);
+    List<IndexInfo> indexes = lookup(table);
     if (indexes == null) {
       return false;
     }
     return indexes.stream()
         .anyMatch(idx -> idx.columnName() != null && idx.columnName().equalsIgnoreCase(column));
+  }
+
+  /**
+   * Returns the index list registered for the given table. If the table is schema-qualified (e.g.
+   * {@code myschema.users}) and the qualified key is not registered, falls back to the unqualified
+   * suffix. Returns {@code null} when neither key is registered.
+   */
+  private List<IndexInfo> lookup(String table) {
+    if (table == null) {
+      return null;
+    }
+    List<IndexInfo> direct = indexesByTable.get(table);
+    if (direct != null) {
+      return direct;
+    }
+    String unqualified = stripSchemaPrefix(table);
+    if (unqualified == null || unqualified.equals(table)) {
+      return null;
+    }
+    return indexesByTable.get(unqualified);
+  }
+
+  /**
+   * Returns the suffix of a schema-qualified identifier (e.g. {@code myschema.users} →
+   * {@code users}, {@code db.schema.users} → {@code users}). Returns the input unchanged when no
+   * dot is present.
+   */
+  private static String stripSchemaPrefix(String table) {
+    if (table == null) {
+      return null;
+    }
+    int lastDot = table.lastIndexOf('.');
+    return lastDot < 0 ? table : table.substring(lastDot + 1);
   }
 
   /**
@@ -58,7 +91,7 @@ public class IndexMetadata {
     if (table == null || columns == null || columns.isEmpty()) {
       return false;
     }
-    List<IndexInfo> indexes = indexesByTable.get(table);
+    List<IndexInfo> indexes = lookup(table);
     if (indexes == null) {
       return false;
     }
@@ -94,7 +127,7 @@ public class IndexMetadata {
     if (table == null || columns == null || columns.isEmpty()) {
       return false;
     }
-    List<IndexInfo> indexes = indexesByTable.get(table);
+    List<IndexInfo> indexes = lookup(table);
     if (indexes == null) {
       return false;
     }
@@ -124,7 +157,8 @@ public class IndexMetadata {
     if (table == null) {
       return Collections.emptyList();
     }
-    return indexesByTable.getOrDefault(table, Collections.emptyList());
+    List<IndexInfo> indexes = lookup(table);
+    return indexes != null ? indexes : Collections.emptyList();
   }
 
   public Map<String, List<IndexInfo>> getCompositeIndexes(String table) {
@@ -144,7 +178,7 @@ public class IndexMetadata {
    * should skip it to avoid false positives.
    */
   public boolean hasTable(String table) {
-    return table != null && indexesByTable.containsKey(table);
+    return lookup(table) != null;
   }
 
   public boolean isEmpty() {

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/MissingIndexDetectorSchemaQualifiedTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/MissingIndexDetectorSchemaQualifiedTest.java
@@ -1,0 +1,86 @@
+package io.queryaudit.core.detector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.IndexInfo;
+import io.queryaudit.core.model.IndexMetadata;
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.QueryRecord;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #128 — schema-qualified table names ({@code myschema.users}) used to
+ * silently bypass {@code MissingIndexDetector} because the alias regex captured only the schema
+ * portion and the metadata lookup keyed on the bare name.
+ */
+class MissingIndexDetectorSchemaQualifiedTest {
+
+  private static QueryRecord rec(String sql) {
+    return new QueryRecord(sql, 0L, System.currentTimeMillis(), "");
+  }
+
+  @Test
+  @DisplayName("Schema-qualified table resolves to bare-name metadata")
+  void schemaQualifiedTwoPart() {
+    String sql = "SELECT * FROM myschema.users WHERE email = 'a@b.com'";
+    IndexMetadata meta = new IndexMetadata(Map.of("users", List.of()));
+
+    List<Issue> issues = new MissingIndexDetector().evaluate(List.of(rec(sql)), meta);
+
+    assertThat(issues)
+        .as("schema-qualified `myschema.users` should match metadata registered as `users`")
+        .isNotEmpty();
+    assertThat(issues.get(0).column()).isEqualToIgnoringCase("email");
+  }
+
+  @Test
+  @DisplayName("Three-part name (db.schema.table) also resolves")
+  void threePartName() {
+    String sql = "SELECT * FROM mydb.myschema.users WHERE email = 'a@b.com'";
+    IndexMetadata meta = new IndexMetadata(Map.of("users", List.of()));
+
+    List<Issue> issues = new MissingIndexDetector().evaluate(List.of(rec(sql)), meta);
+
+    assertThat(issues).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("Bare-name behavior is unchanged")
+  void bareNameStillWorks() {
+    String sql = "SELECT * FROM users WHERE email = 'a@b.com'";
+    IndexMetadata meta = new IndexMetadata(Map.of("users", List.of()));
+
+    List<Issue> issues = new MissingIndexDetector().evaluate(List.of(rec(sql)), meta);
+
+    assertThat(issues).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("Schema-qualified table with existing index does NOT warn")
+  void schemaQualifiedWithIndexNoWarn() {
+    String sql = "SELECT * FROM myschema.users WHERE email = 'a@b.com'";
+    IndexMetadata meta =
+        new IndexMetadata(
+            Map.of(
+                "users",
+                List.of(new IndexInfo("users", "idx_email", "email", 1, true, 100))));
+
+    List<Issue> issues = new MissingIndexDetector().evaluate(List.of(rec(sql)), meta);
+
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  @DisplayName("IndexMetadata.hasTable falls back to unqualified suffix")
+  void hasTableFallsBackToSuffix() {
+    IndexMetadata meta = new IndexMetadata(Map.of("users", List.of()));
+
+    assertThat(meta.hasTable("users")).isTrue();
+    assertThat(meta.hasTable("myschema.users")).isTrue();
+    assertThat(meta.hasTable("db.schema.users")).isTrue();
+    assertThat(meta.hasTable("orders")).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary
- Two-layer fix for the silent miss on schema-qualified queries (`myschema.users`).
- `MissingIndexDetector.resolveAliases` now matches up to three-part names (`db.schema.table`) and registers both qualified and bare aliases.
- `IndexMetadata` lookups fall back to the unqualified suffix when the qualified key is absent — transparently fixes other index-aware detectors (`CompositeIndexDetector`, `DmlWithoutIndexDetector`, `RangeLockDetector`, ...).

## Why
PostgreSQL/Oracle codebases routinely write fully-qualified table references. Before this fix, `SELECT … FROM myschema.users WHERE email = …` produced **zero** issues even when `users.email` had no index — a silent false-negative that let production missing-index regressions ship.

## Test plan
- [x] New `MissingIndexDetectorSchemaQualifiedTest` covers two-part, three-part, and bare-name forms; `hasTable` fallback; and the negative case (qualified table with index → no warn).
- [x] Existing `MissingIndexDetectorLikeTest` and the broader `:query-audit-core:test` still pass (only unrelated pre-existing failures from other open issues remain).

Quoted identifiers (`"schema"."users"`) remain out of scope — see #103.

Closes #128