### PR TITLE
fix(core): NonClosingDataSource decorator to prevent ProxyDataSource cascade-close (#153)

### DIFF
--- a/query-audit-core/src/main/java/io/queryaudit/core/interceptor/DataSourceProxyFactory.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/interceptor/DataSourceProxyFactory.java
@@ -18,16 +18,20 @@ public final class DataSourceProxyFactory {
 
   /**
    * Wraps the given {@code DataSource} in a proxy that delegates query lifecycle events to the
-   * supplied {@link QueryInterceptor}.
+   * supplied {@link QueryInterceptor}. The proxy is itself wrapped in a {@link
+   * NonClosingDataSource} so Spring does not auto-infer a destroy method on the post-BPP instance
+   * — see issue #153 for the cascade-close regression this prevents.
    *
    * @param original the real data source to wrap
    * @param interceptor the interceptor that will record queries
-   * @return a proxy data source
+   * @return a non-{@code Closeable} wrapper around the query-recording proxy
    */
   public static DataSource wrap(DataSource original, QueryInterceptor interceptor) {
-    return ProxyDataSourceBuilder.create(original)
-        .name("query-audit")
-        .listener(interceptor)
-        .build();
+    DataSource proxy =
+        ProxyDataSourceBuilder.create(original)
+            .name("query-audit")
+            .listener(interceptor)
+            .build();
+    return new NonClosingDataSource(proxy);
   }
 }

--- a/query-audit-core/src/main/java/io/queryaudit/core/interceptor/NonClosingDataSource.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/interceptor/NonClosingDataSource.java
@@ -1,0 +1,97 @@
+package io.queryaudit.core.interceptor;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * Delegating {@link DataSource} that intentionally does <em>not</em> implement {@link
+ * java.io.Closeable} or {@link AutoCloseable}.
+ *
+ * <p>Spring infers a destroy method on a bean when the bean's runtime type exposes {@code close()}
+ * via {@code Closeable}/{@code AutoCloseable}. When the auto-configured {@code BeanPostProcessor}
+ * returns a raw {@code ProxyDataSource} (which implements {@code Closeable}), Spring registers it
+ * as the lifecycle target and, on context shutdown, calls {@code close()} on the proxy — which
+ * cascades to {@code close()} on the underlying {@code HikariDataSource}. Under Spring Boot 4.x
+ * with the test-context cache evicting contexts, this cascade has been observed to close the pool
+ * of a still-cached sibling context (see GitHub issue #153 for the full analysis).
+ *
+ * <p>Wrapping the proxy once more in this non-{@code Closeable} decorator removes the destroy
+ * inference: Spring leaves the underlying {@code HikariDataSource} as the lifecycle target — which
+ * already has {@code @Bean(destroyMethod = "close")} declared by {@code
+ * DataSourceAutoConfiguration} — and the cascade goes away. Query interception still works because
+ * every {@link #getConnection()} call goes through the wrapped {@code ProxyDataSource}.
+ *
+ * <p>JDBC unwrap is preserved so callers that need direct access to the underlying
+ * {@code ProxyDataSource} or {@code HikariDataSource} can still {@code unwrap()} them.
+ *
+ * @author haroya
+ * @since 0.3.2
+ */
+public final class NonClosingDataSource implements DataSource {
+
+  private final DataSource delegate;
+
+  public NonClosingDataSource(DataSource delegate) {
+    this.delegate = delegate;
+  }
+
+  /** Returns the wrapped data source (typically a {@code ProxyDataSource}). */
+  public DataSource getDelegate() {
+    return delegate;
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return delegate.getConnection();
+  }
+
+  @Override
+  public Connection getConnection(String username, String password) throws SQLException {
+    return delegate.getConnection(username, password);
+  }
+
+  @Override
+  public PrintWriter getLogWriter() throws SQLException {
+    return delegate.getLogWriter();
+  }
+
+  @Override
+  public void setLogWriter(PrintWriter out) throws SQLException {
+    delegate.setLogWriter(out);
+  }
+
+  @Override
+  public void setLoginTimeout(int seconds) throws SQLException {
+    delegate.setLoginTimeout(seconds);
+  }
+
+  @Override
+  public int getLoginTimeout() throws SQLException {
+    return delegate.getLoginTimeout();
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return delegate.getParentLogger();
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    if (iface.isInstance(this)) {
+      return iface.cast(this);
+    }
+    if (iface.isInstance(delegate)) {
+      return iface.cast(delegate);
+    }
+    return delegate.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return iface.isInstance(this) || iface.isInstance(delegate) || delegate.isWrapperFor(iface);
+  }
+}

--- a/query-audit-core/src/test/java/io/queryaudit/core/interceptor/NonClosingDataSourceTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/interceptor/NonClosingDataSourceTest.java
@@ -1,0 +1,122 @@
+package io.queryaudit.core.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Closeable;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for issue #153 — the post-BPP {@link DataSource} returned by {@link
+ * DataSourceProxyFactory#wrap} must not implement {@link Closeable}/{@link AutoCloseable} so that
+ * Spring's destroy-method inference cannot register a close-cascade against it.
+ */
+class NonClosingDataSourceTest {
+
+  @Test
+  void wrap_returnsNonCloseableNonAutoCloseableInstance() {
+    CountingCloseableDataSource underlying = new CountingCloseableDataSource();
+
+    DataSource wrapped = DataSourceProxyFactory.wrap(underlying, new QueryInterceptor());
+
+    assertThat(wrapped).isInstanceOf(NonClosingDataSource.class);
+    assertThat(wrapped).isNotInstanceOf(Closeable.class);
+    assertThat(wrapped).isNotInstanceOf(AutoCloseable.class);
+  }
+
+  @Test
+  void wrap_preservesUnwrapToProxyDataSource() throws SQLException {
+    CountingCloseableDataSource underlying = new CountingCloseableDataSource();
+
+    DataSource wrapped = DataSourceProxyFactory.wrap(underlying, new QueryInterceptor());
+
+    assertThat(wrapped.isWrapperFor(ProxyDataSource.class)).isTrue();
+    assertThat(wrapped.unwrap(ProxyDataSource.class)).isInstanceOf(ProxyDataSource.class);
+  }
+
+  @Test
+  void wrap_doesNotCascadeCloseToUnderlying() {
+    CountingCloseableDataSource underlying = new CountingCloseableDataSource();
+
+    DataSource wrapped = DataSourceProxyFactory.wrap(underlying, new QueryInterceptor());
+
+    // The whole point: there is no close() to invoke on the returned instance, so a Spring
+    // shutdown that walks AutoCloseable beans cannot reach the underlying. Verify symbolically
+    // by asserting the underlying counter stays at zero even after we explicitly traverse the
+    // chain looking for a close().
+    if (wrapped instanceof AutoCloseable autoCloseable) {
+      try {
+        autoCloseable.close();
+      } catch (Exception ignored) {
+        // would have cascaded — but we asserted above this branch is unreachable
+      }
+    }
+    assertThat(underlying.closeCount.get()).isZero();
+  }
+
+  /**
+   * Minimal {@link DataSource} that implements {@link AutoCloseable} (matching {@code
+   * HikariDataSource}) and counts how many times {@code close()} has been called. We only need
+   * enough of the contract to flow through datasource-proxy's builder; we never actually open
+   * connections in these tests.
+   */
+  private static final class CountingCloseableDataSource implements DataSource, AutoCloseable {
+    final AtomicInteger closeCount = new AtomicInteger();
+
+    @Override
+    public void close() {
+      closeCount.incrementAndGet();
+    }
+
+    @Override
+    public Connection getConnection() {
+      throw new UnsupportedOperationException("not exercised");
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) {
+      throw new UnsupportedOperationException("not exercised");
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+      return null;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {}
+
+    @Override
+    public void setLoginTimeout(int seconds) {}
+
+    @Override
+    public int getLoginTimeout() {
+      return 0;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+      throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) {
+      if (iface.isInstance(this)) {
+        return iface.cast(this);
+      }
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+      return iface.isInstance(this);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `NonClosingDataSource` decorator that wraps `ProxyDataSource` so Spring's destroy-method inference no longer finds a `close()` on the post-BPP `dataSource` bean. This stops the cascade-close regression reported in #153 (Boot 4.x + 30+ `@SpringBootTest` classes → `HikariDataSource has been closed`).

The reproducer was confirmed on `haroya01/short-link` after sweeping `@QueryAudit` to 36 service/repository/integration tests: 145 tests failed with `CannotCreateTransactionException → HikariDataSource has been closed`. With this fix consumed via mavenLocal `0.3.2-SNAPSHOT`, all 1,257 tests pass.

## What changed

- `DataSourceProxyFactory.wrap()` now returns `new NonClosingDataSource(proxyDataSource)` instead of the raw `ProxyDataSource`.
- `NonClosingDataSource` implements `DataSource` but intentionally not `Closeable`/`AutoCloseable`. JDBC `unwrap`/`isWrapperFor` is preserved so existing chain traversal (e.g., `DataSourceResolver.findProxyDataSource`) still resolves the proxy via `unwrap(ProxyDataSource.class)`.
- The underlying `HikariDataSource` still has `@Bean(destroyMethod = "close")` from `DataSourceAutoConfiguration`, so normal context shutdown closes it exactly once — no cascade through the BPP-returned instance.

## Why this approach (Option A from #153)

#153 listed two fix directions. **A** wraps the proxy in a non-`Closeable` decorator; **B** forces `destroyMethodName=""` via a `BeanDefinitionRegistryPostProcessor`. A was chosen because:

1. It's symmetric — both the auto-wrap BPP path and the `@QueryAudit`-runtime path in `DataSourceResolver.hookInterceptor` (Strategy 2) go through `DataSourceProxyFactory.wrap` and therefore both stop cascading without any extra coordination.
2. It doesn't touch bean definitions, so it doesn't conflict with user config that may already declare destroy semantics on the `DataSource` bean.

## Test plan

- [x] New regression test `NonClosingDataSourceTest` — asserts the wrapped instance is not `Closeable`/`AutoCloseable`, that `unwrap(ProxyDataSource.class)` still works, and that the cascade-close attempt is unreachable from the runtime type system.
- [x] Existing query-audit suite: `./gradlew test` → all 24 tasks green.
- [x] Downstream reproducer (`short-link` with 36 `@QueryAudit` classes): from 145 failures → 0 failures on `0.3.2-SNAPSHOT`.

Closes #153.