### PR TITLE
fix(core): make isQuerySuppressed literal- and word-boundary aware (#124)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
@@ -4,11 +4,14 @@ import io.queryaudit.core.detector.RepeatedSingleInsertDetector;
 import io.queryaudit.core.detector.RepositoryReturnTypeResolver;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import io.queryaudit.core.model.Severity;
+import io.queryaudit.core.parser.SqlParser;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 /**
  * Immutable configuration for QueryAudit analysis. Controls which rules are enabled, their severity
@@ -250,13 +253,32 @@ public class QueryAuditConfig {
     return false;
   }
 
+  /**
+   * Cache of compiled word-boundary regexes for {@link #suppressQueries} patterns. The patterns
+   * are user-supplied, immutable for the lifetime of this config, and small (one entry per
+   * suppression rule); a plain {@link ConcurrentHashMap} is sufficient.
+   */
+  private static final Map<String, Pattern> SUPPRESS_PATTERN_CACHE = new ConcurrentHashMap<>();
+
   public boolean isQuerySuppressed(String sql) {
     if (suppressQueries.isEmpty() || sql == null) {
       return false;
     }
-    String normalized = sql.trim().toLowerCase();
-    for (String pattern : suppressQueries) {
-      if (normalized.contains(pattern.trim().toLowerCase())) {
+    // Mask string literals first so a suppression pattern can never match content inside a quoted
+    // string (issue #124: "from users" used to spuriously match `description = 'from users …'`).
+    String masked = SqlParser.replaceStringLiterals(sql).toLowerCase();
+    for (String raw : suppressQueries) {
+      String pattern = raw == null ? null : raw.trim();
+      if (pattern == null || pattern.isEmpty()) {
+        continue;
+      }
+      Pattern compiled =
+          SUPPRESS_PATTERN_CACHE.computeIfAbsent(
+              pattern.toLowerCase(),
+              p ->
+                  Pattern.compile(
+                      "(?<![\\w])" + Pattern.quote(p) + "(?![\\w])", Pattern.CASE_INSENSITIVE));
+      if (compiled.matcher(masked).find()) {
         return true;
       }
     }

--- a/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
@@ -251,8 +251,13 @@ public final class SqlParser {
    * ({@code ''}) and MySQL backslash escaping ({@code \'}). Double-quoted identifiers are preserved
    * per SQL standard (PostgreSQL, Oracle, SQL Server). Uses a manual loop instead of regex to avoid
    * StackOverflowError on large inputs.
+   *
+   * <p>Public so other modules (notably suppression-pattern matching in {@code QueryAuditConfig})
+   * can mask literals before doing structural comparisons against the SQL.
+   *
+   * @since 0.4.0
    */
-  private static String replaceStringLiterals(String sql) {
+  public static String replaceStringLiterals(String sql) {
     StringBuilder sb = new StringBuilder(sql.length());
     int i = 0;
     while (i < sql.length()) {

--- a/query-audit-core/src/test/java/io/queryaudit/core/config/QueryAuditConfigSuppressionTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/config/QueryAuditConfigSuppressionTest.java
@@ -1,0 +1,83 @@
+package io.queryaudit.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #124 — the prior {@code isQuerySuppressed} used {@code String.contains}
+ * with no awareness of string literals or word boundaries, so suppression patterns spuriously
+ * matched content inside quoted strings and as substrings of unrelated identifiers.
+ */
+class QueryAuditConfigSuppressionTest {
+
+  private static QueryAuditConfig configWithPattern(String pattern) {
+    return QueryAuditConfig.builder().suppressQueries(Set.of(pattern)).build();
+  }
+
+  @Test
+  @DisplayName("Pattern inside a string literal does NOT suppress (issue #124)")
+  void doesNotMatchInsideStringLiteral() {
+    QueryAuditConfig config = configWithPattern("from users");
+
+    String sql = "SELECT * FROM orders WHERE description = 'imported from users history'";
+
+    assertThat(config.isQuerySuppressed(sql)).isFalse();
+  }
+
+  @Test
+  @DisplayName("Pattern matching the actual table reference still suppresses")
+  void matchesActualTableReference() {
+    QueryAuditConfig config = configWithPattern("from users");
+
+    String sql = "SELECT * FROM users WHERE id = 1";
+
+    assertThat(config.isQuerySuppressed(sql)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Pattern is not a substring match against a longer identifier")
+  void doesNotMatchAsSubstringOfIdentifier() {
+    QueryAuditConfig config = configWithPattern("users");
+
+    String sql = "SELECT * FROM users_archive WHERE id = 1";
+
+    assertThat(config.isQuerySuppressed(sql)).isFalse();
+  }
+
+  @Test
+  @DisplayName("Pattern still matches the bare identifier when both forms appear")
+  void matchesBareIdentifierEvenAlongsideLongerIdentifier() {
+    QueryAuditConfig config = configWithPattern("users");
+
+    String sql = "SELECT * FROM users JOIN users_archive ON users.id = users_archive.id";
+
+    assertThat(config.isQuerySuppressed(sql)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Match is case-insensitive")
+  void matchIsCaseInsensitive() {
+    QueryAuditConfig config = configWithPattern("from users");
+
+    assertThat(config.isQuerySuppressed("SELECT * FROM USERS")).isTrue();
+    assertThat(config.isQuerySuppressed("select * from users")).isTrue();
+  }
+
+  @Test
+  @DisplayName("Empty / null inputs and patterns are tolerated")
+  void emptyInputs() {
+    QueryAuditConfig empty = QueryAuditConfig.defaults();
+    assertThat(empty.isQuerySuppressed("SELECT * FROM users")).isFalse();
+
+    QueryAuditConfig blankPattern =
+        QueryAuditConfig.builder().suppressQueries(Set.of("   ")).build();
+    assertThat(blankPattern.isQuerySuppressed("SELECT * FROM users")).isFalse();
+
+    QueryAuditConfig configured = configWithPattern("from users");
+    assertThat(configured.isQuerySuppressed(null)).isFalse();
+    assertThat(configured.isQuerySuppressed("")).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary
- Mask string literals (via newly-public `SqlParser.replaceStringLiterals`) before matching suppression patterns.
- Switch from `String.contains` to a word-boundary regex so a short pattern (e.g. `users`) does not match inside `users_archive`.
- Compiled patterns are cached.

## Why
The old implementation silently dropped issues a user wanted to see. A pattern of `from users` matched any query whose string literal happened to contain that text (`description = 'imported from users history'`). A pattern of `users` matched `users_archive`. Both produced under-reporting with no diagnostic signal — the worst possible failure mode for a static-analysis tool.

## Test plan
- [x] New `QueryAuditConfigSuppressionTest` covers: string-literal containment, substring of longer identifier, the two intended matches, case-insensitivity, and null/blank inputs.
- [x] Existing `RobustnessTest.isQuerySuppressed(null/"")` cases still pass.
- [x] Full `:query-audit-core:test` (only unrelated pre-existing failures from other open issues remain).

Closes #124