### PR TITLE
docs: review pass for 0.3.2 — version, type signatures, missing keys, overclaim softening

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.0'
-    testImplementation 'io.github.haroya01:query-audit-mysql:0.3.0'
+    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
+    testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
 }
 ```
 
@@ -61,8 +61,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.0'
-    testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.0'
+    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
+    testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.2'
 }
 ```
 
@@ -75,13 +75,13 @@ dependencies {
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-spring-boot-starter</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.2</version>
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-mysql</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.2</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -92,13 +92,13 @@ dependencies {
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-spring-boot-starter</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.2</version>
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-postgresql</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.2</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -109,8 +109,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-junit5:0.3.0'
-    testRuntimeOnly 'io.github.haroya01:query-audit-mysql:0.3.0'  // or query-audit-postgresql
+    testImplementation 'io.github.haroya01:query-audit-junit5:0.3.2'
+    testRuntimeOnly 'io.github.haroya01:query-audit-mysql:0.3.2'  // or query-audit-postgresql
 }
 ```
 

--- a/docs/detections/overview.md
+++ b/docs/detections/overview.md
@@ -1,28 +1,33 @@
 # Detection Rules Overview
 
-QueryAudit ships with **57 active detection rules** that catch SQL performance issues,
-logic bugs, and anti-patterns during your test runs. These 57 rules emit **60 distinct
-issue types** (because `MissingIndexDetector` alone emits 4 different issue types).
-Rules are organized by severity and confidence model to help you prioritize fixes.
+QueryAudit ships with **active detection rules** that catch SQL performance issues, logic
+bugs, and anti-patterns during your test runs. The rules are organized by severity and
+confidence model to help you prioritize fixes.
 
-!!! info "IssueType enum vs active rules"
-    The `IssueType` enum contains **64** entries. Of those, **60** are actively emitted by
-    **57 detection rules**. The remaining 4 are [disabled or reserved](#disabled-reserved-rules).
+!!! info "IssueType enum"
+    The `IssueType` enum currently contains **66** entries. **62** are actively emitted by
+    detection rules (one rule can emit multiple issue types — `MissingIndexDetector` alone
+    emits 4). The remaining 4 are [disabled or reserved](#disabled-reserved-rules).
+    The full canonical list is in
+    [`IssueType.java`](https://github.com/haroya01/query-audit/blob/main/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java).
 
 ---
 
 ## Confidence Model
 
-### Confirmed (100% Reliable)
+### Confirmed (Structural / Pattern-based)
 
 These rules analyze **SQL structure and database schema** -- things that do not change with data
-volume. If QueryAudit reports a Confirmed issue, it is a real problem regardless of whether you
-are running against 5 test rows or 5 million production rows.
+volume. The detection logic examines the SQL text, repetition patterns, or cross-references the
+actual index metadata via `SHOW INDEX` / `pg_catalog`. Heuristics that depend on data distribution
+live in the INFO tier instead.
 
-!!! success "Confirmed = Structural / Pattern-based"
-    The detection logic examines the SQL text, repetition patterns, or cross-references the
-    actual index metadata via `SHOW INDEX`. None of these depend on row counts or data
-    distribution.
+!!! success "High-signal tier"
+    Findings here are not gated by row counts or data distribution. False positives are tracked
+    as bugs and fixed -- the design intent is that a confirmed flag is a real problem worth
+    investigating. The most recent false-positive fixes are listed in
+    [CHANGELOG](https://github.com/haroya01/query-audit/blob/main/CHANGELOG.md); please report
+    any new one you hit.
 
 ### Info (Data-Dependent / Heuristic)
 
@@ -48,7 +53,8 @@ Production: 1M rows --> MySQL: "Use index"           --> Index scan
 
 ## Quick Reference Table
 
-The complete searchable reference of all 60 issue types emitted by 57 active detection rules.
+The complete searchable reference of issue types emitted by the active detection rules.
+(The full canonical list, including the newest additions, is the `IssueType` enum.)
 
 | # | Rule Name | Code | Severity | Category | Description |
 |---|-----------|------|----------|----------|-------------|
@@ -240,7 +246,7 @@ Important issues that should be reviewed and typically fixed.
 
 ---
 
-### INFO Severity (11 issue types)
+### INFO Severity (12 issue types)
 
 Best-practice suggestions and heuristic checks. These won't fail your build by default
 but are worth reviewing.
@@ -249,7 +255,7 @@ but are worth reviewing.
 |------|-------------|-----------------|
 | `select-all` | SELECT * usage | Regex match on parsed SQL |
 | `redundant-filter` | Redundant duplicate WHERE condition | Detect duplicate predicates in WHERE clause |
-| `count-instead-of-exists` | COUNT used where EXISTS is better | Detect `COUNT(*)` in conditional context |
+| `count-instead-of-exists` | COUNT used where EXISTS is better | Detect `COUNT(*)` in conditional context. Off by default; enable via `query-audit.count-instead-of-exists.enabled: true`. |
 | `union-without-all` | UNION without ALL forces dedup sort | Detect UNION without ALL keyword |
 | `covering-index-opportunity` | Query could benefit from covering index | Analyze SELECT columns vs available indexes |
 | `count-star-no-where` | COUNT(*) without WHERE scans full table | Detect `COUNT(*)` without WHERE clause |
@@ -258,6 +264,7 @@ but are worth reviewing.
 | `mergeable-queries` | Multiple queries could be merged | Detect multiple simple SELECTs to same table |
 | `non-deterministic-pagination` | ORDER BY+LIMIT on non-unique column | Detect ORDER BY + LIMIT on non-unique columns |
 | `force-index-hint` | FORCE/USE/IGNORE INDEX overrides optimizer | Detect index hint keywords in query |
+| `find-by-id-for-association` | `findById()` used only for FK association — consider `getReferenceById()` to skip the SELECT | Spring Data return-type and call-site analysis |
 
 !!! info "Info rules are still useful"
     Even though they can produce false positives with small test data, they serve as early
@@ -268,8 +275,8 @@ but are worth reviewing.
 
 ## Disabled & Reserved Rules
 
-The `IssueType` enum has **64 entries**, but only **60 are actively emitted** by **57 detection
-rules**. The remaining 4 entries fall into two categories:
+The `IssueType` enum currently has **66 entries**. **62 are actively emitted** by detection
+rules. The remaining 4 entries fall into two categories:
 
 ### Disabled Rules (1 entry)
 
@@ -297,17 +304,17 @@ for a planned EXPLAIN-based detection phase.
 
 | Category | Count |
 |----------|-------|
-| Active detection rules (detectors) in `QueryAuditAnalyzer` | **57** |
-| Active issue types emitted by those rules | **60** |
+| Active issue types emitted by detectors | **62** |
 | Disabled (DuplicateQueryDetector) | 1 |
 | Reserved EXPLAIN-based (full-scan, filesort, temporary-table) | 3 |
-| **Total IssueType enum entries** | **64** |
+| **Total IssueType enum entries** | **66** |
 
-!!! note "Why 57 rules but 60 issue types?"
-    The `MissingIndexDetector` is registered as a **single detection rule** but emits **4
-    different IssueTypes** (`missing-where-index`, `missing-join-index`, `missing-order-by-index`,
-    `missing-group-by-index`), one for each SQL clause it analyzes. This accounts for the
-    difference: 57 rules + 3 extra IssueTypes from MissingIndexDetector = 60 active IssueTypes.
+!!! note "Why 57 detection rules but 62 active issue types?"
+    A single detector can emit multiple issue types. The biggest example is
+    `MissingIndexDetector`, which is registered as one detection rule but emits 4 different
+    `IssueType`s (`missing-where-index`, `missing-join-index`, `missing-order-by-index`,
+    `missing-group-by-index`) -- one per SQL clause it analyzes. That accounts for the
+    bulk of the difference between detector count and active issue-type count.
 
 ---
 
@@ -401,10 +408,10 @@ for a planned EXPLAIN-based detection phase.
 |----------|-------------|--------|
 | ERROR | 11 | Must fix -- logic bugs or guaranteed performance degradation |
 | WARNING | 38 | Should fix -- important issues that typically need attention |
-| INFO | 11 | Review -- best-practice suggestions, may have false positives |
-| **Active Total** | **60 issue types** | **Emitted by 57 detection rules** |
+| INFO | 12 | Review -- best-practice suggestions, may have false positives |
+| **Active Total** | **62 issue types** | Emitted by the active detector set |
 | Disabled | 1 | DuplicateQueryDetector (awaiting parameter tracking) |
-| Reserved | 3 | EXPLAIN-based detectors (planned) |
+| Reserved | 3 | EXPLAIN-based placeholders (planned) |
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,7 +18,7 @@ description: Add QueryAudit to your Java project with Gradle or Maven.
 | **JUnit** | 5.9+ |
 | **MySQL** | 5.7+ / 8.0+ |
 | **PostgreSQL** | 12+ |
-| **Spring Boot** *(optional)* | 3.0+ |
+| **Spring Boot** *(optional)* | 3.x or 4.x (4.x requires query-audit 0.3.2+) |
 
 !!! note "Database requirement"
     You need either MySQL **or** PostgreSQL -- not both. Pick the tab that matches your database below.
@@ -37,8 +37,8 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.0'
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.0'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
     }
     ```
 
@@ -49,7 +49,7 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.0'
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
     }
     ```
 
@@ -59,8 +59,8 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.0'
-        testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.0'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.2'
     }
     ```
 
