### PR TITLE
chore: use release-please block markers in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
-version=0.3.1 # x-release-please-version
+# x-release-please-start-version
+version=0.3.1
+# x-release-please-end
 group=io.github.haroya01


### PR DESCRIPTION
## Summary

The previous attempt (PR #150) put the release-please marker inline:

\`\`\`
version=0.3.1 # x-release-please-version
\`\`\`

That syntax is valid in YAML/JSON but **not** in Java Properties files: \`#\` is only a comment delimiter at the start of a line, never mid-value. Gradle then reported \`version: 0.3.1 # x-release-please-version\` as the literal version string, and the publish job uploaded artefacts whose paths contained spaces and \`#\` — Sonatype refused with \"version cannot contain spaces\" and \"file path contains invalid characters\" for all 5 modules.

This switches to release-please's documented block-marker form, which works in Properties:

\`\`\`
# x-release-please-start-version
version=0.3.1
# x-release-please-end
group=io.github.haroya01
\`\`\`

Both marker lines are pure Properties comments, the middle line is a clean \`key=value\` pair. Verified locally: \`./gradlew properties -q | grep ^version\` now reports \`version: 0.3.1\` with no trailing garbage. release-please's generic updater replaces the SemVer between the two markers on the next bump.

## Recovery sequence after merge

1. Merge this PR.
2. \`gh workflow run release-please.yml --ref main\` — picks up the fixed gradle.properties from main HEAD and publishes 0.3.1 artefacts with valid paths.

## Test plan

- [x] \`./gradlew properties -q | grep -E '^(version|group):'\` reports \`version: 0.3.1\` and \`group: io.github.haroya01\` (no marker leakage).
- [ ] After merge + dispatch: Sonatype shows 0.3.1 deployment with normal coordinates (no \"contains invalid characters\" rejection).