### PR TITLE
fix(core): suppress DistinctMisuse rule when query contains a JOIN (#127)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/DistinctMisuseDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/DistinctMisuseDetector.java
@@ -103,7 +103,15 @@ public class DistinctMisuseDetector implements DetectionRule {
         continue; // Don't report multiple issues for the same query
       }
 
-      // (c) DISTINCT on primary key column
+      // Any JOIN can multiply rows on the result side, breaking PK uniqueness on the base table
+      // and making DISTINCT a legitimate dedupe step. Without proven 1:1 cardinality (issue #127),
+      // we skip the entire rule for JOIN queries — false positives there fail the build, while
+      // the lost true positive (a redundant DISTINCT on a 1:1 JOIN) is at most cosmetic.
+      if (hasJoin) {
+        continue;
+      }
+
+      // (c) DISTINCT on primary key column — only safe to flag without JOINs.
       if (indexMetadata != null && !indexMetadata.isEmpty()) {
         List<String> distinctCols = extractDistinctColumnNames(sql);
         List<String> tables = EnhancedSqlParser.extractTableNames(sql);
@@ -125,27 +133,8 @@ public class DistinctMisuseDetector implements DetectionRule {
                     "DISTINCT on primary key column is unnecessary",
                     "Remove DISTINCT — the primary key column is already unique by definition.",
                     query.stackTrace()));
-            continue;
           }
         }
-      }
-
-      // (a) DISTINCT + JOIN may indicate a missing JOIN condition
-      if (hasJoin) {
-        List<String> tables = EnhancedSqlParser.extractTableNames(sql);
-        String table = tables.isEmpty() ? null : tables.get(0);
-
-        issues.add(
-            new Issue(
-                IssueType.DISTINCT_MISUSE,
-                Severity.WARNING,
-                normalized,
-                table,
-                null,
-                "DISTINCT with JOIN may indicate a missing JOIN condition or could use EXISTS",
-                "Review JOIN conditions for correctness. "
-                    + "If checking existence, use EXISTS (SELECT 1 FROM ...) instead.",
-                query.stackTrace()));
       }
     }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/AcademicBenchmarkTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/AcademicBenchmarkTest.java
@@ -362,24 +362,22 @@ class AcademicBenchmarkTest {
       }
 
       @Test
