### PR TITLE
fix(mysql): lower-case map key in IndexMetadataProvider to match detector lookup (#148)

### DIFF
--- a/query-audit-mysql/src/main/java/io/queryaudit/mysql/MySqlIndexMetadataProvider.java
+++ b/query-audit-mysql/src/main/java/io/queryaudit/mysql/MySqlIndexMetadataProvider.java
@@ -7,6 +7,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -37,7 +38,12 @@ public class MySqlIndexMetadataProvider implements IndexMetadataProvider {
     for (String tableName : tableNames) {
       List<IndexInfo> indexes = collectIndexes(connection, tableName);
       if (!indexes.isEmpty()) {
-        indexesByTable.put(tableName, indexes);
+        // Detectors lowercase the table name extracted from SQL before consulting IndexMetadata,
+        // but MySQL with lower_case_table_names=0 (Linux default on case-sensitive filesystems)
+        // returns table names in their original case. Normalising the map key on the provider
+        // side keeps the lookup contract symmetric. IndexInfo retains the raw case for reporting.
+        // See issue #148.
+        indexesByTable.put(tableName.toLowerCase(Locale.ROOT), indexes);
       }
     }
 

--- a/query-audit-mysql/src/test/java/io/queryaudit/mysql/MySqlIndexMetadataProviderTest.java
+++ b/query-audit-mysql/src/test/java/io/queryaudit/mysql/MySqlIndexMetadataProviderTest.java
@@ -156,6 +156,41 @@ class MySqlIndexMetadataProviderTest {
     }
 
     @Test
+    @DisplayName(
+        "[#148] case-sensitive lookup misses metadata when MySQL returns mixed-case table names")
+    void issue148_caseSensitiveLookupMissesMetadataOnLinuxStyleMySQL() throws SQLException {
+      // Simulate MySQL on Linux with lower_case_table_names=0 — TABLES query returns raw case.
+      // Detectors (CompositeIndexDetector, MissingIndexDetector, ...) extract the table name from
+      // the SQL via SqlParser and then call `.toLowerCase()` before consulting IndexMetadata.
+      // If the provider keeps the raw-case key, the lookup misses and detectors silently treat
+      // the table as having no metadata.
+      Statement tableStatement = mock(Statement.class);
+      when(connection.createStatement()).thenReturn(tableStatement).thenReturn(statement);
+
+      when(tableStatement.executeQuery(contains("INFORMATION_SCHEMA.TABLES")))
+          .thenReturn(tableResultSet);
+      when(tableResultSet.next()).thenReturn(true, false);
+      when(tableResultSet.getString("TABLE_NAME")).thenReturn("Users");
+
+      when(statement.executeQuery(contains("SHOW INDEX"))).thenReturn(indexResultSet);
+      when(indexResultSet.next()).thenReturn(true, false);
+      when(indexResultSet.getString("Table")).thenReturn("Users");
+      when(indexResultSet.getString("Key_name")).thenReturn("PRIMARY");
+      when(indexResultSet.getInt("Seq_in_index")).thenReturn(1);
+      when(indexResultSet.getString("Column_name")).thenReturn("id");
+      when(indexResultSet.getInt("Non_unique")).thenReturn(0);
+      when(indexResultSet.getLong("Cardinality")).thenReturn(1000L);
+
+      IndexMetadata metadata = provider.getIndexMetadata(connection);
+
+      assertThat(metadata.hasTable("users"))
+          .as(
+              "detector-side lowercase lookup must find metadata for a table that MySQL"
+                  + " reported as 'Users' (lower_case_table_names=0)")
+          .isTrue();
+    }
+
+    @Test
     @DisplayName("skips tables that have no indexes")
     void skipsTablesWithNoIndexes() throws SQLException {
       Statement stmt1 = mock(Statement.class);


### PR DESCRIPTION
## Summary

On MySQL with `lower_case_table_names=0` (the Linux default on case-sensitive filesystems), `INFORMATION_SCHEMA.TABLES` returns names in their original case (`Users`, not `users`). Detectors lowercase the table name extracted from the SQL before consulting `IndexMetadata`. The map key was stored raw, so the lookup silently missed and every metadata-gated detector degraded to "no metadata available" for mixed-case tables — no warning, just a missed finding.

On macOS and Windows the bug is invisible because MySQL folds names before returning them (default `lower_case_table_names=2/1`). Linux CI with default MySQL packaging is the affected configuration.

## What changed

`MySqlIndexMetadataProvider#getIndexMetadata` now normalises the map key with `tableName.toLowerCase(Locale.ROOT)` when populating `indexesByTable`. `IndexInfo.tableName()` retains the raw case for reports.

`Locale.ROOT` is used deliberately to avoid the Turkish-`I` locale trap (`I` → `ı` under `tr_TR`).

## Why provider-side rather than `IndexMetadata#lookup`

Two options were considered:

1. **Normalise on the provider side** (chosen). Matches the existing convention: detectors already lowercase before lookup, so the contract is "keys are lowercase". Symmetric with `PostgreSqlIndexMetadataProvider`, which gets this behavior for free because PostgreSQL folds unquoted identifiers.
2. Normalise on the lookup side. More invasive — touches the shared `IndexMetadata` model class for one DB-specific quirk.

## Verifying test

`issue148_caseSensitiveLookupMissesMetadataOnLinuxStyleMySQL` simulates MySQL returning `"Users"` for the TABLES query and asserts `metadata.hasTable("users")` is true. Fails on `main`, passes here.

## Test plan

- [x] Unit tests (Mockito): all green including new verifying test
- [x] `:query-audit-mysql:integrationTest` (Testcontainers MySQL): green
- [x] Existing detector tests that already assume lowercase keys continue to pass

Closes #148.