### PR TITLE
feat(junit5): add @ExpectQueries type-separated query budget annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ See the [Detection Rules Overview](https://haroya01.github.io/query-audit/detect
 | `@EnableQueryInspector` | Report-only mode -- runs all detections but never fails the test |
 | `@DetectNPlusOne` | Focused check -- fails only if N+1 query patterns are detected |
 | `@ExpectMaxQueryCount(n)` | Query budget -- fails if more than `n` queries are executed |
+| `@ExpectQueries(select=n, ...)` | Per-type query budget -- fails when a SELECT/INSERT/UPDATE/DELETE budget is exceeded |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes
 
 - **57 detection rules** covering N+1 queries, missing indexes, DML safety, locking risks, ORM anti-patterns, and more
 - **Zero configuration** -- add one annotation and go
+- **Per-type query budgets** -- `@ExpectQueries(select = 2, insert = 1)` fails the test when a SELECT / INSERT / UPDATE / DELETE budget is exceeded
 - **Actionable reports** -- every issue includes the SQL, table, column, and a concrete fix suggestion
 - **No production overhead** -- runs only in your test suite
 
@@ -216,6 +217,17 @@ See the [Detection Rules Overview](https://haroya01.github.io/query-audit/detect
 | `@DetectNPlusOne` | Focused check -- fails only if N+1 query patterns are detected |
 | `@ExpectMaxQueryCount(n)` | Query budget -- fails if more than `n` queries are executed |
 | `@ExpectQueries(select=n, ...)` | Per-type query budget -- fails when a SELECT/INSERT/UPDATE/DELETE budget is exceeded |
+
+Query budgets make per-test contracts explicit -- and `@ExpectQueries(insert = 0, update = 0, delete = 0)` turns a test into a read-only contract:
+
+```java
+@Test
+@ExpectQueries(select = 2, insert = 1)  // per-type budgets
+@ExpectMaxQueryCount(5)                 // total cap
+void createOrder() {
+    orderService.createOrder(request);
+}
+```
 
 ---
 

--- a/docs/guide/annotations.md
+++ b/docs/guide/annotations.md
@@ -13,6 +13,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 | `@EnableQueryInspector` | Class | Report-only mode, never fails | No |
 | `@DetectNPlusOne` | Class / Method | N+1 detection only | Yes (on N+1 only) |
 | `@ExpectMaxQueryCount` | Method | Assert max query count | Yes (on count exceeded) |
+| `@ExpectQueries` | Method | Assert per-type query budgets (SELECT/INSERT/UPDATE/DELETE) | Yes (on budget exceeded) |
 
 ### Annotation Attributes at a Glance
 
@@ -27,6 +28,10 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 | `includeSetupQueries` | `@QueryAudit` | `boolean` | `false` | Include `@BeforeEach`/`@AfterEach` queries in analysis |
 | `threshold` | `@DetectNPlusOne` | `int` | `3` | Repeated query count to consider N+1 |
 | `value` | `@ExpectMaxQueryCount` | `int` | *(required)* | Maximum number of queries allowed |
+| `select` | `@ExpectQueries` | `int` | `-1` (not verified) | Maximum SELECT queries allowed |
+| `insert` | `@ExpectQueries` | `int` | `-1` (not verified) | Maximum INSERT queries allowed |
+| `update` | `@ExpectQueries` | `int` | `-1` (not verified) | Maximum UPDATE queries allowed |
+| `delete` | `@ExpectQueries` | `int` | `-1` (not verified) | Maximum DELETE queries allowed |
 
 !!! info "Why `BooleanOverride` instead of `boolean`?"
     Java annotation attributes cannot distinguish between "explicitly set to default" and
@@ -311,6 +316,68 @@ Tip: Check the Query Patterns section in the report above to identify which quer
     `@ExpectMaxQueryCount` counts all query types, including INSERTs from test data setup.
     If you use `@BeforeEach` to seed data, those INSERTs are included in the count.
     Consider using a higher limit or moving setup to `@BeforeAll`.
+
+---
+
+## @ExpectQueries
+
+Asserts per-type query budgets for a test method. Each attribute limits one query type
+(SELECT / INSERT / UPDATE / DELETE) independently; attributes left at `-1` are not verified.
+
+```java
+@SpringBootTest
+@QueryAudit
+class OrderServiceTest {
+
+    @Test
+    @ExpectQueries(select = 2, insert = 1)
+    void createOrder() {
+        orderService.createOrder(request);
+        // Fails if more than 2 SELECTs or more than 1 INSERT are executed
+    }
+
+    @Test
+    @ExpectQueries(insert = 0, update = 0, delete = 0)
+    void findOrderById() {
+        orderService.findById(1L);
+        // A read-only contract: any write query fails the test
+    }
+}
+```
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `select` | `int` | `-1` (not verified) | Maximum SELECT queries allowed |
+| `insert` | `int` | `-1` (not verified) | Maximum INSERT queries allowed |
+| `update` | `int` | `-1` (not verified) | Maximum UPDATE queries allowed |
+| `delete` | `int` | `-1` (not verified) | Maximum DELETE queries allowed |
+
+### Failure Message
+
+When a budget is exceeded, every query of the violated type is listed with its call site:
+
+```
+QueryAudit: createOrder() exceeded its query budget.
+SELECT: executed 3, expected at most 2.
+  select * from orders where customer_id = ?
+    at com.example.OrderService.createOrder:42
+  select * from members where id = ?
+    at com.example.OrderService.loadCustomer:57
+  ...
+```
+
+!!! tip "Use `0` to forbid a query type"
+    `@ExpectQueries(insert = 0, update = 0, delete = 0)` turns a test into a read-only
+    contract -- useful for guarding query-only endpoints against accidental writes.
+
+!!! warning "Counts ALL queries"
+    Like `@ExpectMaxQueryCount`, budgets count queries from the whole test lifecycle,
+    including INSERTs from `@BeforeEach` data setup.
+
+`@ExpectQueries` can be combined with `@ExpectMaxQueryCount`: the latter caps the total
+while the former constrains individual types.
 
 ---
 

--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -24,6 +24,11 @@ OrderServiceTest > findRecentOrders_shouldUseIndex FAILED
         Suggestion: CREATE INDEX idx_orders_user_id ON orders (user_id);
 ```
 
+Per-test query contracts fail the build the same way: `@ExpectMaxQueryCount` caps the
+total query count, and `@ExpectQueries` sets independent SELECT / INSERT / UPDATE / DELETE
+budgets -- catching a silently growing SELECT count or an accidental write on a read-only
+path in CI. See the [Annotations Guide](annotations.md#expectqueries) for details.
+
 ---
 
 ## GitHub Actions

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/ExpectQueries.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/ExpectQueries.java
@@ -1,0 +1,52 @@
+package io.queryaudit.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Fails the test when the number of executed queries of a given type exceeds its declared budget.
+ * Each attribute limits one query type independently; attributes left at {@code -1} are not
+ * verified.
+ *
+ * <p>Complements {@link ExpectMaxQueryCount}, which limits the total query count regardless of
+ * type. Both annotations can be combined on the same test method.
+ *
+ * <pre>{@code
+ * @Test
+ * @ExpectQueries(select = 2, insert = 1)
+ * void createOrder() {
+ *     orderService.createOrder(request);
+ *     // fails if more than 2 SELECTs or more than 1 INSERT are executed
+ * }
+ * }</pre>
+ *
+ * <p>A budget of {@code 0} forbids that query type entirely. For example
+ * {@code @ExpectQueries(insert = 0, update = 0, delete = 0)} asserts that a read-only path performs
+ * no writes.
+ *
+ * <p>When a budget is exceeded, the failure message lists every query of the violated type together
+ * with its call site.
+ *
+ * @author haroya
+ * @since 0.4.0
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(QueryAuditExtension.class)
+public @interface ExpectQueries {
+
+  /** Maximum number of SELECT queries allowed, or {@code -1} to skip verification. */
+  int select() default -1;
+
+  /** Maximum number of INSERT queries allowed, or {@code -1} to skip verification. */
+  int insert() default -1;
+
+  /** Maximum number of UPDATE queries allowed, or {@code -1} to skip verification. */
+  int update() default -1;
+
+  /** Maximum number of DELETE queries allowed, or {@code -1} to skip verification. */
+  int delete() default -1;
+}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -10,6 +10,7 @@ import io.queryaudit.core.interceptor.LazyLoadTracker;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import io.queryaudit.core.model.*;
 import io.queryaudit.core.model.LifecyclePhase;
+import io.queryaudit.core.parser.SqlParser;
 import io.queryaudit.core.regression.QueryCountBaseline;
 import io.queryaudit.core.regression.QueryCountRegressionDetector;
 import io.queryaudit.core.regression.QueryCounts;
@@ -25,6 +26,7 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.extension.*;
 
@@ -228,6 +230,9 @@ public class QueryAuditExtension
 
     // --- @ExpectMaxQueryCount ---
     checkMaxQueryCount(context, queries, testName);
+
+    // --- @ExpectQueries ---
+    checkExpectQueries(context, queries, testName);
 
     // --- @DetectNPlusOne ---
     checkDetectNPlusOne(context, report, testName);
@@ -453,6 +458,78 @@ public class QueryAuditExtension
                   + "Tip: Check the Query Patterns section in the report above to identify which queries to optimize.",
               testName, actual, max));
     }
+  }
+
+  private void checkExpectQueries(
+      ExtensionContext context, List<QueryRecord> queries, String testName) {
+    ExpectQueries annotation = context.getRequiredTestMethod().getAnnotation(ExpectQueries.class);
+    if (annotation == null) return;
+
+    String failure = buildExpectQueriesFailureMessage(annotation, queries, testName);
+    if (failure != null) {
+      throw new AssertionError(failure);
+    }
+  }
+
+  /**
+   * Builds the failure message for {@link ExpectQueries}, or returns {@code null} when every
+   * declared budget is respected. Package-private for testing.
+   */
+  static String buildExpectQueriesFailureMessage(
+      ExpectQueries annotation, List<QueryRecord> queries, String testName) {
+    StringBuilder violations = new StringBuilder();
+    appendBudgetViolation(
+        violations, "SELECT", annotation.select(), queries, SqlParser::isSelectQuery);
+    appendBudgetViolation(
+        violations, "INSERT", annotation.insert(), queries, SqlParser::isInsertQuery);
+    appendBudgetViolation(
+        violations, "UPDATE", annotation.update(), queries, SqlParser::isUpdateQuery);
+    appendBudgetViolation(
+        violations, "DELETE", annotation.delete(), queries, SqlParser::isDeleteQuery);
+
+    if (violations.length() == 0) {
+      return null;
+    }
+    return "QueryAudit: " + testName + " exceeded its query budget.\n" + violations;
+  }
+
+  /**
+   * Appends one violation block when the given type exceeds its budget: a summary line followed by
+   * every query of that type with its call site. A negative budget means "not verified".
+   */
+  private static void appendBudgetViolation(
+      StringBuilder sb,
+      String type,
+      int max,
+      List<QueryRecord> queries,
+      Predicate<String> typeMatcher) {
+    if (max < 0) {
+      return;
+    }
+    List<QueryRecord> matched = queries.stream().filter(q -> typeMatcher.test(q.sql())).toList();
+    if (matched.size() <= max) {
+      return;
+    }
+
+    sb.append(String.format("%s: executed %d, expected at most %d.\n", type, matched.size(), max));
+    for (QueryRecord query : matched) {
+      String sql = query.sql();
+      sb.append("  ").append(sql.length() > 100 ? sql.substring(0, 100) + "..." : sql);
+      String callSite = firstStackFrame(query.stackTrace());
+      if (callSite != null) {
+        sb.append("\n    at ").append(callSite);
+      }
+      sb.append('\n');
+    }
+  }
+
+  /** Returns the first (innermost application) frame of a recorded stack trace. */
+  private static String firstStackFrame(String stackTrace) {
+    if (stackTrace == null || stackTrace.isEmpty()) {
+      return null;
+    }
+    int newline = stackTrace.indexOf('\n');
+    return newline < 0 ? stackTrace : stackTrace.substring(0, newline);
   }
 
   private void checkDetectNPlusOne(

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/ExpectQueriesMessageTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/ExpectQueriesMessageTest.java
@@ -1,0 +1,158 @@
+package io.queryaudit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.QueryRecord;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link ExpectQueries} budget verification implemented in {@link
+ * QueryAuditExtension#buildExpectQueriesFailureMessage}.
+ */
+class ExpectQueriesMessageTest {
+
+  private static final String CALL_SITE = "com.example.OrderService.createOrder:42";
+
+  /** Annotation fixtures — budgets are read from these methods via reflection. */
+  @SuppressWarnings("unused")
+  private static class Fixtures {
+
+    @ExpectQueries(select = 1)
+    void selectBudgetOne() {}
+
+    @ExpectQueries(insert = 2)
+    void insertBudgetTwo() {}
+
+    @ExpectQueries(select = 0, update = 0)
+    void selectAndUpdateForbidden() {}
+
+    @ExpectQueries(insert = 0, update = 0, delete = 0)
+    void readOnly() {}
+
+    @ExpectQueries
+    void noBudgets() {}
+  }
+
+  private static ExpectQueries budget(String fixtureMethod) throws NoSuchMethodException {
+    return Fixtures.class.getDeclaredMethod(fixtureMethod).getAnnotation(ExpectQueries.class);
+  }
+
+  private static QueryRecord query(String sql) {
+    return new QueryRecord(sql, 0, 0, CALL_SITE);
+  }
+
+  @Test
+  @DisplayName("Fails when the SELECT budget is exceeded, listing SQL and call site")
+  void failsWhenSelectBudgetExceeded() throws NoSuchMethodException {
+    List<QueryRecord> queries =
+        List.of(query("select * from orders"), query("select * from members"));
+
+    String message =
+        QueryAuditExtension.buildExpectQueriesFailureMessage(
+            budget("selectBudgetOne"), queries, "createOrder()");
+
+    assertThat(message)
+        .contains("createOrder()")
+        .contains("SELECT: executed 2, expected at most 1")
+        .contains("select * from orders")
+        .contains("select * from members")
+        .contains("at " + CALL_SITE);
+  }
+
+  @Test
+  @DisplayName("Passes when the count equals the budget exactly")
+  void passesAtExactBudget() throws NoSuchMethodException {
+    List<QueryRecord> queries = List.of(query("select * from orders"));
+
+    String message =
+        QueryAuditExtension.buildExpectQueriesFailureMessage(
+            budget("selectBudgetOne"), queries, "createOrder()");
+
+    assertThat(message).isNull();
+  }
+
+  @Test
+  @DisplayName("Ignores query types left at the default -1")
+  void ignoresTypesLeftAtDefault() throws NoSuchMethodException {
+    List<QueryRecord> queries =
+        List.of(
+            query("select * from orders"),
+            query("insert into orders (id) values (1)"),
+            query("update orders set status = 'PAID'"),
+            query("delete from carts where id = 1"));
+
+    String message =
+        QueryAuditExtension.buildExpectQueriesFailureMessage(
+            budget("noBudgets"), queries, "createOrder()");
+
+    assertThat(message).isNull();
+  }
+
+  @Test
+  @DisplayName("Counts only queries of the budgeted type")
+  void countsOnlyMatchingType() throws NoSuchMethodException {
+    List<QueryRecord> queries =
+        List.of(
+            query("select * from orders"),
+            query("select * from members"),
+            query("select * from teams"),
+            query("insert into orders (id) values (1)"),
+            query("insert into orders (id) values (2)"));
+
+    String message =
+        QueryAuditExtension.buildExpectQueriesFailureMessage(
+            budget("insertBudgetTwo"), queries, "createOrder()");
+
+    assertThat(message).isNull();
+  }
+
+  @Test
+  @DisplayName("Reports every violated type in a single failure")
+  void reportsEveryViolatedType() throws NoSuchMethodException {
+    List<QueryRecord> queries =
+        List.of(
+            query("select * from orders"),
+            query("update orders set status = 'PAID'"),
+            query("insert into audit_log (id) values (1)"));
+
+    String message =
+        QueryAuditExtension.buildExpectQueriesFailureMessage(
+            budget("selectAndUpdateForbidden"), queries, "createOrder()");
+
+    assertThat(message)
+        .contains("SELECT: executed 1, expected at most 0")
+        .contains("UPDATE: executed 1, expected at most 0")
+        .doesNotContain("INSERT:");
+  }
+
+  @Test
+  @DisplayName("A zero budget blocks all DML on a read-only path")
+  void zeroBudgetBlocksDml() throws NoSuchMethodException {
+    List<QueryRecord> queries =
+        List.of(query("select * from orders"), query("delete from orders where id = 1"));
+
+    String message =
+        QueryAuditExtension.buildExpectQueriesFailureMessage(
+            budget("readOnly"), queries, "listOrders()");
+
+    assertThat(message)
+        .contains("DELETE: executed 1, expected at most 0")
+        .doesNotContain("SELECT:");
+  }
+
+  @Test
+  @DisplayName("Truncates long SQL to 100 characters in the failure message")
+  void truncatesLongSql() throws NoSuchMethodException {
+    String longSql =
+        "select column_name_padding from a_very_long_table_name where " + "x".repeat(80);
+    List<QueryRecord> queries = List.of(query(longSql), query("select 1"));
+
+    String message =
+        QueryAuditExtension.buildExpectQueriesFailureMessage(
+            budget("selectBudgetOne"), queries, "createOrder()");
+
+    assertThat(message).contains(longSql.substring(0, 100) + "...").doesNotContain(longSql);
+  }
+}

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/QueryAuditJpaIntegrationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/QueryAuditJpaIntegrationTest.java
@@ -217,6 +217,15 @@ class QueryAuditJpaIntegrationTest {
       assertThat(selects).isGreaterThanOrEqualTo(2);
       assertThat(deletes).isZero();
     }
+
+    @Test
+    @ExpectQueries(select = 50, delete = 0)
+    @ExpectMaxQueryCount(50)
+    @DisplayName("Combines with @ExpectMaxQueryCount on the same test method")
+    void combinesWithMaxQueryCount() {
+      memberRepository.findByStatus("ACTIVE");
+      teamRepository.findAll();
+    }
   }
 
   // ── @DetectNPlusOne ─────────────────────────────────────────────────

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/QueryAuditJpaIntegrationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/QueryAuditJpaIntegrationTest.java
@@ -10,9 +10,11 @@ import io.queryaudit.core.model.Issue;
 import io.queryaudit.core.model.IssueType;
 import io.queryaudit.core.model.QueryAuditReport;
 import io.queryaudit.core.model.QueryRecord;
+import io.queryaudit.core.parser.SqlParser;
 import io.queryaudit.core.reporter.HtmlReportAggregator;
 import io.queryaudit.junit5.EnableQueryInspector;
 import io.queryaudit.junit5.ExpectMaxQueryCount;
+import io.queryaudit.junit5.ExpectQueries;
 import io.queryaudit.junit5.integration.entity.Member;
 import io.queryaudit.junit5.integration.entity.Team;
 import io.queryaudit.junit5.integration.repository.MemberRepository;
@@ -183,6 +185,37 @@ class QueryAuditJpaIntegrationTest {
       queryInterceptor.stop();
 
       assertThat(queryInterceptor.getRecordedQueries().size()).isGreaterThan(1);
+    }
+  }
+
+  // ── @ExpectQueries ──────────────────────────────────────────────────
+
+  @Nested
+  @DisplayName("@ExpectQueries")
+  class ExpectQueriesTests {
+
+    @Test
+    @ExpectQueries(select = 50, update = 0, delete = 0)
+    @DisplayName("Passes when per-type query counts stay within their budgets")
+    void passesWithinBudgets() {
+      memberRepository.findByStatus("ACTIVE");
+      teamRepository.findAll();
+    }
+
+    @Test
+    @DisplayName("Programmatic verification that real captured queries classify by type")
+    void classifiesRealQueriesByType() {
+      queryInterceptor.start();
+      memberRepository.findByStatus("ACTIVE");
+      teamRepository.findAll();
+      queryInterceptor.stop();
+
+      List<QueryRecord> queries = queryInterceptor.getRecordedQueries();
+      long selects = queries.stream().filter(q -> SqlParser.isSelectQuery(q.sql())).count();
+      long deletes = queries.stream().filter(q -> SqlParser.isDeleteQuery(q.sql())).count();
+
+      assertThat(selects).isGreaterThanOrEqualTo(2);
+      assertThat(deletes).isZero();
     }
   }
 


### PR DESCRIPTION
## Approved Issue
Closes #50

## What
Adds `@ExpectQueries`, a method-level annotation that sets independent query budgets per type (`select` / `insert` / `update` / `delete`). Attributes left at `-1` are not verified, and a budget of `0` forbids that query type entirely — a read-only contract. When a budget is exceeded the test fails with every query of the violated type and its call site.

Verification runs in `QueryAuditExtension` right after the existing `@ExpectMaxQueryCount` check and reuses the `SqlParser` prefix classifiers, so both annotations can be combined on the same test. Docs updated (annotations guide + README).

## Why
`@ExpectMaxQueryCount` can only cap the total, so a test cannot express contracts like "this read path must not write" or "creating an order takes at most 2 SELECTs and 1 INSERT". Per-type budgets catch silently growing SELECTs from lazy associations in CI and block accidental DML in read-only APIs, with no false positives since the expected values are declared by the developer.

## How to test
`./gradlew :query-audit-junit5:test`
- `ExpectQueriesMessageTest` — exceeded / exact-boundary / default `-1` / type isolation / multi-type violation / zero-budget DML block / SQL truncation
- `QueryAuditJpaIntegrationTest$ExpectQueriesTests` — annotation passes against real captured H2 queries, plus per-type classification of real SQL

## Checklist
- [x] `./gradlew build` passes
- [x] Tests added (true positive + false positive)
- [x] False positive test suites still pass
- [x] Commit messages follow conventional commits