### PR TITLE
fix: SelectAll literal masking + ProxyDataSource listener cleanup (#145, #146)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/parser/SqlParser.java
@@ -449,6 +449,9 @@ public final class SqlParser {
       return false;
     }
     sql = stripComments(sql);
+    // Mask string literals so 'SELECT *' inside a literal (e.g. an audit-log row or stored
+    // SQL template) does not produce a false positive.
+    sql = replaceStringLiterals(sql);
     // Neutralise EXISTS(SELECT * ...) — it is idiomatic SQL and not a real SELECT *
     String sanitized = EXISTS_SELECT_STAR.matcher(sql).replaceAll("EXISTS(SELECT 1");
     return SELECT_ALL.matcher(sanitized).find();

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ComprehensiveFalsePositiveTest.java
@@ -455,6 +455,26 @@ class ComprehensiveFalsePositiveTest {
 
       assertThat(issuesOfType(issues, IssueType.SELECT_ALL)).isEmpty();
     }
+
+    @Test
+    @DisplayName("TN: 'SELECT *' inside a string literal should not detect")
+    void tn_selectStarInsideStringLiteral() {
+      String sql =
+          "SELECT message FROM audit_logs WHERE error_log LIKE '%SELECT * FROM users%'";
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+      assertThat(issuesOfType(issues, IssueType.SELECT_ALL)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("TN: stored SQL template containing 'SELECT *' should not detect")
+    void tn_selectStarInStoredTemplate() {
+      String sql =
+          "INSERT INTO query_templates (sql_text) VALUES ('SELECT * FROM users WHERE id = ?')";
+      List<Issue> issues = detector.evaluate(List.of(record(sql)), EMPTY_INDEX);
+
+      assertThat(issuesOfType(issues, IssueType.SELECT_ALL)).isEmpty();
+    }
   }
 
   // =====================================================================

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/DataSourceResolver.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/DataSourceResolver.java
@@ -11,6 +11,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
+import net.ttddyy.dsproxy.listener.ChainListener;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -55,21 +57,38 @@ class DataSourceResolver {
   }
 
   /**
-   * Hooks the QueryInterceptor into the DataSource. If the DataSource is already a ProxyDataSource,
-   * adds the interceptor as a listener. Otherwise, wraps with a new ProxyDataSource and replaces
-   * the original where possible.
+   * Hooks the QueryInterceptor into the DataSource and returns a cleanup callback that must be
+   * invoked from {@code afterAll} so that listeners do not accumulate on a shared proxy across
+   * test classes. If the DataSource is already a {@link ProxyDataSource}, the interceptor is added
+   * as a listener (Strategy 1). Otherwise, a fresh proxy is created via {@link
+   * DataSourceProxyFactory} and stored in {@link QueryAuditDataSourceStore} (Strategy 2).
+   *
+   * @return a cleanup callback that detaches the interceptor; never {@code null}
    */
-  void hookInterceptor(DataSource dataSource, QueryInterceptor interceptor) {
+  Runnable hookInterceptor(DataSource dataSource, QueryInterceptor interceptor) {
     // Strategy 1: DataSource is already a ProxyDataSource (e.g., gavlyukovskiy)
     ProxyDataSource proxy = findProxyDataSource(dataSource);
     if (proxy != null) {
       proxy.addListener(interceptor);
-      return;
+      ChainListener chain = proxy.getProxyConfig().getQueryListener();
+      return () -> detachListener(chain, interceptor);
     }
 
     // Strategy 2: Wrap with our own proxy via DataSourceProxyFactory
     QueryAuditDataSourceStore.set(
         dataSource, DataSourceProxyFactory.wrap(dataSource, interceptor), interceptor);
+    return QueryAuditDataSourceStore::clear;
+  }
+
+  /**
+   * Removes a previously-added listener from a {@link ChainListener}. {@code ChainListener} does
+   * not expose a {@code removeListener} API directly, so we copy → filter → reinstall.
+   */
+  private static void detachListener(ChainListener chain, QueryExecutionListener target) {
+    List<QueryExecutionListener> remaining = new ArrayList<>(chain.getListeners());
+    if (remaining.remove(target)) {
+      chain.setListeners(remaining);
+    }
   }
 
   private DataSource resolveFromSpringContext(ExtensionContext context) {

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -61,6 +61,7 @@ public class QueryAuditExtension
   private static final String KEY_CURRENT_COUNTS = "currentCounts";
   private static final String KEY_DATASOURCE = "dataSource";
   private static final String KEY_RETURN_TYPE_RESOLVER = "returnTypeResolver";
+  private static final String KEY_DATASOURCE_HOOK_CLEANUP = "dataSourceHookCleanup";
 
   private static final QueryCountRegressionDetector REGRESSION_DETECTOR =
       new QueryCountRegressionDetector();
@@ -85,7 +86,8 @@ public class QueryAuditExtension
     DataSource dataSource = dataSourceResolver.resolve(context);
     if (dataSource != null) {
       store.put(KEY_DATASOURCE, dataSource);
-      dataSourceResolver.hookInterceptor(dataSource, interceptor);
+      Runnable hookCleanup = dataSourceResolver.hookInterceptor(dataSource, interceptor);
+      store.put(KEY_DATASOURCE_HOOK_CLEANUP, hookCleanup);
 
       IndexMetadata metadata = metadataCollector.collect(dataSource);
       if (metadata != null) {
@@ -341,6 +343,11 @@ public class QueryAuditExtension
     LazyLoadTracker tracker = getLazyLoadTracker(context);
     if (tracker != null) {
       hibernateIntegration.unregisterTracker(context, tracker);
+    }
+    Runnable hookCleanup =
+        context.getStore(NAMESPACE).get(KEY_DATASOURCE_HOOK_CLEANUP, Runnable.class);
+    if (hookCleanup != null) {
+      hookCleanup.run();
     }
     QueryAuditDataSourceStore.clear();
 

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/DataSourceResolverListenerLifecycleTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/DataSourceResolverListenerLifecycleTest.java
@@ -1,0 +1,76 @@
+package io.queryaudit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.interceptor.QueryInterceptor;
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.listener.ChainListener;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Regression for the Strategy-1 ({@link ProxyDataSource} reuse) path in {@link
+ * DataSourceResolver#hookInterceptor}. Each test class creates a fresh {@link QueryInterceptor},
+ * and the previous one must be detached from the shared proxy when the test class finishes —
+ * otherwise listeners accumulate across the JVM run, leaking memory and causing queries from a
+ * later test class to be dispatched to all prior interceptors.
+ */
+class DataSourceResolverListenerLifecycleTest {
+
+  @Test
+  @DisplayName(
+      "Strategy 1: hookInterceptor returns a cleanup that detaches the listener from the proxy")
+  void hookInterceptor_returnsCleanupThatDetachesListener() {
+    ProxyDataSource proxy = new ProxyDataSource(Mockito.mock(DataSource.class));
+    DataSourceResolver resolver = new DataSourceResolver();
+    QueryInterceptor interceptor = new QueryInterceptor();
+
+    int before = listenerCount(proxy);
+    Runnable cleanup = resolver.hookInterceptor(proxy, interceptor);
+
+    assertThat(cleanup).as("Strategy 1 must return a non-null cleanup").isNotNull();
+    assertThat(listenerCount(proxy)).isEqualTo(before + 1);
+    assertThat(listenerInstances(proxy)).contains(interceptor);
+
+    cleanup.run();
+
+    assertThat(listenerCount(proxy)).isEqualTo(before);
+    assertThat(listenerInstances(proxy)).doesNotContain(interceptor);
+  }
+
+  @Test
+  @DisplayName(
+      "Strategy 1: repeated hook/release cycles do not accumulate listeners on a shared proxy")
+  void repeatedHookAndReleaseCyclesDoNotAccumulate() {
+    ProxyDataSource proxy = new ProxyDataSource(Mockito.mock(DataSource.class));
+    DataSourceResolver resolver = new DataSourceResolver();
+
+    int baseline = listenerCount(proxy);
+
+    for (int i = 0; i < 5; i++) {
+      QueryInterceptor interceptor = new QueryInterceptor();
+      Runnable cleanup = resolver.hookInterceptor(proxy, interceptor);
+      assertThat(cleanup).isNotNull();
+      cleanup.run();
+    }
+
+    assertThat(listenerCount(proxy))
+        .as("After N register/release cycles, listener count must return to baseline")
+        .isEqualTo(baseline);
+  }
+
+  private static int listenerCount(ProxyDataSource proxy) {
+    return chain(proxy).getListeners().size();
+  }
+
+  private static java.util.List<QueryExecutionListener> listenerInstances(ProxyDataSource proxy) {
+    return chain(proxy).getListeners();
+  }
+
+  private static ChainListener chain(ProxyDataSource proxy) {
+    return proxy.getProxyConfig().getQueryListener();
+  }
+}


### PR DESCRIPTION
## Summary

Two regressions discovered during a broader audit of detector regex hygiene and JUnit 5 lifecycle handling. Both fixes are independent commits so release-please picks them up as separate `fix:` entries in the 0.3.1 changelog.

### 1. `SelectAllDetector` false-positive on string literals — closes #145

`SqlParser.hasSelectAll` only stripped comments before running the `SELECT *` regex. Any query embedding the bytes `SELECT *` inside a single-quoted literal — `LIKE '%SELECT *%'` on an audit log, or a stored SQL template — was flagged. Fix: apply the existing public `replaceStringLiterals` after `stripComments`. The `EXISTS(SELECT *)` neutralisation already in place continues to run on the masked SQL.

### 2. `QueryInterceptor` listener leak on Strategy 1 — closes #146

`DataSourceResolver.hookInterceptor` calls `proxy.addListener` when the test's DataSource is already a `ProxyDataSource` (e.g. gavlyukovskiy's starter), but nothing detached it in `afterAll`. `beforeAll` builds a fresh interceptor per test class, so every subsequent class on the same JVM piled another stale listener onto the shared proxy.

`hookInterceptor` now returns a cleanup `Runnable`:

- Strategy 1: copy → filter → reinstall the `ChainListener`'s listener list (it has no public `removeListener`).
- Strategy 2: `QueryAuditDataSourceStore::clear` — preserves existing behaviour.

`QueryAuditExtension` stashes the cleanup on the per-class `ExtensionContext.Store` and runs it from `afterAll`.

## Follow-ups (not in this PR)

Two more genuine bugs were verified during the audit and filed for separate work:

- #147 — `PostgreSqlIndexMetadataProvider.CARDINALITY_QUERY` returns wrong row across same-named tables in multiple schemas.
- #148 — `MySqlIndexMetadataProvider` preserves table-name case while detectors lowercase, breaking lookups on `lower_case_table_names=0`.

The remaining audit findings (literal masking for other regex-based detectors, quoted-identifier handling in CartesianJoinDetector, HtmlReportAggregator singleton reset) were either speculative or already addressed by the recent #117 bug-cluster fixes; not filed.

## Test plan

- [x] `:query-audit-core:test` — new tests in `ComprehensiveFalsePositiveTest.SelectAllDetectorTests` (2 cases) fail before the SqlParser change, pass after.
- [x] `:query-audit-junit5:test` — new `DataSourceResolverListenerLifecycleTest` (2 cases) fails to compile before the API change, passes after.
- [x] Full `./gradlew test` — green.

Refs #145, #146.