### PR TITLE
ci(release): add workflow_dispatch trigger for recovery scenarios

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,15 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Version label for the Summary section. The actual version that gets
+          published is always whatever gradle.properties reads from the latest
+          main commit at run time.
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -18,6 +27,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+        if: github.event_name == 'push'
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
@@ -25,7 +35,9 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      needs.release-please.outputs.release_created == 'true'
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,13 +62,17 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Release ${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          VERSION="${{ needs.release-please.outputs.version || inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(grep -E '^version=' gradle.properties | head -n 1 | sed 's/^version=//; s/ *#.*//')
+          fi
+          echo "## Release ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Published to Maven Central:" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          echo "io.github.haroya01:query-audit-core:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "io.github.haroya01:query-audit-junit5:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "io.github.haroya01:query-audit-mysql:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "io.github.haroya01:query-audit-postgresql:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "io.github.haroya01:query-audit-spring-boot-starter:${{ needs.release-please.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "io.github.haroya01:query-audit-core:${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "io.github.haroya01:query-audit-junit5:${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "io.github.haroya01:query-audit-mysql:${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "io.github.haroya01:query-audit-postgresql:${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "io.github.haroya01:query-audit-spring-boot-starter:${VERSION}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The release workflow only publishes when release-please's \`release_created\` output is \`true\` — which means a workflow re-run after a publish failure pulls the original commit SHA (via default \`actions/checkout@v4\`) and rebuilds the same broken state.

Adds a \`workflow_dispatch\` trigger so we can manually re-publish whatever is currently at HEAD of \`main\`, which is the recovery path for the 0.3.1 Sonatype DropPublish.

## Changes

- \`workflow_dispatch\` trigger with an optional \`version\` input (Summary-line label only — the actual version is whatever \`gradle.properties\` says at run time).
- The release-please step is gated on \`if: github.event_name == 'push'\` so manual runs don't reconcile against the manifest.
- The publish job's gate accepts either the original push+release path or workflow_dispatch.
- Summary's version label falls back to reading \`gradle.properties\` when the dispatch input is empty and there is no release-please output.

## Immediate use

After merge: trigger \`Run workflow\` on this workflow against the \`main\` branch. Since \`gradle.properties\` is now \`0.3.1\` on main (PR #150), the publish step will upload 0.3.1 artefacts and Sonatype should accept them this time.

## Test plan

- [x] YAML syntax validated locally (no parser errors).
- [ ] After merge: dispatch the workflow against main and verify \`Build and Test\` + \`Publish to Maven Central\` both succeed and that Sonatype shows the 0.3.1 deployment (not 0.3.0).