@@ -71,7 +71,7 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.0'
+        testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.2'
     }
     ```
 
@@ -84,13 +84,13 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-spring-boot-starter</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-mysql</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -103,7 +103,7 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-mysql</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -116,13 +116,13 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-spring-boot-starter</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-postgresql</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -135,7 +135,7 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-postgresql</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -45,8 +45,8 @@ No configuration. No extra beans. No proxy setup. Just the annotation.
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.0'
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.0'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
     }
     ```
 
@@ -56,13 +56,13 @@ No configuration. No extra beans. No proxy setup. Just the annotation.
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-spring-boot-starter</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.2</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-mysql</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.2</version>
         <scope>test</scope>
     </dependency>
     ```

--- a/docs/getting-started/spring-boot.md
+++ b/docs/getting-started/spring-boot.md
@@ -43,8 +43,8 @@ any connection pool (HikariCP, Tomcat, etc.) and any JPA provider (Hibernate, Ec
 
     ```kotlin
     dependencies {
-        testImplementation("io.github.haroya01:query-audit-spring-boot-starter:0.3.0")
-        testImplementation("io.github.haroya01:query-audit-mysql:0.3.0")
+        testImplementation("io.github.haroya01:query-audit-spring-boot-starter:0.3.2")
+        testImplementation("io.github.haroya01:query-audit-mysql:0.3.2")
     }
     ```
 
@@ -52,8 +52,8 @@ any connection pool (HikariCP, Tomcat, etc.) and any JPA provider (Hibernate, Ec
 
     ```groovy
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.0'
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.0'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
     }
     ```
 
@@ -63,13 +63,13 @@ any connection pool (HikariCP, Tomcat, etc.) and any JPA provider (Hibernate, Ec
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-spring-boot-starter</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.2</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-mysql</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.2</version>
         <scope>test</scope>
     </dependency>
     ```
