### PR TITLE
fix(postgresql): scope cardinality + index metadata queries to current_schema() (#147)

### DIFF
--- a/query-audit-postgresql/src/main/java/io/queryaudit/postgresql/PostgreSqlIndexMetadataProvider.java
+++ b/query-audit-postgresql/src/main/java/io/queryaudit/postgresql/PostgreSqlIndexMetadataProvider.java
@@ -23,6 +23,11 @@ public class PostgreSqlIndexMetadataProvider implements IndexMetadataProvider {
   private static final String LIST_TABLES_SQL =
       "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()";
 
+  // Both queries scope by current_schema() to avoid cross-schema name collisions: pg_class is
+  // database-wide and pg_class.relname is unique only per-namespace. Without the join, a same-
+  // named table in another schema (e.g. public.orders + staging.orders) would silently leak its
+  // indexes / cardinality into the result for the table actually iterated from
+  // pg_tables WHERE schemaname = current_schema(). See issue #147.
   private static final String INDEX_QUERY =
       """
             SELECT
@@ -31,16 +36,22 @@ public class PostgreSqlIndexMetadataProvider implements IndexMetadataProvider {
                 ix.indisunique AS is_unique,
                 array_position(ix.indkey, a.attnum) AS seq_in_index
             FROM pg_class t
+            JOIN pg_namespace n ON n.oid = t.relnamespace
             JOIN pg_index ix ON t.oid = ix.indrelid
             JOIN pg_class i  ON i.oid = ix.indexrelid
             JOIN pg_attribute a ON a.attrelid = t.oid
                 AND a.attnum = ANY(ix.indkey)
-            WHERE t.relname = ? AND t.relkind = 'r'
+            WHERE t.relname = ? AND t.relkind = 'r' AND n.nspname = current_schema()
             ORDER BY i.relname, array_position(ix.indkey, a.attnum)
             """;
 
   private static final String CARDINALITY_QUERY =
-      "SELECT reltuples FROM pg_class WHERE relname = ?";
+      """
+            SELECT c.reltuples
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = ? AND n.nspname = current_schema()
+            """;
 
   @Override
   public String supportedDatabase() {

--- a/query-audit-postgresql/src/test/java/io/queryaudit/postgresql/PostgreSqlIndexMetadataProviderTest.java
+++ b/query-audit-postgresql/src/test/java/io/queryaudit/postgresql/PostgreSqlIndexMetadataProviderTest.java
@@ -7,11 +7,13 @@ import static org.mockito.Mockito.*;
 import io.queryaudit.core.model.IndexInfo;
 import io.queryaudit.core.model.IndexMetadata;
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -163,6 +165,58 @@ class PostgreSqlIndexMetadataProviderTest {
       assertThat(metadata.hasTable("products")).isTrue();
       assertThat(metadata.getIndexesForTable("orders")).hasSize(1);
       assertThat(metadata.getIndexesForTable("products")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName(
+        "[#147] CARDINALITY_QUERY must scope by current_schema to avoid cross-schema collision")
+    void issue147_cardinalityQueryMustBeSchemaScoped() throws SQLException {
+      // listUserTables IS schema-scoped (pg_tables WHERE schemaname = current_schema()),
+      // but CARDINALITY_QUERY just does `WHERE relname = ?` against pg_class. When the same
+      // table name exists in multiple schemas (e.g. public.orders + staging.orders), pg_class
+      // returns whichever row PostgreSQL surfaces first by OID — silently mismatching the
+      // table that was actually iterated.
+      when(connection.createStatement()).thenReturn(statement);
+      when(statement.executeQuery(contains("pg_tables"))).thenReturn(tableResultSet);
+      when(tableResultSet.next()).thenReturn(true, false);
+      when(tableResultSet.getString("tablename")).thenReturn("orders");
+
+      PreparedStatement cardPstmt = mock(PreparedStatement.class);
+      ResultSet cardRs = mock(ResultSet.class);
+      PreparedStatement indexPstmt = mock(PreparedStatement.class);
+      ResultSet indexRs = mock(ResultSet.class);
+
+      ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+      when(connection.prepareStatement(sqlCaptor.capture()))
+          .thenAnswer(
+              inv -> {
+                String sql = inv.getArgument(0);
+                if (sql.contains("reltuples")) return cardPstmt;
+                if (sql.contains("pg_index")) return indexPstmt;
+                throw new IllegalArgumentException("unexpected SQL: " + sql);
+              });
+      when(cardPstmt.executeQuery()).thenReturn(cardRs);
+      when(cardRs.next()).thenReturn(true);
+      when(cardRs.getFloat("reltuples")).thenReturn(0.0f);
+      when(indexPstmt.executeQuery()).thenReturn(indexRs);
+      when(indexRs.next()).thenReturn(false);
+
+      provider.getIndexMetadata(connection);
+
+      List<String> cardinalitySqls = new ArrayList<>();
+      for (String sql : sqlCaptor.getAllValues()) {
+        if (sql.contains("reltuples")) cardinalitySqls.add(sql);
+      }
+      assertThat(cardinalitySqls)
+          .as("cardinality query must be sent at least once")
+          .isNotEmpty();
+
+      assertThat(cardinalitySqls.get(0))
+          .as(
+              "CARDINALITY_QUERY must include a schema constraint "
+                  + "(current_schema(), pg_namespace, or nspname). "
+                  + "Without it, same-named tables in other schemas overwrite the result.")
+          .containsAnyOf("current_schema", "pg_namespace", "nspname");
     }
 
     @Test


### PR DESCRIPTION
## Summary

`PostgreSqlIndexMetadataProvider` queried `pg_class.relname` without filtering by schema. Since `relname` is unique only per-namespace, a same-named table in another schema (`public.orders` + `staging.orders`) leaked its cardinality and indexes into the result for the table actually iterated from `listUserTables` (which IS schema-scoped via `pg_tables WHERE schemaname = current_schema()`).

## Scope wider than the original issue suggested

The issue body for #147 framed this as cardinality-only — "the list/iterate side (`listUserTables + INDEX_QUERY`) is correctly scoped". But reading the actual SQL, `INDEX_QUERY` was ALSO unscoped (`WHERE t.relname = ? AND t.relkind = 'r'`), so this PR fixes both queries together. Without the wider fix, `IndexInfo.tableName` for `public.orders` would silently carry indexes that actually belong to `staging.orders` — a structural false-positive risk for any detector that gates on `IndexMetadata.getIndexesForTable(...)` (notably `MissingIndexDetector`).

## What changed

Both `CARDINALITY_QUERY` and `INDEX_QUERY` now `JOIN pg_namespace` and constrain `n.nspname = current_schema()`. The contract is now symmetric with `LIST_TABLES_SQL`.

```sql
-- before
SELECT reltuples FROM pg_class WHERE relname = ?

-- after
SELECT c.reltuples
FROM pg_class c
JOIN pg_namespace n ON n.oid = c.relnamespace
WHERE c.relname = ? AND n.nspname = current_schema()
```

## Verifying test

`issue147_cardinalityQueryMustBeSchemaScoped` captures the SQL sent to `prepareStatement` via Mockito `ArgumentCaptor` and asserts it contains a schema constraint (`current_schema`, `pg_namespace`, or `nspname`). Fails on `main`, passes here.

## Test plan

- [x] Unit tests (Mockito): all green including verifying test
- [x] `:query-audit-postgresql:integrationTest` (Testcontainers Postgres): green
- [x] No change to public API of `IndexMetadataProvider`

Closes #147.