### PR TITLE
refactor(core): consolidate alias resolution onto MissingIndexDetector (#82)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/ForUpdateNonUniqueIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/ForUpdateNonUniqueIndexDetector.java
@@ -9,12 +9,10 @@ import io.queryaudit.core.model.Severity;
 import io.queryaudit.core.parser.ColumnReference;
 import io.queryaudit.core.parser.EnhancedSqlParser;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -34,12 +32,6 @@ public class ForUpdateNonUniqueIndexDetector implements DetectionRule {
 
   private static final Pattern FOR_UPDATE_OR_SHARE =
       Pattern.compile("\\bFOR\\s+(?:UPDATE|SHARE)\\b", Pattern.CASE_INSENSITIVE);
-
-  private static final Pattern FROM_ALIAS =
-      Pattern.compile("\\bFROM\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
-
-  private static final Pattern JOIN_ALIAS =
-      Pattern.compile("\\bJOIN\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
 
   @Override
   public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
@@ -72,7 +64,7 @@ public class ForUpdateNonUniqueIndexDetector implements DetectionRule {
         continue;
       }
 
-      Map<String, String> aliasToTable = resolveAliases(sql);
+      Map<String, String> aliasToTable = MissingIndexDetector.resolveAliases(sql);
 
       for (ColumnReference col : whereColumns) {
         String table = resolveTable(col.tableOrAlias(), aliasToTable);
@@ -126,32 +118,6 @@ public class ForUpdateNonUniqueIndexDetector implements DetectionRule {
       }
     }
     return hasIndex;
-  }
-
-  private Map<String, String> resolveAliases(String sql) {
-    Map<String, String> aliasToTable = new HashMap<>();
-
-    Matcher fromMatcher = FROM_ALIAS.matcher(sql);
-    while (fromMatcher.find()) {
-      String table = fromMatcher.group(1);
-      String alias = fromMatcher.group(2);
-      aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-      if (alias != null) {
-        aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-      }
-    }
-
-    Matcher joinMatcher = JOIN_ALIAS.matcher(sql);
-    while (joinMatcher.find()) {
-      String table = joinMatcher.group(1);
-      String alias = joinMatcher.group(2);
-      aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-      if (alias != null) {
-        aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-      }
-    }
-
-    return aliasToTable;
   }
 
   private String resolveTable(String tableOrAlias, Map<String, String> aliasToTable) {

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/NonDeterministicPaginationDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/NonDeterministicPaginationDetector.java
@@ -10,12 +10,10 @@ import io.queryaudit.core.parser.ColumnReference;
 import io.queryaudit.core.parser.EnhancedSqlParser;
 import io.queryaudit.core.parser.SqlParser;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -37,14 +35,6 @@ public class NonDeterministicPaginationDetector implements DetectionRule {
 
   private static final Pattern LIMIT_PATTERN =
       Pattern.compile("\\bLIMIT\\b", Pattern.CASE_INSENSITIVE);
-
-  private static final Pattern FROM_ALIAS =
-      Pattern.compile(
-          "\\bFROM\\s+`?(\\w+)`?(?:\\s+(?:AS\\s+)?`?(\\w+)`?)?", Pattern.CASE_INSENSITIVE);
-
-  private static final Pattern JOIN_ALIAS =
-      Pattern.compile(
-          "\\bJOIN\\s+`?(\\w+)`?(?:\\s+(?:AS\\s+)?`?(\\w+)`?)?", Pattern.CASE_INSENSITIVE);
 
   @Override
   public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
@@ -80,7 +70,7 @@ public class NonDeterministicPaginationDetector implements DetectionRule {
         continue;
       }
 
-      Map<String, String> aliasToTable = resolveAliases(sql);
+      Map<String, String> aliasToTable = MissingIndexDetector.resolveAliases(sql);
 
       // Check if any ORDER BY column has a unique index
       boolean hasUniqueTiebreaker = false;
@@ -140,32 +130,6 @@ public class NonDeterministicPaginationDetector implements DetectionRule {
       }
     }
     return false;
-  }
-
-  private Map<String, String> resolveAliases(String sql) {
-    Map<String, String> aliasToTable = new HashMap<>();
-
-    Matcher fromMatcher = FROM_ALIAS.matcher(sql);
-    while (fromMatcher.find()) {
-      String table = fromMatcher.group(1);
-      String alias = fromMatcher.group(2);
-      aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-      if (alias != null) {
-        aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-      }
-    }
-
-    Matcher joinMatcher = JOIN_ALIAS.matcher(sql);
-    while (joinMatcher.find()) {
-      String table = joinMatcher.group(1);
-      String alias = joinMatcher.group(2);
-      aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-      if (alias != null) {
-        aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-      }
-    }
-
-    return aliasToTable;
   }
 
   private String resolveTable(String tableOrAlias, Map<String, String> aliasToTable) {

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/OrderByLimitWithoutIndexDetector.java
@@ -34,12 +34,6 @@ public class OrderByLimitWithoutIndexDetector implements DetectionRule {
   private static final Pattern ORDER_BY_PATTERN =
       Pattern.compile("\\bORDER\\s+BY\\b", Pattern.CASE_INSENSITIVE);
 
-  private static final Pattern FROM_ALIAS =
-      Pattern.compile("\\bFROM\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
-
-  private static final Pattern JOIN_ALIAS =
-      Pattern.compile("\\bJOIN\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
-
   @Override
   public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
     List<Issue> issues = new ArrayList<>();

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/RangeLockDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/RangeLockDetector.java
@@ -8,12 +8,10 @@ import io.queryaudit.core.model.Severity;
 import io.queryaudit.core.parser.EnhancedSqlParser;
 import io.queryaudit.core.parser.WhereColumnReference;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -37,12 +35,6 @@ public class RangeLockDetector implements DetectionRule {
 
   /** Range operators that cause gap locks in InnoDB. */
   private static final Set<String> RANGE_OPERATORS = Set.of(">", "<", ">=", "<=", "BETWEEN");
-
-  private static final Pattern FROM_ALIAS =
-      Pattern.compile("\\bFROM\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
-
-  private static final Pattern JOIN_ALIAS =
-      Pattern.compile("\\bJOIN\\s+(\\w+)(?:\\s+(?:AS\\s+)?(\\w+))?", Pattern.CASE_INSENSITIVE);
 
   @Override
   public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
@@ -78,7 +70,7 @@ public class RangeLockDetector implements DetectionRule {
         continue; // No WHERE clause -- ForUpdateWithoutIndexDetector handles this
       }
 
-      Map<String, String> aliasToTable = resolveAliases(sql);
+      Map<String, String> aliasToTable = MissingIndexDetector.resolveAliases(sql);
 
       for (WhereColumnReference col : whereColumns) {
         String operator = col.operator() != null ? col.operator().trim().toUpperCase() : "";
@@ -122,32 +114,6 @@ public class RangeLockDetector implements DetectionRule {
     }
 
     return issues;
-  }
-
-  private Map<String, String> resolveAliases(String sql) {
-    Map<String, String> aliasToTable = new HashMap<>();
-
-    Matcher fromMatcher = FROM_ALIAS.matcher(sql);
-    while (fromMatcher.find()) {
-      String table = fromMatcher.group(1);
-      String alias = fromMatcher.group(2);
-      aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-      if (alias != null) {
-        aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-      }
-    }
-
-    Matcher joinMatcher = JOIN_ALIAS.matcher(sql);
-    while (joinMatcher.find()) {
-      String table = joinMatcher.group(1);
-      String alias = joinMatcher.group(2);
-      aliasToTable.put(table.toLowerCase(), table.toLowerCase());
-      if (alias != null) {
-        aliasToTable.put(alias.toLowerCase(), table.toLowerCase());
-      }
-    }
-
-    return aliasToTable;
   }
 
   private String resolveTable(String tableOrAlias, Map<String, String> aliasToTable) {

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/QuotedTableAliasResolutionTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/QuotedTableAliasResolutionTest.java
@@ -20,8 +20,10 @@ import org.junit.jupiter.api.Test;
  * register the alias. The {@code resolveTable} fallback then drops Hibernate-pattern aliases on
  * the floor (returns {@code null}), silently skipping legitimate missing-index issues.
  *
- * <p>The detectors that share {@code MissingIndexDetector.resolveAliases} are:
- * MissingIndexDetector, CompositeIndexDetector, RedundantFilterDetector, ForUpdateWithoutIndexDetector.
+ * <p>Detectors covered here: MissingIndexDetector, RedundantFilterDetector,
+ * NonDeterministicPaginationDetector, RangeLockDetector, ForUpdateNonUniqueIndexDetector. All
+ * five route through {@code MissingIndexDetector.resolveAliases} after the consolidation
+ * follow-up to PR #143.
  */
 class QuotedTableAliasResolutionTest {
 
@@ -31,6 +33,10 @@ class QuotedTableAliasResolutionTest {
 
   private static IndexInfo pk(String table, String column) {
     return new IndexInfo(table, "PRIMARY", column, 1, false, 1000);
+  }
+
+  private static IndexInfo nonUniqueIdx(String table, String name, String column) {
+    return new IndexInfo(table, name, column, 1, true, 100);
   }
 
   private static IndexMetadata metadata(IndexInfo... infos) {
@@ -95,5 +101,66 @@ class QuotedTableAliasResolutionTest {
         .anyMatch(
             i ->
                 "rooms".equalsIgnoreCase(i.table()) && "status".equalsIgnoreCase(i.column()));
+  }
+
+  @Test
+  @DisplayName("Double-quoted FROM with Hibernate alias: NonDeterministicPagination still reported")
+  void doubleQuoted_nonDeterministicPagination_reported() {
+    // messages: PK(id), no unique index on created_at — ORDER BY created_at LIMIT N
+    // is non-deterministic. Pre-fix the detector's local FROM_ALIAS regex matched only
+    // bare and backtick-quoted segments (no double-quote support), so the alias map
+    // was empty for this SQL, resolveTable returned "m1_0", hasTable("m1_0") was false,
+    // the detector treated this as "can't determine — skip".
+    IndexMetadata meta = metadata(pk("messages", "id"));
+
+    String sql = "SELECT m1_0.id FROM \"messages\" m1_0 ORDER BY m1_0.created_at LIMIT 10";
+
+    List<Issue> issues =
+        new NonDeterministicPaginationDetector().evaluate(List.of(record(sql)), meta);
+
+    assertThat(issues)
+        .anyMatch(i -> i.type() == IssueType.NON_DETERMINISTIC_PAGINATION);
+  }
+
+  @Test
+  @DisplayName("Backtick-quoted FROM with Hibernate alias: RangeLockDetector still reported")
+  void backtickQuoted_rangeLock_reported() {
+    // orders: PK(id), no index on created_at. FOR UPDATE with range condition on
+    // unindexed column → gap-lock risk. Pre-fix the detector silently skipped because
+    // resolveTable returned "o1_0" which is not in metadata.
+    IndexMetadata meta = metadata(pk("orders", "id"));
+
+    String sql =
+        "SELECT o1_0.id FROM `orders` o1_0 WHERE o1_0.created_at > ? FOR UPDATE";
+
+    List<Issue> issues = new RangeLockDetector().evaluate(List.of(record(sql)), meta);
+
+    assertThat(issues)
+        .anyMatch(
+            i ->
+                i.type() == IssueType.RANGE_LOCK_RISK
+                    && "orders".equalsIgnoreCase(i.table())
+                    && "created_at".equalsIgnoreCase(i.column()));
+  }
+
+  @Test
+  @DisplayName("Backtick-quoted FROM with Hibernate alias: ForUpdateNonUniqueIndex still reported")
+  void backtickQuoted_forUpdateNonUnique_reported() {
+    // orders: PK(id), non-unique idx on user_id. FOR UPDATE WHERE user_id = ? takes a
+    // next-key lock on a non-unique index. Pre-fix the detector silently skipped.
+    IndexMetadata meta = metadata(pk("orders", "id"), nonUniqueIdx("orders", "idx_user", "user_id"));
+
+    String sql =
+        "SELECT o1_0.id FROM `orders` o1_0 WHERE o1_0.user_id = ? FOR UPDATE";
+
+    List<Issue> issues =
+        new ForUpdateNonUniqueIndexDetector().evaluate(List.of(record(sql)), meta);
+
+    assertThat(issues)
+        .anyMatch(
+            i ->
+                i.type() == IssueType.FOR_UPDATE_NON_UNIQUE
+                    && "orders".equalsIgnoreCase(i.table())
+                    && "user_id".equalsIgnoreCase(i.column()));
   }
 }


### PR DESCRIPTION
## Summary
Stacked on **#143**.

- `NonDeterministicPaginationDetector`, `RangeLockDetector`, and `ForUpdateNonUniqueIndexDetector` each carried a near-identical private `resolveAliases` / `resolveTable` with its own `FROM_ALIAS` / `JOIN_ALIAS` regex. Two had no quoted-identifier support; the third had partial backticks only. They stayed broken even after #143 because they never went through the shared resolver.
- All three now call `MissingIndexDetector.resolveAliases(sql)` and the duplicate regexes / `resolveAliases` methods are deleted.
- `OrderByLimitWithoutIndexDetector` already routes through `MissingIndexDetector.resolveAliases` (line 76); its local `FROM_ALIAS` / `JOIN_ALIAS` Pattern fields were dead code — removed.
- Each detector keeps its own `resolveTable` because the fallback semantics differ (single-table-from-map-values vs. external `tables` list vs. Hibernate-pattern guard). Unifying that is a bigger change and is out of scope.

## Why
Pure follow-up to #82's quoted-identifier issue. After #143 fixed `MissingIndexDetector.resolveAliases`, the detectors using it picked up backtick + double-quote support automatically. The three detectors above did not, so the same Hibernate SQL (`hibernate.globally_quoted_identifiers=true` or reserved-word table names) still produced false negatives for them — `RangeLockDetector` silently skipped gap-lock risks, `ForUpdateNonUniqueIndexDetector` silently skipped non-unique FOR UPDATE patterns, `NonDeterministicPaginationDetector` silently skipped under double quotes.

Consolidating now also stops these from drifting — the next time someone tweaks alias resolution, it's one place.

## Test plan
- [x] Three new tests in `QuotedTableAliasResolutionTest` exercising backtick FROM for `RangeLockDetector` and `ForUpdateNonUniqueIndexDetector`, and double-quoted FROM for `NonDeterministicPaginationDetector` (its old regex already handled bare backticks, so the test deliberately exercises the gap).
- [x] **Verified the 2 backtick tests fail on this PR's parent commit** (PR #143 HEAD), confirming the consolidation actually fixes a real regression in those detectors. The double-quoted NDP test also fails on parent.
- [x] All `:query-audit-core:test` detector tests pass on this branch.
- [x] Pre-existing perf-budget flakes (`DetectorStressTest > Performance > tenThousandQueries_completesInTime`, `RobustnessTest > MemoryPressureTests > *`) reproduce on the parent commit too — unrelated, environmental on the local box.

## Notes for reviewer
- `MissingIndexDetector.resolveAliases` is already package-private static, so the call sites only required swapping `resolveAliases(sql)` → `MissingIndexDetector.resolveAliases(sql)`.
- The behavioural delta vs. the old per-detector copies: stricter SQL-keyword filtering (e.g., a literal `FROM SELECT` won't pollute the alias map) and schema-prefix support — both upside.

Refs #82.