### PR TITLE
fix(core): suppress ImplicitTypeConversion on known-numeric _code columns (#125)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/ImplicitTypeConversionDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/ImplicitTypeConversionDetector.java
@@ -57,6 +57,23 @@ public class ImplicitTypeConversionDetector implements DetectionRule {
       Set.of("id", "count", "num", "no", "seq", "order", "size", "length");
 
   /**
+   * Column names that contain a string-like token but are conventionally numeric. Without column
+   * type metadata the detector cannot tell {@code zip_code = 12345} (numeric, correct) from
+   * {@code email = 12345} (string, wrong); this list short-circuits the false-positive cases
+   * called out in issue #125.
+   */
+  private static final Set<String> KNOWN_NUMERIC_COLUMNS =
+      Set.of(
+          "zip_code",
+          "area_code",
+          "country_code",
+          "error_code",
+          "type_code",
+          "status_code",
+          "post_code",
+          "postal_code");
+
+  /**
    * Pattern to match: column_name = bare_number in a WHERE context. Captures group(1) = column
    * name, group(2) = numeric literal. Works on raw SQL (before normalization replaces literals).
    */
@@ -121,6 +138,10 @@ public class ImplicitTypeConversionDetector implements DetectionRule {
   /** Returns true when the column name suggests a string type. */
   boolean isStringColumn(String columnName) {
     String lower = columnName.toLowerCase();
+
+    if (KNOWN_NUMERIC_COLUMNS.contains(lower)) {
+      return false;
+    }
 
     int lastUnderscore = lower.lastIndexOf('_');
     if (lastUnderscore >= 0) {

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ImplicitTypeConversionDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ImplicitTypeConversionDetectorTest.java
@@ -273,4 +273,42 @@ class ImplicitTypeConversionDetectorTest {
 
     assertThat(issues).isEmpty();
   }
+
+  // ── Regression: issue #125 — known-numeric `_code` columns ──────────
+
+  @Test
+  void noIssueForZipCodeRegressionForIssue125() {
+    String sql = "SELECT * FROM addresses WHERE zip_code = 12345";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+
+    assertThat(issues).isEmpty();
+  }
+
+  @Test
+  void noIssueForKnownNumericCodeColumns() {
+    List<String> sqls =
+        List.of(
+            "SELECT * FROM phones WHERE area_code = 415",
+            "SELECT * FROM countries WHERE country_code = 82",
+            "SELECT * FROM responses WHERE error_code = 404",
+            "SELECT * FROM types WHERE type_code = 7",
+            "SELECT * FROM orders WHERE status_code = 1",
+            "SELECT * FROM addresses WHERE postal_code = 90210");
+
+    for (String sql : sqls) {
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+      assertThat(issues).as("should not flag: %s", sql).isEmpty();
+    }
+  }
+
+  @Test
+  void stillFlagsActualStringColumnComparedToNumber() {
+    String sql = "SELECT * FROM users WHERE name = 12345";
+
+    List<Issue> issues = detector.evaluate(List.of(record(sql)), emptyMetadata);
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).column()).isEqualTo("name");
+  }
 }

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/MySqlFalsePositiveEvidenceTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/MySqlFalsePositiveEvidenceTest.java
@@ -181,46 +181,32 @@ class MySqlFalsePositiveEvidenceTest {
   // ═══════════════════════════════════════════════════════════════
 
   @Nested
-  @DisplayName("ImplicitTypeConversionDetector — Numeric _code column limitation")
+  @DisplayName("ImplicitTypeConversionDetector — known-numeric _code columns suppressed")
   class ImplicitTypeConversionDetectorFalsePositives {
 
     private final ImplicitTypeConversionDetector detector = new ImplicitTypeConversionDetector();
 
     @Test
-    @DisplayName(
-        "TN: zip_code = 12345 triggers despite possibly being an INTEGER column (known limitation) "
-            + "- Ref: https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html")
-    void numericComparisonOnCodeColumn_flaggedAsKnownLimitation() {
-      // country_code, zip_code, area_code could be INTEGER columns.
-      // WHERE zip_code = 12345 is NOT implicit type conversion if the column is numeric.
-      // The detector uses heuristics (_code suffix -> string) and cannot verify actual schema.
+    @DisplayName("TN: zip_code = 12345 no longer flagged (issue #125)")
+    void zipCodeNumeric_notFlaggedAfterIssue125() {
+      // Per issue #125, zip_code/area_code/country_code/error_code/type_code/status_code/
+      // postal_code are conventionally numeric and have been added to the deny-list to suppress
+      // the heuristic mismatch.
       String sql = "SELECT * FROM addresses WHERE zip_code = 12345";
 
       List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
 
-      // Known limitation: detector flags this because _code is in STRING_COLUMN_INDICATORS
-      assertThat(issues)
-          .anyMatch(
-              i -> i.type() == IssueType.IMPLICIT_TYPE_CONVERSION && "zip_code".equals(i.column()));
+      assertThat(issues).noneMatch(i -> i.type() == IssueType.IMPLICIT_TYPE_CONVERSION);
     }
 
     @Test
-    @DisplayName(
-        "TN: country_code = 82 triggers despite being a valid numeric comparison (known limitation) "
-            + "- Ref: https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html")
-    void countryCodeNumeric_flaggedAsKnownLimitation() {
-      // country_code could be an INT storing ISO 3166-1 numeric codes (e.g., 82 = South Korea).
-      // The detector cannot distinguish string vs numeric column types.
+    @DisplayName("TN: country_code = 82 no longer flagged (issue #125)")
+    void countryCodeNumeric_notFlaggedAfterIssue125() {
       String sql = "SELECT * FROM countries WHERE country_code = 82";
 
       List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
 
-      // Known limitation: heuristic-based detection cannot verify column type
-      assertThat(issues)
-          .anyMatch(
-              i ->
-                  i.type() == IssueType.IMPLICIT_TYPE_CONVERSION
-                      && "country_code".equals(i.column()));
+      assertThat(issues).noneMatch(i -> i.type() == IssueType.IMPLICIT_TYPE_CONVERSION);
     }
   }
 


### PR DESCRIPTION
## Summary
- Add a deny-list of conventional numeric `_code` column names — `zip_code`, `area_code`, `country_code`, `error_code`, `type_code`, `status_code`, `post_code`, `postal_code` — so `ImplicitTypeConversionDetector` no longer fires on them.
- Genuine string-column mismatches (`WHERE name = 12345`) still warn unchanged.

## Why
The detector classifies columns by name tokens. The `code` token caught a wave of numeric `_code` columns and emitted a WARNING with a "fix" (`= '12345'`) that would actively break the query. With `fail-on-detection` it broke real builds.

Without column-type metadata the heuristic cannot tell string from numeric — option 2 from the issue (explicit deny-list) is the lowest-risk fix.

## Test plan
- [x] New `ImplicitTypeConversionDetectorTest` regression tests for the issue's repro and each known-numeric name.
- [x] `MySqlFalsePositiveEvidenceTest` cases that pinned the bug as a "known limitation" updated to assert the suppressed behavior.
- [x] `stillFlagsActualStringColumnComparedToNumber` ensures genuine FPs still surface.
- [x] Full `:query-audit-core:test` (only unrelated pre-existing failures from other open issues remain).

Closes #125