### PR TITLE
fix(core): make CountInsteadOfExistsDetector opt-in (#126)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
@@ -44,6 +44,7 @@ public class QueryAuditConfig {
   private final long slowQueryErrorMs;
   private final RepositoryReturnTypeResolver repositoryReturnTypeResolver;
   private final boolean includeSetupQueries;
+  private final boolean countInsteadOfExistsEnabled;
 
   private QueryAuditConfig(Builder builder) {
     this.enabled = builder.enabled;
@@ -70,6 +71,7 @@ public class QueryAuditConfig {
     this.slowQueryErrorMs = builder.slowQueryErrorMs;
     this.repositoryReturnTypeResolver = builder.repositoryReturnTypeResolver;
     this.includeSetupQueries = builder.includeSetupQueries;
+    this.countInsteadOfExistsEnabled = builder.countInsteadOfExistsEnabled;
   }
 
   public static Builder builder() {
@@ -221,6 +223,17 @@ public class QueryAuditConfig {
     return includeSetupQueries;
   }
 
+  /**
+   * Returns whether {@link io.queryaudit.core.detector.CountInsteadOfExistsDetector} is enabled.
+   * Off by default since 0.4.0 (issue #126) — the rule cannot tell aggregate counts from existence
+   * checks from SQL alone, and was the loudest noise source on real reports.
+   *
+   * @since 0.4.0
+   */
+  public boolean isCountInsteadOfExistsEnabled() {
+    return countInsteadOfExistsEnabled;
+  }
+
   public boolean isSuppressed(String issueCode, String table, String column) {
     if (suppressPatterns.isEmpty()) {
       return false;
@@ -276,6 +289,7 @@ public class QueryAuditConfig {
     private long slowQueryErrorMs = 3000;
     private RepositoryReturnTypeResolver repositoryReturnTypeResolver = null;
     private boolean includeSetupQueries = false;
+    private boolean countInsteadOfExistsEnabled = false;
 
     /**
      * Creates a new builder pre-populated with all values from the given config. Useful for
@@ -306,6 +320,7 @@ public class QueryAuditConfig {
       b.slowQueryWarningMs = source.slowQueryWarningMs;
       b.slowQueryErrorMs = source.slowQueryErrorMs;
       b.repositoryReturnTypeResolver = source.repositoryReturnTypeResolver;
+      b.countInsteadOfExistsEnabled = source.countInsteadOfExistsEnabled;
       return b;
     }
 
@@ -458,6 +473,17 @@ public class QueryAuditConfig {
 
     public Builder includeSetupQueries(boolean includeSetupQueries) {
       this.includeSetupQueries = includeSetupQueries;
+      return this;
+    }
+
+    /**
+     * Toggles {@link io.queryaudit.core.detector.CountInsteadOfExistsDetector}. Off by default
+     * since 0.4.0 (issue #126).
+     *
+     * @since 0.4.0
+     */
+    public Builder countInsteadOfExistsEnabled(boolean enabled) {
+      this.countInsteadOfExistsEnabled = enabled;
       return this;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/CountInsteadOfExistsDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/CountInsteadOfExistsDetector.java
@@ -25,10 +25,32 @@ import java.util.regex.Pattern;
  *   <li>Does NOT have HAVING
  * </ul>
  *
+ * <p><b>Off by default since 0.4.0 (issue #126):</b> the SQL alone cannot tell an aggregate count
+ * from an existence check, and on real codebases the rule produced one of the highest issue
+ * volumes (every paginated count, every dashboard metric, every audit query). Users who want it
+ * must opt in via {@code QueryAuditConfig.countInsteadOfExistsEnabled(true)} or
+ * {@code query-audit.count-instead-of-exists.enabled: true}. When constructing the detector
+ * directly (e.g. in tests) use the {@code (true)} overload to keep the legacy behavior.
+ *
  * @author haroya
  * @since 0.2.0
  */
 public class CountInsteadOfExistsDetector implements DetectionRule {
+
+  private final boolean enabled;
+
+  /** Constructs the detector in its default-off state — calling {@link #evaluate} returns empty. */
+  public CountInsteadOfExistsDetector() {
+    this(false);
+  }
+
+  /**
+   * @param enabled when {@code false}, {@link #evaluate} short-circuits and returns no issues
+   * @since 0.4.0
+   */
+  public CountInsteadOfExistsDetector(boolean enabled) {
+    this.enabled = enabled;
+  }
 
   private static final Pattern COUNT_PATTERN =
       Pattern.compile(
@@ -60,6 +82,9 @@ public class CountInsteadOfExistsDetector implements DetectionRule {
 
   @Override
   public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
+    if (!enabled) {
+      return List.of();
+    }
     List<Issue> issues = new ArrayList<>();
     Set<String> seen = new LinkedHashSet<>();
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
@@ -136,7 +136,7 @@ public class QueryAuditAnalyzer {
     ruleList.add(new IndexRedundancyDetector());
     ruleList.add(
         new SlowQueryDetector(config.getSlowQueryWarningMs(), config.getSlowQueryErrorMs()));
-    ruleList.add(new CountInsteadOfExistsDetector());
+    ruleList.add(new CountInsteadOfExistsDetector(config.isCountInsteadOfExistsEnabled()));
     ruleList.add(new UnboundedResultSetDetector(config.getRepositoryReturnTypeResolver()));
     ruleList.add(new WriteAmplificationDetector(config.getWriteAmplificationThreshold()));
     ruleList.add(new ImplicitTypeConversionDetector());

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/AcademicBenchmarkTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/AcademicBenchmarkTest.java
@@ -572,7 +572,7 @@ class AcademicBenchmarkTest {
       @Test
       @DisplayName("AP21: COUNT(*) where EXISTS would suffice")
       void countInsteadOfExists() {
-        CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector();
+        CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector(true);
 
         List<Issue> bad =
             detector.evaluate(
@@ -592,7 +592,7 @@ class AcademicBenchmarkTest {
       @Test
       @DisplayName("AP22: COUNT(column) for existence check")
       void countColumnInsteadOfExists() {
-        CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector();
+        CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector(true);
 
         List<Issue> bad =
             detector.evaluate(

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/AdversarialFalsePositiveTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/AdversarialFalsePositiveTest.java
@@ -1680,7 +1680,7 @@ class AdversarialFalsePositiveTest {
   @Nested
   class CountInsteadOfExistsDetectorFalsePositives {
 
-    private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector();
+    private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector(true);
 
     @Test
     void countWithGroupByShouldNotTrigger() {

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
@@ -789,7 +789,7 @@ class ComprehensiveFalsePositiveTest {
   @DisplayName("15. CountInsteadOfExistsDetector")
   class CountInsteadOfExistsDetectorTests {
 
-    private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector();
+    private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector(true);
 
     @Test
     @DisplayName("TP: COUNT(*) with WHERE (existence check) should detect")

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/CountInsteadOfExistsDetectorHibernateFalsePositiveTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/CountInsteadOfExistsDetectorHibernateFalsePositiveTest.java
@@ -38,7 +38,7 @@ class CountInsteadOfExistsDetectorHibernateFalsePositiveTest {
     return new QueryRecord(sql, 0L, System.currentTimeMillis(), "");
   }
 
-  private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector();
+  private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector(true);
 
   // ── SQL already contains a boolean comparison (count > ?) ────────────────
   // These queries express existence intent AT the SQL level.

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/CountInsteadOfExistsDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/CountInsteadOfExistsDetectorTest.java
@@ -19,7 +19,7 @@ class CountInsteadOfExistsDetectorTest {
     return new QueryRecord(sql, 0L, System.currentTimeMillis(), "");
   }
 
-  private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector();
+  private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector(true);
 
   @Test
   void detectsCountStarWithWhere() {
@@ -150,5 +150,17 @@ class CountInsteadOfExistsDetectorTest {
 
     assertThat(issues).hasSize(1);
     assertThat(issues.get(0).severity()).isEqualTo(Severity.INFO);
+  }
+
+  @Test
+  void defaultIsDisabledRegressionForIssue126() {
+    // Regression for #126: the detector cannot tell aggregate counts from existence checks from
+    // SQL alone, so the no-arg constructor is off-by-default since 0.4.0.
+    CountInsteadOfExistsDetector defaultDetector = new CountInsteadOfExistsDetector();
+
+    String sql = "SELECT COUNT(*) FROM orders WHERE user_id = 42";
+    List<Issue> issues = defaultDetector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+    assertThat(issues).isEmpty();
   }
 }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/MySqlFalsePositiveEvidenceTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/MySqlFalsePositiveEvidenceTest.java
@@ -381,7 +381,7 @@ class MySqlFalsePositiveEvidenceTest {
   @DisplayName("CountInsteadOfExistsDetector — Legitimate COUNT usage")
   class CountInsteadOfExistsDetectorFalsePositives {
 
-    private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector();
+    private final CountInsteadOfExistsDetector detector = new CountInsteadOfExistsDetector(true);
 
     @Test
     @DisplayName(

--- a/query-audit-core/src/test/java/io/queryaudit/core/eval/FalsePositiveAuditTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/eval/FalsePositiveAuditTest.java
@@ -372,7 +372,7 @@ class FalsePositiveAuditTest {
             "update users set name=? where id=?",
             "select sum(total) from orders where user_id=?",
             "select max(created_at) from users where status=?");
-    List<Issue> issues = evaluate(new CountInsteadOfExistsDetector(), sqls);
+    List<Issue> issues = evaluate(new CountInsteadOfExistsDetector(true), sqls);
     assertThat(issues).as("CountInsteadOfExistsDetector false positives").isEmpty();
   }
 
@@ -898,7 +898,7 @@ class FalsePositiveAuditTest {
         List.of(
             "select status,count(*) from orders group by status",
             "select user_id,count(1) from orders group by user_id");
-    List<Issue> issues = evaluate(new CountInsteadOfExistsDetector(), sqls);
+    List<Issue> issues = evaluate(new CountInsteadOfExistsDetector(true), sqls);
     assertThat(issues).as("CountInsteadOfExistsDetector with GROUP BY").isEmpty();
   }
 

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/ResultSetSortIntegrationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/ResultSetSortIntegrationTest.java
@@ -226,8 +226,8 @@ class ResultSetSortIntegrationTest {
   class CountInsteadOfExistsTests {
 
     @Test
-    @DisplayName("COUNT(*) for existence check should use EXISTS")
-    void detectsCountInsteadOfExists() {
+    @DisplayName("CountInsteadOfExists is opt-in (issue #126); default analyzer does not fire")
+    void countInsteadOfExistsIsOptIn() {
       queryInterceptor.start();
       entityManager
           .createNativeQuery("SELECT COUNT(*) FROM members WHERE status = 'ACTIVE'")
@@ -236,7 +236,7 @@ class ResultSetSortIntegrationTest {
 
       QueryAuditReport report =
           analyze("countInsteadOfExists", queryInterceptor.getRecordedQueries());
-      assertThat(allIssues(report)).anyMatch(i -> i.type() == IssueType.COUNT_INSTEAD_OF_EXISTS);
+      assertThat(allIssues(report)).noneMatch(i -> i.type() == IssueType.COUNT_INSTEAD_OF_EXISTS);
     }
   }
 

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
@@ -60,6 +60,7 @@ public class QueryAuditAutoConfiguration {
         .writeAmplificationThreshold(properties.getWriteAmplification().getThreshold())
         .slowQueryWarningMs(properties.getSlowQuery().getWarningMs())
         .slowQueryErrorMs(properties.getSlowQuery().getErrorMs())
+        .countInsteadOfExistsEnabled(properties.getCountInsteadOfExists().isEnabled())
         .build();
   }
 

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
@@ -35,6 +35,7 @@ public class QueryAuditProperties {
   private RepeatedInsert repeatedInsert = new RepeatedInsert();
   private WriteAmplification writeAmplification = new WriteAmplification();
   private SlowQuery slowQuery = new SlowQuery();
+  private CountInsteadOfExists countInsteadOfExists = new CountInsteadOfExists();
 
   // ── Top-level getters & setters ────────────────────────────────────
 
@@ -190,6 +191,14 @@ public class QueryAuditProperties {
     this.slowQuery = slowQuery;
   }
 
+  public CountInsteadOfExists getCountInsteadOfExists() {
+    return countInsteadOfExists;
+  }
+
+  public void setCountInsteadOfExists(CountInsteadOfExists countInsteadOfExists) {
+    this.countInsteadOfExists = countInsteadOfExists;
+  }
+
   // ── Nested configuration classes ───────────────────────────────────
 
   public static class NPlusOne {
@@ -334,6 +343,21 @@ public class QueryAuditProperties {
 
     public void setThreshold(int threshold) {
       this.threshold = threshold;
+    }
+  }
+
+  /**
+   * @since 0.4.0
+   */
+  public static class CountInsteadOfExists {
+    private boolean enabled = false;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
     }
   }
 


### PR DESCRIPTION
## Summary
- Default-off the rule (option 1 in the issue's suggested directions): on real codebases it was the loudest noise source because the SQL alone cannot tell aggregate counts from existence checks.
- New no-arg constructor leaves the detector disabled; `(true)` overload keeps the legacy behavior for direct callers.
- New `QueryAuditConfig.countInsteadOfExistsEnabled(boolean)` and `query-audit.count-instead-of-exists.enabled` (Spring Boot YAML) for opt-in.
- Existing direct unit-test instantiations migrated to `(true)` so the detection logic stays covered.

## Why
The rule fired on every `SELECT COUNT(*) ... WHERE` — paginated counts, dashboard metrics, audit queries — drowning out higher-signal findings. Without runtime context (does the caller use the count as a number?), it can never tell which case applies.

## Test plan
- [x] New `CountInsteadOfExistsDetectorTest.defaultIsDisabledRegressionForIssue126`.
- [x] Existing `CountInsteadOfExistsDetectorTest` cases pass (now use `(true)` overload).
- [x] Cross-project FP/benchmark tests (`AcademicBenchmarkTest`, `ComprehensiveFalsePositiveTest`, `MySqlFalsePositiveEvidenceTest`, `AdversarialFalsePositiveTest`, `FalsePositiveAuditTest`) updated to `(true)`.
- [x] Full `:query-audit-core:test` and `:query-audit-spring-boot-starter:test` runs (only unrelated pre-existing failures from other open issues remain).

Closes #126