### PR TITLE
chore: bump gradle.properties to 0.3.1 and inline release-please marker

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-# x-release-please-version
-version=0.3.0
+version=0.3.1 # x-release-please-version
 group=io.github.haroya01


### PR DESCRIPTION
## Summary

Recovery for the failed 0.3.1 publish: release-please did not update \`gradle.properties\` (it stayed at 0.3.0), so the publish job built 0.3.0 artefacts which Sonatype dropped as duplicates of the already-released 0.3.0 version.

## Root cause

The generic file updater in release-please did not match the previous marker layout (marker on its own line, value on the next line):

\`\`\`
# x-release-please-version
version=0.3.0
\`\`\`

Switching to the inline marker syntax — which is the documented form — should make future release-please runs update \`gradle.properties\` automatically:

\`\`\`
version=0.3.1 # x-release-please-version
\`\`\`

The 0.3.0 release worked only because of a manual bump commit (\`18a21ec\`) that preceded the release PR, not because release-please had actually updated the file.

## Recovery sequence after merge

1. This PR lands on main with \`version=0.3.1\`.
2. Re-run the \`publish\` job in workflow run [26073524419](https://github.com/haroya01/query-audit/actions/runs/26073524419) — it does \`actions/checkout@v4\` without a ref so it'll pick up the fix from main and rebuild as 0.3.1.
3. Sonatype gets a clean 0.3.1 deployment.

The \`v0.3.1\` Git tag and GitHub Release already exist (release-please-action created them on the first run) — no need to recreate them.

## Test plan

- [x] Local \`./gradlew properties | grep version\` reports 0.3.1.
- [ ] After merge: re-run of the publish job uploads 5 artefacts at 0.3.1 and Sonatype accepts the deployment.
- [ ] Next release-please PR (0.3.2) shows \`gradle.properties\` in its diff alongside \`CHANGELOG.md\` and \`.release-please-manifest.json\`.