@@ -207,10 +207,10 @@ class QueryAuditTestConfig {
             public Object postProcessAfterInitialization(Object bean, String beanName)
                     throws BeansException {
                 if (bean instanceof ProxyDataSource proxyDs) {
-                    // Add QueryInterceptor to the existing proxy's listener chain
-                    proxyDs.getProxyConfig()
-                           .getMethodListener()
-                           .addListener(interceptor);
+                    // Attach QueryInterceptor to the existing proxy's query listener chain.
+                    // ProxyDataSource.addListener(QueryExecutionListener) appends to the
+                    // chain returned by getProxyConfig().getQueryListener().
+                    proxyDs.addListener(interceptor);
                 }
                 return bean;
             }
@@ -219,19 +219,22 @@ class QueryAuditTestConfig {
 }
 ```
 
-Then disable QueryAudit's built-in proxy in your test configuration:
+Then disable only QueryAudit's auto-wrap `BeanPostProcessor` -- **not** the whole library --
+so the `QueryInterceptor` bean stays available for the `@QueryAudit` annotation:
 
 ```yaml
 # application-test.yml
 query-audit:
-  enabled: false          # Disable the auto BeanPostProcessor
+  wrap-data-source:
+    enabled: false        # Disable ONLY the auto BPP (issue #134 escape hatch)
   fail-on-detection: true # Still used by @QueryAudit annotation
 ```
 
 !!! note
-    With this approach, QueryAudit's auto-configuration `BeanPostProcessor` is disabled.
-    The `@QueryAudit` annotation and JUnit extension still work normally because they
-    read the `QueryInterceptor` bean from the application context.
+    Use `wrap-data-source.enabled: false`, not `query-audit.enabled: false`. The latter
+    disables the entire auto-configuration including the `QueryInterceptor` bean, which
+    would also break the `@QueryAudit` annotation. `wrap-data-source.enabled: false` is the
+    surgical escape hatch added in 0.3.0+.
 
 ### Approach 2: Accept the double proxy
 

--- a/docs/guide/annotations.md
+++ b/docs/guide/annotations.md
@@ -18,14 +18,22 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 
 | Attribute | Annotation | Type | Default | Description |
 |---|---|---|---|---|
-| `failOnDetection` | `@QueryAudit` | `boolean` | `true` | Fail the test on confirmed issues |
-| `nPlusOneThreshold` | `@QueryAudit` | `int` | `-1` (use default: 3) | Override N+1 threshold |
+| `failOnDetection` | `@QueryAudit` | `BooleanOverride` | `INHERIT` (yml default: `true`) | Fail the test on confirmed issues |
+| `nPlusOneThreshold` | `@QueryAudit` | `int` | `-1` (use yml/default: 3) | Override N+1 threshold |
 | `suppress` | `@QueryAudit` | `String[]` | `{}` | Issue codes to suppress |
 | `failOn` | `@QueryAudit` | `IssueType[]` | `{}` (all confirmed) | Only fail on specific issue types |
 | `baselinePath` | `@QueryAudit` | `String` | `""` (default path) | Path to baseline file |
-| `autoOpenReport` | `@QueryAudit` | `boolean` | `false` | Open HTML report in browser after tests |
+| `autoOpenReport` | `@QueryAudit` | `BooleanOverride` | `INHERIT` (yml default: `true`) | Open HTML report in browser after tests |
+| `includeSetupQueries` | `@QueryAudit` | `boolean` | `false` | Include `@BeforeEach`/`@AfterEach` queries in analysis |
 | `threshold` | `@DetectNPlusOne` | `int` | `3` | Repeated query count to consider N+1 |
 | `value` | `@ExpectMaxQueryCount` | `int` | *(required)* | Maximum number of queries allowed |
+
+!!! info "Why `BooleanOverride` instead of `boolean`?"
+    Java annotation attributes cannot distinguish between "explicitly set to default" and
+    "not specified" with a `boolean` type. `BooleanOverride` is a tri-state enum
+    (`INHERIT`/`TRUE`/`FALSE`) that lets a method-level annotation cleanly fall back to the
+    class-level or `application.yml` value when left as `INHERIT`. Pass `BooleanOverride.TRUE`
+    or `BooleanOverride.FALSE` to explicitly override.
 
 ---
 
@@ -51,12 +59,13 @@ class OrderServiceTest {
 
 | Attribute | Type | Default | Description |
 |---|---|---|---|
-| `failOnDetection` | `boolean` | `true` | Fail the test on confirmed issues |
-| `nPlusOneThreshold` | `int` | `-1` (use default: 3) | Override N+1 threshold |
+| `failOnDetection` | `BooleanOverride` | `INHERIT` (yml default: `true`) | Fail the test on confirmed issues. Use `BooleanOverride.TRUE`/`FALSE` to override. |
+| `nPlusOneThreshold` | `int` | `-1` (use yml/default: 3) | Override N+1 threshold |
 | `suppress` | `String[]` | `{}` | Issue codes to suppress |
 | `failOn` | `IssueType[]` | `{}` (all confirmed) | Only fail on specific issue types |
 | `baselinePath` | `String` | `""` (default path) | Path to baseline file |
-| `autoOpenReport` | `boolean` | `false` | Open HTML report in browser after tests |
+| `autoOpenReport` | `BooleanOverride` | `INHERIT` (yml default: `true`) | Open HTML report in browser after tests |
+| `includeSetupQueries` | `boolean` | `false` | Include queries from `@BeforeEach`/`@AfterEach` lifecycle methods in analysis. Default analyzes only `@Test` body queries. |
 
 ### Usage Patterns
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -16,8 +16,11 @@ All properties are optional. The table below lists every supported key under the
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | `boolean` | `true` | Master switch. When `false`, the `BeanPostProcessor` that wraps DataSources is not created. |
+| `enabled` | `boolean` | `true` | Master switch for the entire auto-configuration. When `false`, the `QueryInterceptor` bean and the wrapping `BeanPostProcessor` are both skipped — the `@QueryAudit` annotation will not work either. Use `wrap-data-source.enabled: false` instead if you want to keep the interceptor active but skip the auto-wrap. |
+| `wrap-data-source.enabled` | `boolean` | `true` | Surgical escape hatch (issue #134) — disables only the auto-wrap `BeanPostProcessor` while keeping `QueryInterceptor` and `QueryAuditConfig` beans active. Use this when integrating with an existing datasource-proxy (e.g. gavlyukovskiy). |
 | `fail-on-detection` | `boolean` | `true` | Whether confirmed issues (ERROR/WARNING) should cause the test to fail with an `AssertionError`. |
+| `count-instead-of-exists.enabled` | `boolean` | `false` | Enable the `count-instead-of-exists` INFO detector. Off by default because it can fire on legitimate aggregate counts. |
+| `repeated-insert.exclude-tables` | `List<String>` | `["temp_*", "staging_*", "*_temp", "*_staging"]` | Table-name globs (case-insensitive, `*` wildcard) treated as deliberate staging targets — repeated single-row inserts into these tables are not flagged. |
 | `n-plus-one.threshold` | `int` | `3` | Number of times a structurally identical query must repeat before it is flagged as N+1. |
 | `offset-pagination.threshold` | `int` | `1000` | The OFFSET value that triggers a warning. |
 | `or-clause.threshold` | `int` | `3` | Number of OR conditions in a single WHERE clause before flagging. |
@@ -212,10 +215,11 @@ See the [Annotations Guide](annotations.md) for detailed usage patterns.
 |---|---|---|---|
 | `suppress` | `String[]` | `{}` | Issue codes or qualified patterns to suppress. |
 | `failOn` | `IssueType[]` | `{}` (all confirmed) | Restrict which issue types cause a test failure. |
-| `nPlusOneThreshold` | `int` | `-1` (use default) | Override the N+1 detection threshold. |
-| `failOnDetection` | `boolean` | `true` | Whether to fail the test when confirmed issues are detected. |
+| `nPlusOneThreshold` | `int` | `-1` (use yml/default) | Override the N+1 detection threshold. |
+| `failOnDetection` | `BooleanOverride` | `INHERIT` (yml default: `true`) | Whether to fail the test when confirmed issues are detected. Use `BooleanOverride.TRUE`/`FALSE` to override. |
 | `baselinePath` | `String` | `""` (default) | Path to the baseline file. |
-| `autoOpenReport` | `boolean` | `false` | Open HTML report in browser after tests. |
+| `autoOpenReport` | `BooleanOverride` | `INHERIT` (yml default: `true`) | Open HTML report in browser after tests. Use `BooleanOverride.TRUE`/`FALSE` to override. |
+| `includeSetupQueries` | `boolean` | `false` | Include queries from `@BeforeEach`/`@AfterEach` in analysis. |
 
 ### Annotation-Based Configuration Examples
 
@@ -329,8 +333,9 @@ These can be passed via `-D` flags on the command line:
 
 ## Issue Types Reference
 
-All 64 issue codes that can be used in `suppress`, `failOn`, and `suppress-patterns`.
-Of these, 60 are actively emitted by 57 detection rules. The remaining 4 are disabled or reserved.
+All 66 issue codes that can be used in `suppress`, `failOn`, and `suppress-patterns`.
+Of these, 62 are actively emitted; the remaining 4 are disabled or reserved (see
+[Detection Rules Overview](../detections/overview.md#disabled-reserved-rules)).
 
 ### ERROR Severity (11 issue types)
 
@@ -411,6 +416,7 @@ Of these, 60 are actively emitted by 57 detection rules. The remaining 4 are dis
 | `mergeable-queries` | `MERGEABLE_QUERIES` | Multiple queries to same table could be merged |
 | `non-deterministic-pagination` | `NON_DETERMINISTIC_PAGINATION` | ORDER BY + LIMIT on non-unique column gives inconsistent results |
 | `force-index-hint` | `FORCE_INDEX_HINT` | FORCE/USE/IGNORE INDEX hint overrides optimizer decisions |
+| `find-by-id-for-association` | `FIND_BY_ID_FOR_ASSOCIATION` | `findById()` used only for FK association — consider `getReferenceById()` to avoid the SELECT |
 
 ---
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -4,6 +4,40 @@ Common issues and solutions when using QueryAudit.
 
 ---
 
+## "HikariDataSource has been closed" on Spring Boot 4.x
+
+**Symptom:** Tests fail with
+
+```
+org.springframework.transaction.CannotCreateTransactionException: Could not open JPA EntityManager
+Caused by: java.sql.SQLException: HikariDataSource (HikariPool-N) has been closed.
+  at net.ttddyy.dsproxy.support.ProxyDataSource.performProxyLogic(...)
+```
+
+after sweeping `@QueryAudit` across many `@SpringBootTest` classes.
+
+**Cause:** In query-audit 0.3.1 and earlier on Spring Boot 4.x with 30+ test contexts, Spring's
+destroy-method inference attached `close()` to the `ProxyDataSource` post-BPP instance, which then
+cascade-closed the underlying `HikariDataSource` of a still-cached sibling context. See
+[issue #153](https://github.com/haroya01/query-audit/issues/153) for the full analysis.
+
+**Fix:** **Upgrade to 0.3.2.** The post-BPP `DataSource` is now wrapped in a `NonClosingDataSource`
+decorator that does not implement `Closeable`/`AutoCloseable`, so Spring's destroy inference no
+longer cascades. Boot 3.x was never affected and continues to work unchanged.
+
+If you can't upgrade yet, the surgical escape hatch from #134/#142 still works:
+
+```yaml
+# application-test.yml
+query-audit:
+  wrap-data-source:
+    enabled: false   # Skip the auto-wrap. Note: @QueryAudit annotation still
+                     # triggers the same wrap path internally, so this only helps
+                     # if you don't use the annotation.
+```
+
+---
+
 ## QueryAudit Not Detecting Any Queries
 
 **Symptom:** Report shows `0 queries analyzed` even though your test executes SQL.

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,9 +83,9 @@ Catches N+1 queries, missing indexes, `SELECT *`, DML anti-patterns, batch inser
 
 <div class="qg-feature" markdown>
 
-### :material-check-decagram: 100% Reliable
+### :material-check-decagram: Structural Detection
 
-Confirmed detections are **structural** -- they inspect SQL text and index metadata, not runtime data. No flaky heuristics. No false positives. If QueryAudit flags it, it is a real problem.
+Confirmed detections are **structural** -- they inspect SQL text and index metadata, not runtime data. Heuristics live in the INFO tier so the WARNING/ERROR tier stays high-signal. False positives are tracked as bugs and fixed -- the goal is "if QueryAudit flags it as confirmed, it is a real problem worth investigating."
 
 </div>
 


### PR DESCRIPTION
## Summary

Pre-release doc review for 0.3.2. Fixes accuracy and completeness gaps found by reading every public-facing markdown against the actual source.

## What changed

### Critical correctness
- Dependency coordinates bumped `0.3.0` → `0.3.2` in README + all `getting-started/` docs.
- `failOnDetection` / `autoOpenReport` attribute types corrected from `boolean` to `BooleanOverride` in `annotations.md` and `configuration.md`. Added a short callout explaining why the tri-state enum exists. The code samples already used `BooleanOverride.FALSE` etc., so the docs were internally contradicting themselves before.
- `spring-boot.md` gavlyukovskiy integration example:
  - Listener attachment changed from a non-existent `getProxyConfig().getMethodListener().addListener(...)` to the supported `proxyDs.addListener(...)`.
  - Escape-hatch property changed from `query-audit.enabled: false` (which also disables `QueryInterceptor` and breaks `@QueryAudit`) to the surgical `query-audit.wrap-data-source.enabled: false` (added in #142).
- `installation.md` prereq table: Spring Boot `3.0+` → `3.x or 4.x (4.x requires 0.3.2+)`, reflecting the cascade-close fix in #154.

### Missing documentation
- `@QueryAudit.includeSetupQueries` (boolean, default `false`) added to attribute tables in `annotations.md` and `configuration.md`.
- `query-audit.wrap-data-source.enabled`, `count-instead-of-exists.enabled`, `repeated-insert.exclude-tables` added to the `configuration.md` properties table.
- `find-by-id-for-association` issue type added to the INFO list in `detections/overview.md` and `configuration.md`. Was the only enum entry not previously documented.
- New troubleshooting entry "HikariDataSource has been closed on Spring Boot 4.x" linking #153 and the `NonClosingDataSource` fix in 0.3.2.

### Tone
- `index.md` "100% Reliable / No false positives" softened to "Structural Detection". The pre-existing claim was contradicted by the closed false-positive issue list (#126, #127, #145, etc.) and by #147's structural FP risk.
- `detections/overview.md` "Confirmed (100% Reliable)" → "Confirmed (Structural / Pattern-based)" with the same softening.

### IssueType counts
- Real enum entries: **66** (the docs said 64). The two undocumented entries were `find-by-id-for-association` (added above) and `duplicate-query` had already been listed as reserved.
- Active issue types: **62** (the docs said 60).
- Detection rule count "57" was actually correct — verified via `grep -cE "new [A-Z][A-Za-z]+Detector\(" QueryAuditAnalyzer.java`.

## Test plan

- [x] All version strings now point at `0.3.2`.
- [x] `BooleanOverride` attribute usages match the source in `QueryAudit.java`.
- [x] Spring Boot 4 reference is consistent across installation, troubleshooting, and #153/#154 references.
- [x] `IssueType` total count (66) matches the enum.
- [ ] mkdocs build runs clean (run locally / in CI).

No source-code changes — docs/README only.