-      @DisplayName("AP10: Unnecessary DISTINCT with JOIN")
+      @DisplayName("AP10: DISTINCT with JOIN — intentionally suppressed since #127")
       void distinctWithJoin() {
+        // Per issue #127, the detector no longer flags any DISTINCT+JOIN combination because
+        // 1:N JOINs legitimately require DISTINCT and we cannot prove 1:1 cardinality from SQL
+        // alone. This benchmark case is acknowledged as a missed detection (acceptable per the
+        // issue's acceptance criteria).
         DistinctMisuseDetector detector = new DistinctMisuseDetector();
 
-        List<Issue> bad =
+        List<Issue> issues =
             detector.evaluate(
                 List.of(
                     record(
                         "SELECT DISTINCT u.name FROM users u JOIN orders o ON o.user_id = u.id")),
                 EMPTY_INDEX);
-        List<Issue> good =
-            detector.evaluate(
-                List.of(
-                    record(
-                        "SELECT u.name FROM users u WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id)")),
-                EMPTY_INDEX);
 
-        assertAntiPatternDetected(bad, IssueType.DISTINCT_MISUSE, good);
+        assertThat(issues).isEmpty();
       }
 
       @Test

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest2.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest2.java
@@ -531,15 +531,15 @@ class ComprehensiveFalsePositiveTest2 {
     private final DistinctMisuseDetector detector = new DistinctMisuseDetector();
 
     @Test
-    @DisplayName("TP: DISTINCT with JOIN triggers WARNING")
-    void truePositive_distinctWithJoin() {
+    @DisplayName("Suppressed: DISTINCT with JOIN no longer fires (issue #127)")
+    void distinctWithJoinSuppressed() {
+      // Per #127, any JOIN suppresses DISTINCT_MISUSE entirely — 1:N joins legitimately need
+      // DISTINCT and the prior WARNING was a build-breaking false positive.
       List<Issue> issues =
           detector.evaluate(
               queries("SELECT DISTINCT a.id FROM a JOIN b ON a.id = b.a_id"), EMPTY_INDEX);
 
-      assertThat(issues).hasSize(1);
-      assertThat(issues.get(0).type()).isEqualTo(IssueType.DISTINCT_MISUSE);
-      assertThat(issues.get(0).severity()).isEqualTo(Severity.WARNING);
+      assertThat(issues).isEmpty();
     }
 
     @Test

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/DistinctMisuseDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/DistinctMisuseDetectorTest.java
@@ -36,15 +36,34 @@ class DistinctMisuseDetectorTest {
   }
 
   @Test
-  void detectsDistinctWithJoin() {
+  void doesNotFlagDistinctWithJoin() {
+    // DISTINCT with any JOIN is intentionally not flagged: a 1:N JOIN legitimately needs DISTINCT
+    // to dedupe rows, and we cannot prove 1:1 cardinality from the SQL alone (issue #127).
     String sql = "SELECT DISTINCT u.name FROM users u JOIN orders o ON u.id = o.user_id";
 
     List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
 
-    assertThat(issues).hasSize(1);
-    assertThat(issues.get(0).type()).isEqualTo(IssueType.DISTINCT_MISUSE);
-    assertThat(issues.get(0).severity()).isEqualTo(Severity.WARNING);
-    assertThat(issues.get(0).detail()).contains("JOIN");
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void doesNotFlagDistinctOnPkWithLeftJoin() {
+    // Regression for #127: SELECT DISTINCT u.id … LEFT JOIN orders … used to fire
+    // "DISTINCT on primary key column is unnecessary", which was actively harmful — removing
+    // DISTINCT would silently produce duplicate user rows for users with multiple orders.
+    IndexMetadata metadata =
+        new IndexMetadata(
+            Map.of(
+                "users", List.of(new IndexInfo("users", "PRIMARY", "id", 1, false, 10000)),
+                "orders", List.of(new IndexInfo("orders", "idx_user_id", "user_id", 1, true, 100))));
+
+    String sql =
+        "SELECT DISTINCT u.id, u.name FROM users u "
+            + "LEFT JOIN orders o ON u.id = o.user_id WHERE u.active = true";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
+
+    assertThat(issues).isEmpty();
   }
 
   @Test
@@ -140,24 +159,21 @@ class DistinctMisuseDetectorTest {
   }
 
   @Test
-  void distinctWithJoinDetectedWhenNoPKMatch() {
-    // Kills NegateConditionalsMutator on line 124: hasJoin check
-    // Verifies the JOIN detection path is hit after PK check fails
+  void distinctWithJoinNoLongerFiresWhenNoPKMatch() {
+    // Per #127, any JOIN suppresses DISTINCT_MISUSE entirely (PK or otherwise), since 1:N JOINs
+    // legitimately require DISTINCT and we cannot prove 1:1 cardinality from SQL alone.
     IndexMetadata metadata =
         new IndexMetadata(
             Map.of("users", List.of(new IndexInfo("users", "PRIMARY", "id", 1, false, 10000))));
 
-    // DISTINCT on non-PK column with JOIN
     String sql = "SELECT DISTINCT u.name FROM users u JOIN orders o ON u.id = o.user_id";
     List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
-    assertThat(issues).hasSize(1);
-    assertThat(issues.get(0).detail()).contains("JOIN");
+    assertThat(issues).isEmpty();
   }
 
   @Test
-  void distinctOnPKColumnWithJoinReportsPKIssue() {
-    // Kills NegateConditionalsMutator on line 78 (table empty check)
-    // and ensures PK detection takes priority over JOIN detection
+  void distinctOnPKColumnSingleTableStillReportsPKIssue() {
+    // The genuine misuse — DISTINCT on a PK column of a single-table query — still fires.
     IndexMetadata metadata =
         new IndexMetadata(
             Map.of("users", List.of(new IndexInfo("users", "PRIMARY", "id", 1, false, 10000))));
@@ -275,15 +291,11 @@ class DistinctMisuseDetectorTest {
   }
 
   @Test
-  void distinctWithJoinReportsCorrectTable_killsLine124() {
-    // Kills NegateConditionalsMutator on line 124: tables.isEmpty() negated.
-    // If negated, table would be null when tables exist.
-    // Verify table is NOT null in the JOIN detection path.
+  void distinctWithJoinIsSuppressed() {
+    // Per #127, any JOIN suppresses DISTINCT_MISUSE entirely.
     String sql = "SELECT DISTINCT u.email FROM users u JOIN orders o ON u.id = o.user_id";
     List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
-    assertThat(issues).hasSize(1);
-    assertThat(issues.get(0).table()).isNotNull();
-    assertThat(issues.get(0).table()).isEqualTo("users");
+    assertThat(issues).isEmpty();
   }
 
   @Test
@@ -336,18 +348,15 @@ class DistinctMisuseDetectorTest {
   }
 
   @Test
-  void distinctWithJoinNoGroupByNoPKMetadata_killsLine124Path() {
-    // Specifically tests the path where PK check is performed but doesn't match,
-    // falling through to JOIN detection (line 122-137).
+  void distinctOnNonPkColumnWithJoinIsSuppressed() {
+    // After #127 the detector skips any JOIN query; the prior "JOIN may indicate missing JOIN
+    // condition" warning was a noisy false positive in 1:N joins.
     IndexMetadata metadata =
         new IndexMetadata(
             Map.of("users", List.of(new IndexInfo("users", "PRIMARY", "id", 1, false, 10000))));
-    // DISTINCT on 'name' (not PK) with JOIN -> should report JOIN issue
     String sql = "SELECT DISTINCT name FROM users JOIN roles ON users.role_id = roles.id";
     List<Issue> issues = detector.evaluate(List.of(record(sql)), metadata);
-    assertThat(issues).hasSize(1);
-    assertThat(issues.get(0).detail()).contains("JOIN");
-    assertThat(issues.get(0).table()).isNotNull();
+    assertThat(issues).isEmpty();
   }
 
   // ── false positive fix: DISTINCT in subquery ──────────────────────
@@ -369,14 +378,14 @@ class DistinctMisuseDetectorTest {
   }
 
   @Test
-  void stillDetectsDistinctInOuterQueryWithSubquery() {
-    // DISTINCT in the outer query should still be detected even if there's a subquery
+  void distinctInOuterQueryWithJoinAndSubqueryIsSuppressed() {
+    // The outer query has a JOIN, so per #127 the entire rule is skipped — the inner subquery
+    // just confirms removeSubqueries does not somehow re-introduce a false positive.
     String sql =
         "SELECT DISTINCT u.name FROM users u "
             + "JOIN orders o ON u.id = o.user_id "
             + "WHERE o.id IN (SELECT id FROM recent_orders)";
     List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
-    assertThat(issues).hasSize(1);
-    assertThat(issues.get(0).detail()).contains("JOIN");
+    assertThat(issues).isEmpty();
   }
 }

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/SqlStyleIntegrationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/SqlStyleIntegrationTest.java
@@ -94,8 +94,8 @@ class SqlStyleIntegrationTest {
     }
 
     @Test
-    @DisplayName("DISTINCT with JOIN may indicate missing condition")
-    void detectsDistinctWithJoin() {
+    @DisplayName("DISTINCT with JOIN is intentionally not flagged (issue #127)")
+    void doesNotFlagDistinctWithJoin() {
       queryInterceptor.start();
       entityManager
           .createNativeQuery(
@@ -104,7 +104,7 @@ class SqlStyleIntegrationTest {
       queryInterceptor.stop();
 
       QueryAuditReport report = analyze("distinctWithJoin", queryInterceptor.getRecordedQueries());
-      assertThat(allIssues(report)).anyMatch(i -> i.type() == IssueType.DISTINCT_MISUSE);
+      assertThat(allIssues(report)).noneMatch(i -> i.type() == IssueType.DISTINCT_MISUSE);
     }
   }
 


### PR DESCRIPTION
## Summary
- Skip the entire `DistinctMisuseDetector` rule when any JOIN is present (option 1 from the issue's suggested directions).
- Drop the companion "DISTINCT with JOIN may indicate a missing JOIN condition" warning — same false positive class.
- Single-table redundant-DISTINCT detection (`SELECT DISTINCT id FROM users …`) is unchanged.
- DISTINCT + GROUP BY detection is unchanged.

## Why
The rule asserted "PK uniqueness ⇒ rows are unique" — true for the base table, but a LEFT/INNER JOIN can multiply rows and DISTINCT is then the correct dedupe. The "fix" the warning suggested ("Remove DISTINCT") would silently introduce duplicates. With `fail-on-detection`, it broke the build on legitimate code.

## Test plan
- [x] New `doesNotFlagDistinctOnPkWithLeftJoin` regression test on the issue's repro SQL.
- [x] `DistinctMisuseDetectorTest` updated: JOIN-related cases now assert empty.
- [x] Two pre-existing benchmark tests (`AcademicBenchmarkTest.AP10`, `ComprehensiveFalsePositiveTest2`) updated to the new contract.
- [x] Full `:query-audit-core:test` runs (only unrelated pre-existing failures from other open issues remain).

Closes #127