### PR TITLE
fix(spring-boot-starter): add query-audit.wrap-data-source escape hatch (#134)

### DIFF
--- a/query-audit-spring-boot-starter/build.gradle
+++ b/query-audit-spring-boot-starter/build.gradle
@@ -11,4 +11,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.4.1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-jdbc:3.4.1'
+    testImplementation 'com.zaxxer:HikariCP:5.1.0'
+    testImplementation 'com.h2database:h2:2.3.232'
 }

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
@@ -71,8 +71,19 @@ public class QueryAuditAutoConfiguration {
     return interceptor;
   }
 
+  /**
+   * Wraps every {@link DataSource} bean with a query-recording proxy. Both {@code
+   * query-audit.enabled} and {@code query-audit.wrap-data-source.enabled} default to {@code true};
+   * either can be flipped to {@code false} to skip the wrap. {@code wrap-data-source.enabled =
+   * false} is the documented escape hatch for issue #134 — it disables only the auto-wrap while
+   * keeping {@link QueryAuditConfig} and {@link QueryInterceptor} available, so {@code
+   * @QueryAudit} per-test wrapping still works.
+   */
   @Bean(name = {"queryAuditDataSourcePostProcessor", "queryGuardDataSourcePostProcessor"})
-  @ConditionalOnProperty(name = "query-audit.enabled", havingValue = "true", matchIfMissing = true)
+  @ConditionalOnProperty(
+      name = {"query-audit.enabled", "query-audit.wrap-data-source.enabled"},
+      havingValue = "true",
+      matchIfMissing = true)
   public BeanPostProcessor queryAuditDataSourcePostProcessor(QueryInterceptor interceptor) {
     return new BeanPostProcessor() {
       @Override

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
@@ -36,6 +36,7 @@ public class QueryAuditProperties {
   private WriteAmplification writeAmplification = new WriteAmplification();
   private SlowQuery slowQuery = new SlowQuery();
   private CountInsteadOfExists countInsteadOfExists = new CountInsteadOfExists();
+  private WrapDataSource wrapDataSource = new WrapDataSource();
 
   // ── Top-level getters & setters ────────────────────────────────────
 
@@ -199,6 +200,14 @@ public class QueryAuditProperties {
     this.countInsteadOfExists = countInsteadOfExists;
   }
 
+  public WrapDataSource getWrapDataSource() {
+    return wrapDataSource;
+  }
+
+  public void setWrapDataSource(WrapDataSource wrapDataSource) {
+    this.wrapDataSource = wrapDataSource;
+  }
+
   // ── Nested configuration classes ───────────────────────────────────
 
   public static class NPlusOne {
@@ -343,6 +352,31 @@ public class QueryAuditProperties {
 
     public void setThreshold(int threshold) {
       this.threshold = threshold;
+    }
+  }
+
+  /**
+   * Controls the autoconfigured {@link
+   * org.springframework.beans.factory.config.BeanPostProcessor} that wraps every {@code DataSource}
+   * bean. Set {@code query-audit.wrap-data-source.enabled: false} as the documented escape hatch
+   * for issue #134 — when 3+ {@code @SpringBootTest} cache signatures coexist, the wrap interacts
+   * badly with Spring TestContext caching and the underlying {@code HikariDataSource} can be
+   * closed prematurely. Disabling this leaves {@link
+   * io.queryaudit.core.config.QueryAuditConfig} and {@link
+   * io.queryaudit.core.interceptor.QueryInterceptor} active so {@code @QueryAudit} per-test still
+   * works.
+   *
+   * @since 0.4.0
+   */
+  public static class WrapDataSource {
+    private boolean enabled = true;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
     }
   }
 

--- a/query-audit-spring-boot-starter/src/test/java/io/queryaudit/spring/MultiContextDataSourceLifecycleTest.java
+++ b/query-audit-spring-boot-starter/src/test/java/io/queryaudit/spring/MultiContextDataSourceLifecycleTest.java
@@ -1,0 +1,124 @@
+package io.queryaudit.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Reproduction harness and regression coverage for issue #134 — when multiple Spring application
+ * contexts that each carry the QueryAudit autoconfig coexist, the {@code DataSource} of a still-live
+ * context must not be closed prematurely.
+ *
+ * <p>The bug as reported is observed under Spring Boot 4.x; with the Spring Boot 3.4.x baseline
+ * this project compiles against, the multi-context scenario already behaves correctly. These tests
+ * pin that good behavior so a future Spring Boot upgrade that regresses it is caught immediately,
+ * and exercise the {@code query-audit.wrap-data-source.enabled=false} escape hatch that users on
+ * the affected Boot 4.x versions can opt into today.
+ */
+class MultiContextDataSourceLifecycleTest {
+
+  private final List<ConfigurableApplicationContext> contexts = new ArrayList<>();
+
+  @AfterEach
+  void closeAllContexts() {
+    for (ConfigurableApplicationContext ctx : contexts) {
+      try {
+        ctx.close();
+      } catch (Exception ignored) {
+        // best effort cleanup
+      }
+    }
+    contexts.clear();
+  }
+
+  private ConfigurableApplicationContext openContextWithHikari() {
+    AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+    ctx.register(HikariConfig.class, QueryAuditAutoConfiguration.class);
+    ctx.refresh();
+    contexts.add(ctx);
+    return ctx;
+  }
+
+  @Test
+  @DisplayName("All four contexts' DataSources stay usable after all are open (regression #134)")
+  void allDataSourcesUsableWithFourCoexistingContexts() throws Exception {
+    ConfigurableApplicationContext c1 = openContextWithHikari();
+    ConfigurableApplicationContext c2 = openContextWithHikari();
+    ConfigurableApplicationContext c3 = openContextWithHikari();
+    ConfigurableApplicationContext c4 = openContextWithHikari();
+
+    for (ConfigurableApplicationContext ctx : List.of(c1, c2, c3, c4)) {
+      DataSource ds = ctx.getBean(DataSource.class);
+      try (Connection conn = ds.getConnection()) {
+        assertThat(conn.isValid(1)).as("connection from %s should be valid", ctx).isTrue();
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("Closing one context does not close other contexts' DataSources (regression #134)")
+  void closingOneContextDoesNotAffectOthers() throws Exception {
+    ConfigurableApplicationContext c1 = openContextWithHikari();
+    ConfigurableApplicationContext c2 = openContextWithHikari();
+    ConfigurableApplicationContext c3 = openContextWithHikari();
+
+    DataSource dsB = c2.getBean(DataSource.class);
+    DataSource dsC = c3.getBean(DataSource.class);
+
+    c1.close();
+    contexts.remove(c1);
+
+    try (Connection conn = dsB.getConnection()) {
+      assertThat(conn.isValid(1)).as("dbB connection valid after dbA closed").isTrue();
+    }
+    try (Connection conn = dsC.getConnection()) {
+      assertThat(conn.isValid(1)).as("dbC connection valid after dbA closed").isTrue();
+    }
+  }
+
+  @Test
+  @DisplayName("Escape hatch query-audit.wrap-data-source.enabled=false skips the BPP")
+  void escapeHatchSkipsBeanPostProcessor() {
+    new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(QueryAuditAutoConfiguration.class))
+        .withPropertyValues("query-audit.wrap-data-source.enabled=false")
+        .run(
+            (AssertableApplicationContext context) -> {
+              assertThat(context).doesNotHaveBean("queryAuditDataSourcePostProcessor");
+              assertThat(context).doesNotHaveBean("queryGuardDataSourcePostProcessor");
+              assertThat(context).hasBean("queryAuditConfig");
+              assertThat(context).hasBean("queryAuditInterceptor");
+            });
+  }
+
+  @Configuration
+  @Import(QueryAuditAutoConfiguration.class)
+  static class HikariConfig {
+
+    @Bean(destroyMethod = "close")
+    public DataSource dataSource() {
+      HikariDataSource ds = new HikariDataSource();
+      ds.setDriverClassName("org.h2.Driver");
+      ds.setJdbcUrl("jdbc:h2:mem:" + java.util.UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+      ds.setUsername("sa");
+      ds.setPassword("");
+      ds.setMaximumPoolSize(2);
+      return ds;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New Spring Boot property `query-audit.wrap-data-source.enabled` (default `true`).
- When set to `false`, the autoconfigured DataSource-wrapping `BeanPostProcessor` is skipped while `QueryAuditConfig` and `QueryInterceptor` remain available — so users can still wrap per-test via `@QueryAudit`.
- Multi-context lifecycle test (4 coexisting Hikari-backed contexts) that pins the good Spring Boot 3.4.x behavior plus a regression test for the new flag.
- Adds `spring-boot-starter-jdbc`, `HikariCP`, and `h2` to test classpath only.

## Why
Issue #134 reports that on **Spring Boot 4.0.6** the auto-wrap BPP interacts badly with the Spring TestContext cache: with 3+ cache signatures, one cached context's `HikariDataSource` is closed prematurely (`HikariPool-1 has been closed`).

I could not reproduce the close-cascade against the Spring Boot 3.4.x baseline this project compiles against — the new multi-context test passes today. So this PR ships the **escape hatch** users on Boot 4 can flip immediately, plus the regression test that pins the current good behavior on 3.4.x. The deeper root-cause fix needs a Boot 4 reproduction harness; tracking comments are on #134.

Coarser `query-audit.enabled=false` already disables only the BPP today, but the name reads like a kill-switch for everything; the new flag is the intent-revealing alternative for users who want detection in non-test code paths but not the auto-wrap.

## Test plan
- [x] `MultiContextDataSourceLifecycleTest` — 4-context coexistence + close-isolation + escape-hatch property (3 tests, all green).
- [x] Existing `QueryAuditAutoConfigurationTest` cases unchanged.
- [x] Full `:query-audit-spring-boot-starter:test` BUILD SUCCESSFUL.

Refs #134 (kept open for the Spring Boot 4 root-cause fix).