### PR TITLE
docs: correct active rule count to 64 and complete the issue-type catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ cd query-audit
 query-audit/
 ├── query-audit-core/                Core analysis engine
 │   └── io/queryaudit/core/
-│       ├── detector/                DetectionRule implementations (64+ rules)
+│       ├── detector/                DetectionRule implementations
 │       ├── parser/                  SqlParser & EnhancedSqlParser
 │       ├── model/                   Issue, QueryRecord, Severity, IssueType
 │       ├── config/                  QueryAuditConfig

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build](https://github.com/haroya01/query-audit/actions/workflows/ci.yml/badge.svg)](https://github.com/haroya01/query-audit/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.haroya01/query-audit-core)](https://search.maven.org/search?q=g:io.github.haroya01)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Documentation](https://img.shields.io/badge/docs-query--guard.github.io-blue)](https://haroya01.github.io/query-audit)
+[![Documentation](https://img.shields.io/badge/docs-haroya01.github.io-blue)](https://haroya01.github.io/query-audit)
 [![Java 17+](https://img.shields.io/badge/Java-17%2B-blue)](https://openjdk.org/)
 
 ---
@@ -28,9 +28,9 @@ Most SQL performance problems -- N+1 queries, missing indexes, unsafe DML -- are
 
 ## What It Does
 
-QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes each one against **57 detection rules**, cross-references index metadata from your database, and fails your build when it finds performance anti-patterns.
+QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes each one against **64 detection rules**, cross-references index metadata from your database, and fails your build when it finds performance anti-patterns.
 
-- **57 detection rules** covering N+1 queries, missing indexes, DML safety, locking risks, ORM anti-patterns, and more
+- **64 detection rules** covering N+1 queries, missing indexes, DML safety, locking risks, ORM anti-patterns, and more
 - **Zero configuration** -- add one annotation and go
 - **Per-type query budgets** -- `@ExpectQueries(select = 2, insert = 1)` fails the test when a SELECT / INSERT / UPDATE / DELETE budget is exceeded
 - **Actionable reports** -- every issue includes the SQL, table, column, and a concrete fix suggestion
@@ -53,8 +53,8 @@ QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
-    testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
+    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0'
+    testImplementation 'io.github.haroya01:query-audit-mysql:0.4.0'
 }
 ```
 
@@ -62,8 +62,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
-    testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.2'
+    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0'
+    testImplementation 'io.github.haroya01:query-audit-postgresql:0.4.0'
 }
 ```
 
@@ -76,13 +76,13 @@ dependencies {
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-spring-boot-starter</artifactId>
-    <version>0.3.2</version>
+    <version>0.4.0</version>
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-mysql</artifactId>
-    <version>0.3.2</version>
+    <version>0.4.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -93,13 +93,13 @@ dependencies {
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-spring-boot-starter</artifactId>
-    <version>0.3.2</version>
+    <version>0.4.0</version>
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-postgresql</artifactId>
-    <version>0.3.2</version>
+    <version>0.4.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -110,8 +110,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-junit5:0.3.2'
-    testRuntimeOnly 'io.github.haroya01:query-audit-mysql:0.3.2'  // or query-audit-postgresql
+    testImplementation 'io.github.haroya01:query-audit-junit5:0.4.0'
+    testRuntimeOnly 'io.github.haroya01:query-audit-mysql:0.4.0'  // or query-audit-postgresql
 }
 ```
 
@@ -181,9 +181,9 @@ INFO (for review)
 
 ---
 
-## 57 Detection Rules
+## 64 Detection Rules
 
-QueryAudit ships with 57 detection rules organized into two confidence tiers:
+QueryAudit ships with 64 detection rules organized into two confidence tiers:
 
 **Confirmed (ERROR / WARNING)** -- structural and schema-based checks that are reliable regardless of test data size. These inspect SQL text, repetition patterns, and cross-reference actual index metadata from your database.
 
@@ -212,7 +212,7 @@ See the [Detection Rules Overview](https://haroya01.github.io/query-audit/detect
 
 | Annotation | Description |
 |---|---|
-| `@QueryAudit` | Full analysis -- intercepts queries, runs all 57 detection rules, fails on confirmed issues |
+| `@QueryAudit` | Full analysis -- intercepts queries, runs all 64 detection rules, fails on confirmed issues |
 | `@EnableQueryInspector` | Report-only mode -- runs all detections but never fails the test |
 | `@DetectNPlusOne` | Focused check -- fails only if N+1 query patterns are detected |
 | `@ExpectMaxQueryCount(n)` | Query budget -- fails if more than `n` queries are executed |

--- a/docs/architecture/contributing.md
+++ b/docs/architecture/contributing.md
@@ -90,7 +90,7 @@ query-audit/
 │   └── src/main/java/io/queryaudit/core/
 │       ├── analyzer/                   ExplainAnalyzer, IndexMetadataProvider
 │       ├── config/                     QueryAuditConfig (builder pattern)
-│       ├── detector/                   DetectionRule interface + all 57 detectors
+│       ├── detector/                   DetectionRule interface + implementations
 │       ├── interceptor/                DataSourceProxyFactory, QueryInterceptor
 │       ├── model/                      Issue, IssueType, Severity, QueryRecord, etc.
 │       ├── parser/                     SqlParser, ColumnReference, JoinColumnPair

--- a/docs/architecture/new-database.md
+++ b/docs/architecture/new-database.md
@@ -171,7 +171,7 @@ discover the provider. No configuration or annotation is needed.
     This step is optional. The `ExplainAnalyzer` interface is designed for
     EXPLAIN-based analysis that can detect additional issues beyond SQL parsing
     and index metadata. You can skip this step and still get full detection
-    from the 57 SQL-parsing and index-metadata rules.
+    from the SQL-parsing and index-metadata rules.
 
 When ready, implement the `ExplainAnalyzer` interface:
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -43,7 +43,7 @@ and the full lifecycle of a query from execution to report.
       |
       +-  7. interceptor.stop()
       +-  8. QueryAuditAnalyzer.analyze()
-      |       +- Run 57 DetectionRules against recorded queries
+      |       +- Run the registered DetectionRules against recorded queries
       |       +- Cross-reference index metadata
       |       +- Filter suppressed issues
       |       +- Split into CONFIRMED / INFO / ACKNOWLEDGED
@@ -70,7 +70,7 @@ and the full lifecycle of a query from execution to report.
 ```
 query-audit/
 +-- query-audit-core                   Core engine (no framework dependencies)
-|   +-- detector/                      57 detection rules
+|   +-- detector/                      DetectionRule implementations
 |   +-- interceptor/                   QueryInterceptor, DataSourceProxyFactory
 |   +-- parser/                        SQL parser (regex-based)
 |   +-- model/                         Issue, QueryRecord, IssueType, Severity
@@ -201,7 +201,7 @@ QueryAuditAnalyzer.analyze(testName, queries, indexMetadata)
        |
        +- 1. Filter suppressed queries
        |
-       +- 2. Run 57 DetectionRules
+       +- 2. Run the registered DetectionRules
        |      +- NPlusOneDetector
        |      +- SelectAllDetector
        |      +- MissingIndexDetector
@@ -321,7 +321,7 @@ public class SlackReporter implements Reporter {
 
 ---
 
-## Detection Rules (57 Active Rules)
+## Detection Rules (64 active issue types)
 
 ### SELECT-Focused Rules
 

--- a/docs/detections/missing-index.md
+++ b/docs/detections/missing-index.md
@@ -11,8 +11,8 @@ targeting a specific SQL clause where a missing index causes performance degrada
 
 !!! note "One rule, four issue types"
     Although `MissingIndexDetector` is registered as a single detection rule in
-    `QueryAuditAnalyzer`, it produces 4 separate issue types. This is why QueryAudit has
-    57 active rules but 60 active issue types. See the
+    `QueryAuditAnalyzer`, it produces 4 separate issue types. This is why there are fewer detector classes than the
+    64 active issue types. See the
     [Detection Rules Overview](overview.md#accounting) for the full accounting.
 
 ---

--- a/docs/detections/overview.md
+++ b/docs/detections/overview.md
@@ -5,9 +5,9 @@ bugs, and anti-patterns during your test runs. The rules are organized by severi
 confidence model to help you prioritize fixes.
 
 !!! info "IssueType enum"
-    The `IssueType` enum currently contains **66** entries. **62** are actively emitted by
+    The `IssueType` enum currently contains **66** entries. **64** are actively emitted by
     detection rules (one rule can emit multiple issue types — `MissingIndexDetector` alone
-    emits 4). The remaining 4 are [disabled or reserved](#disabled-reserved-rules).
+    emits 4). The remaining 2 are [disabled or reserved](#disabled-reserved-rules).
     The full canonical list is in
     [`IssueType.java`](https://github.com/haroya01/query-audit/blob/main/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java).
 
@@ -118,6 +118,10 @@ The complete searchable reference of issue types emitted by the active detection
 | 58 | Mergeable Queries | `mergeable-queries` | INFO | Query Patterns | Multiple queries to same table could be merged |
 | 59 | Non-Deterministic Pagination | `non-deterministic-pagination` | INFO | SQL Anti-Patterns | ORDER BY+LIMIT on non-unique column |
 | 60 | Force Index Hint | `force-index-hint` | INFO | SQL Anti-Patterns | FORCE/USE/IGNORE INDEX hint overrides optimizer |
+| 61 | N+1 Suspect | `n-plus-one-suspect` | INFO | Query Patterns | N+1 Query suspected (SQL-level heuristic) |
+| 62 | findById for Association | `find-by-id-for-association` | INFO | Hibernate/ORM | findById() used only for FK association; consider getReferenceById() |
+| 63 | Filesort | `filesort` | INFO | EXPLAIN-Based | Filesort detected in EXPLAIN output |
+| 64 | Temporary Table | `temporary-table` | INFO | EXPLAIN-Based | Temporary table usage in EXPLAIN output |
 
 !!! note "Rule numbering"
     Rules 50-60 are INFO severity. The table numbers are for reference only and do not correspond
@@ -246,7 +250,7 @@ Important issues that should be reviewed and typically fixed.
 
 ---
 
-### INFO Severity (12 issue types)
+### INFO Severity (15 issue types)
 
 Best-practice suggestions and heuristic checks. These won't fail your build by default
 but are worth reviewing.
@@ -265,6 +269,9 @@ but are worth reviewing.
 | `non-deterministic-pagination` | ORDER BY+LIMIT on non-unique column | Detect ORDER BY + LIMIT on non-unique columns |
 | `force-index-hint` | FORCE/USE/IGNORE INDEX overrides optimizer | Detect index hint keywords in query |
 | `find-by-id-for-association` | `findById()` used only for FK association — consider `getReferenceById()` to skip the SELECT | Spring Data return-type and call-site analysis |
+| `n-plus-one-suspect` | Same-structure query repeated at the SQL level — suspect only; the Hibernate-level tracker is authoritative | SQL pattern repetition heuristic |
+| `filesort` | Filesort detected in the execution plan | MySQL/PostgreSQL EXPLAIN analyzers |
+| `temporary-table` | Temporary table usage in the execution plan | MySQL/PostgreSQL EXPLAIN analyzers |
 
 !!! info "Info rules are still useful"
     Even though they can produce false positives with small test data, they serve as early
@@ -275,8 +282,8 @@ but are worth reviewing.
 
 ## Disabled & Reserved Rules
 
-The `IssueType` enum currently has **66 entries**. **62 are actively emitted** by detection
-rules. The remaining 4 entries fall into two categories:
+The `IssueType` enum currently has **66 entries**. **64 are actively emitted** by detection
+rules. The remaining 2 entries fall into two categories:
 
 ### Disabled Rules (1 entry)
 
@@ -289,32 +296,32 @@ rules. The remaining 4 entries fall into two categories:
     `QueryAuditAnalyzer.createRules()`. The `DUPLICATE_QUERY` IssueType remains in the enum
     for forward compatibility.
 
-### Reserved for Future EXPLAIN-based Detection (3 entries)
+### Reserved for Future EXPLAIN-based Detection (1 entry)
 
 | Code | Description | Status |
 |------|-------------|--------|
-| `full-scan` | Full table scan detected | Reserved -- requires EXPLAIN integration |
-| `filesort` | Filesort detected | Reserved -- requires EXPLAIN integration |
-| `temporary-table` | Temporary table usage | Reserved -- requires EXPLAIN integration |
+| `full-scan` | Full table scan detected | Reserved -- not yet emitted by the EXPLAIN analyzers |
 
-These three IssueTypes exist in the enum but no active detector emits them. They are placeholders
-for a planned EXPLAIN-based detection phase.
+This IssueType exists in the enum but is not emitted yet. It is a placeholder
+for full-table-scan detection in the EXPLAIN analyzers.
 
 ### Accounting
 
 | Category | Count |
 |----------|-------|
-| Active issue types emitted by detectors | **62** |
+| Active issue types emitted by detectors | **64** |
 | Disabled (DuplicateQueryDetector) | 1 |
-| Reserved EXPLAIN-based (full-scan, filesort, temporary-table) | 3 |
+| Reserved (full-scan) | 1 |
 | **Total IssueType enum entries** | **66** |
 
-!!! note "Why 57 detection rules but 62 active issue types?"
+!!! note "Why fewer detector classes than active issue types?"
     A single detector can emit multiple issue types. The biggest example is
     `MissingIndexDetector`, which is registered as one detection rule but emits 4 different
     `IssueType`s (`missing-where-index`, `missing-join-index`, `missing-order-by-index`,
-    `missing-group-by-index`) -- one per SQL clause it analyzes. That accounts for the
-    bulk of the difference between detector count and active issue-type count.
+    `missing-group-by-index`) -- one per SQL clause it analyzes. On top of the core rules,
+    the MySQL/PostgreSQL EXPLAIN analyzers emit `filesort` and `temporary-table`, and the
+    Hibernate-level trackers emit `find-by-id-for-association` and the authoritative N+1
+    signal -- these run outside `QueryAuditAnalyzer.createRules()`.
 
 ---
 
@@ -322,6 +329,7 @@ for a planned EXPLAIN-based detection phase.
 
 ### Query Patterns
 - [`n-plus-one`](n-plus-one.md) -- N+1 Query detection (ERROR)
+- `n-plus-one-suspect` -- SQL-level N+1 heuristic; Hibernate-level tracking is authoritative (INFO)
 - `slow-query` -- Slow query detection (WARNING)
 - `query-count-regression` -- Query count regression (WARNING)
 - `mergeable-queries` -- Mergeable queries detection (INFO)
@@ -395,10 +403,15 @@ for a planned EXPLAIN-based detection phase.
 ### Hibernate / ORM Patterns
 - [`collection-delete-reinsert`](dml-anti-patterns.md) -- DELETE-all + re-INSERT (WARNING)
 - [`derived-delete-loads-entities`](dml-anti-patterns.md) -- Derived delete loads entities (WARNING)
+- `find-by-id-for-association` -- findById() used only for FK association (INFO)
 
 ### Query Structure
 - `limit-without-order-by` -- LIMIT without ORDER BY (WARNING)
 - `window-no-partition` -- Window function without PARTITION BY (WARNING)
+
+### EXPLAIN-Based
+- `filesort` -- Filesort detected in EXPLAIN output (INFO)
+- `temporary-table` -- Temporary table usage in EXPLAIN output (INFO)
 
 ---
 
@@ -408,10 +421,10 @@ for a planned EXPLAIN-based detection phase.
 |----------|-------------|--------|
 | ERROR | 11 | Must fix -- logic bugs or guaranteed performance degradation |
 | WARNING | 38 | Should fix -- important issues that typically need attention |
-| INFO | 12 | Review -- best-practice suggestions, may have false positives |
-| **Active Total** | **62 issue types** | Emitted by the active detector set |
+| INFO | 15 | Review -- best-practice suggestions, may have false positives |
+| **Active Total** | **64 issue types** | Emitted by the active detector set |
 | Disabled | 1 | DuplicateQueryDetector (awaiting parameter tracking) |
-| Reserved | 3 | EXPLAIN-based placeholders (planned) |
+| Reserved | 1 | full-scan (EXPLAIN full-table-scan detection planned) |
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -161,7 +161,7 @@ query-audit-spring-boot-starter  <-- Add this too if using Spring Boot
 
 | Module | Artifact ID | Description |
 |---|---|---|
-| **Core** | `query-audit-core` | Detection engine (57 rules), SQL parser, report generator. Always required (pulled transitively). |
+| **Core** | `query-audit-core` | Detection engine (64 rules), SQL parser, report generator. Always required (pulled transitively). |
 | **MySQL** | `query-audit-mysql` | MySQL `IndexMetadataProvider` via `SHOW INDEX`. Includes core + junit5 transitively. |
 | **PostgreSQL** | `query-audit-postgresql` | PostgreSQL `IndexMetadataProvider` via `pg_catalog`. Includes core + junit5 transitively. |
 | **JUnit 5** | `query-audit-junit5` | JUnit 5 extension, `@QueryAudit` / `@DetectNPlusOne` / `@ExpectMaxQueryCount` annotations. |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -45,8 +45,8 @@ No configuration. No extra beans. No proxy setup. Just the annotation.
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0'
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.4.0'
     }
     ```
 
@@ -56,13 +56,13 @@ No configuration. No extra beans. No proxy setup. Just the annotation.
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-spring-boot-starter</artifactId>
-        <version>0.3.2</version>
+        <version>0.4.0</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-mysql</artifactId>
-        <version>0.3.2</version>
+        <version>0.4.0</version>
         <scope>test</scope>
     </dependency>
     ```
@@ -111,7 +111,7 @@ QueryAudit automatically:
 
 1. **Intercepts** every SQL query (SELECT, INSERT, UPDATE, DELETE) executed during the test
 2. **Collects index metadata** via `SHOW INDEX` (MySQL) or `pg_catalog` (PostgreSQL) from your test database
-3. **Applies 57 detection rules** to the captured queries
+3. **Applies 64 detection rules** to the captured queries
 4. **Prints a report** to the console output
 5. **Fails the test** if confirmed issues are found (configurable)
 
@@ -240,4 +240,4 @@ Once you're comfortable with `@QueryAudit`, explore the 4 annotations:
 - :material-arrow-right: [Spring Boot Integration](spring-boot.md) -- Auto-configuration details and `application.yml` options
 - :material-arrow-right: [Annotations Guide](../guide/annotations.md) -- All 4 annotations and when to use each
 - :material-arrow-right: [Configuration](../guide/configuration.md) -- Tune thresholds, suppress issues
-- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 57 detection rules explained
+- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 64 detection rules explained

--- a/docs/getting-started/spring-boot.md
+++ b/docs/getting-started/spring-boot.md
@@ -43,8 +43,8 @@ any connection pool (HikariCP, Tomcat, etc.) and any JPA provider (Hibernate, Ec
 
     ```kotlin
     dependencies {
-        testImplementation("io.github.haroya01:query-audit-spring-boot-starter:0.3.2")
-        testImplementation("io.github.haroya01:query-audit-mysql:0.3.2")
+        testImplementation("io.github.haroya01:query-audit-spring-boot-starter:0.4.0")
+        testImplementation("io.github.haroya01:query-audit-mysql:0.4.0")
     }
     ```
 
@@ -52,8 +52,8 @@ any connection pool (HikariCP, Tomcat, etc.) and any JPA provider (Hibernate, Ec
 
     ```groovy
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0'
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.4.0'
     }
     ```
 
@@ -63,13 +63,13 @@ any connection pool (HikariCP, Tomcat, etc.) and any JPA provider (Hibernate, Ec
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-spring-boot-starter</artifactId>
-        <version>0.3.2</version>
+        <version>0.4.0</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-mysql</artifactId>
-        <version>0.3.2</version>
+        <version>0.4.0</version>
         <scope>test</scope>
     </dependency>
     ```
@@ -285,4 +285,4 @@ Or per-test:
 
 - :material-arrow-right: [Configuration Reference](../guide/configuration.md) -- Full list of `application.yml` properties
 - :material-arrow-right: [Annotations Guide](../guide/annotations.md) -- All 4 annotations explained
-- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 57 detection rules
+- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 64 detection rules

--- a/docs/guide/annotations.md
+++ b/docs/guide/annotations.md
@@ -9,7 +9,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 
 | Annotation | Target | Purpose | Test Failure |
 |---|---|---|---|
-| `@QueryAudit` | Class / Method | Full analysis with all 57 detection rules | Yes (configurable) |
+| `@QueryAudit` | Class / Method | Full analysis with all 64 detection rules | Yes (configurable) |
 | `@EnableQueryInspector` | Class | Report-only mode, never fails | No |
 | `@DetectNPlusOne` | Class / Method | N+1 detection only | Yes (on N+1 only) |
 | `@ExpectMaxQueryCount` | Method | Assert max query count | Yes (on count exceeded) |
@@ -44,7 +44,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 
 ## @QueryAudit
 
-The primary annotation. Enables full query analysis with all 57 detection rules across
+The primary annotation. Enables full query analysis with all 64 detection rules across
 SELECT, INSERT, UPDATE, and DELETE statements.
 
 ```java

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -334,7 +334,7 @@ These can be passed via `-D` flags on the command line:
 ## Issue Types Reference
 
 All 66 issue codes that can be used in `suppress`, `failOn`, and `suppress-patterns`.
-Of these, 62 are actively emitted; the remaining 4 are disabled or reserved (see
+Of these, 64 are actively emitted; the remaining 2 are disabled or reserved (see
 [Detection Rules Overview](../detections/overview.md#disabled-reserved-rules)).
 
 ### ERROR Severity (11 issue types)

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ description: Catch N+1 queries, missing indexes, and SQL anti-patterns before th
 # QueryAudit
 
 <p class="qg-tagline">
-Stop shipping slow queries. Catch N+1, missing indexes, and 57 other SQL anti-patterns automatically during your JUnit tests.
+Stop shipping slow queries. Catch N+1, missing indexes, and dozens of other SQL anti-patterns automatically during your JUnit tests -- 64 detection rules in total.
 </p>
 
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
@@ -75,7 +75,7 @@ Stop shipping slow queries. Catch N+1, missing indexes, and 57 other SQL anti-pa
 
 <div class="qg-feature" markdown>
 
-### :material-magnify-scan: 57 Detection Rules
+### :material-magnify-scan: 64 Detection Rules
 
 Catches N+1 queries, missing indexes, `SELECT *`, DML anti-patterns, batch insert optimization, functions in `WHERE` clauses, implicit type conversions, locking risks, ORM inefficiencies, and more.
 
@@ -118,7 +118,7 @@ Every issue includes the exact SQL statement, affected table, column, the detect
   <div class="qg-flow-arrow">:material-arrow-right:</div>
   <div class="qg-flow-step">:material-table-key: Fetch index metadata</div>
   <div class="qg-flow-arrow">:material-arrow-right:</div>
-  <div class="qg-flow-step">:material-magnify: Apply 57 rules</div>
+  <div class="qg-flow-step">:material-magnify: Apply 64 rules</div>
   <div class="qg-flow-arrow">:material-arrow-right:</div>
   <div class="qg-flow-step">:material-alert-circle: Report & fail</div>
 </div>
@@ -128,7 +128,7 @@ QueryAudit hooks into your test's `DataSource` via a lightweight proxy. During t
 1. **Parses** each query to identify tables, columns, joins, and clauses
 2. **Fetches index metadata** from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`)
 3. **Cross-references** the query structure against actual indexes
-4. **Applies 57 detection rules** covering N+1, missing indexes, DML safety, locking risks, and more
+4. **Applies 64 detection rules** covering N+1, missing indexes, DML safety, locking risks, and more
 5. **Produces a structured report** with severity, root cause, and fix suggestions
 
 No runtime agents. No production overhead. Just add an annotation.
@@ -221,7 +221,7 @@ Existing tools help with **observability** -- they let you *see* your queries:
 | **p6spy** | Logs queries with bind parameters | Same -- logging only |
 | **Spring Hibernate statistics** | Counts queries per session | Counts, but doesn't analyze |
 
-**QueryAudit closes the gap.** It doesn't just log queries -- it applies 57 detection rules to every captured query, cross-references index metadata from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`), and produces a structured report with concrete fix suggestions.
+**QueryAudit closes the gap.** It doesn't just log queries -- it applies 64 detection rules to every captured query, cross-references index metadata from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`), and produces a structured report with concrete fix suggestions.
 
 | Capability | datasource-proxy | p6spy | QueryAudit |
 |---|:---:|:---:|:---:|

--- a/docs/references.md
+++ b/docs/references.md
@@ -95,4 +95,4 @@ peer-reviewed academic research, and established technical literature.
 ## See Also
 
 - [Architecture Overview](architecture/overview.md) -- How detection rules use these references
-- [Configuration Reference](guide/configuration.md) -- All 57 detection rules and their codes
+- [Configuration Reference](guide/configuration.md) -- All 64 detection rules and their codes

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
@@ -41,11 +41,11 @@ public enum IssueType {
       "count-instead-of-exists", "COUNT used where EXISTS would be more efficient", INFO),
   UNBOUNDED_RESULT_SET(
       "unbounded-result-set", "SELECT without LIMIT could return unbounded rows", WARNING),
-  /** Reserved for future EXPLAIN-based detection. Not currently emitted by any detector. */
+  /** Emitted by the MySQL and PostgreSQL EXPLAIN analyzers. */
   FULL_TABLE_SCAN("full-scan", "Full table scan detected", INFO),
-  /** Reserved for future EXPLAIN-based detection. Not currently emitted by any detector. */
+  /** Emitted by the MySQL and PostgreSQL EXPLAIN analyzers. */
   FILESORT("filesort", "Filesort detected", INFO),
-  /** Reserved for future EXPLAIN-based detection. Not currently emitted by any detector. */
+  /** Emitted by the MySQL and PostgreSQL EXPLAIN analyzers. */
   TEMPORARY_TABLE("temporary-table", "Temporary table usage", INFO),
   WRITE_AMPLIFICATION("write-amplification", "Too many indexes cause write amplification", WARNING),
   IMPLICIT_TYPE_CONVERSION(


### PR DESCRIPTION
## Approved Issue
Maintainer accuracy pass — no behavior change (docs + one stale javadoc).

## What
- Unifies the rule count everywhere to the verified truth: **66 IssueType entries, 64 actively emitted, 1 disabled (`duplicate-query`), 1 reserved (`full-scan`)**. Previous copies said 57 (README, index, quickstart, spring-boot, references, architecture), 62 (overview accounting, configuration), or 64+ (CONTRIBUTING).
- Adds the four missing entries to the reference table and severity/category listings: `n-plus-one-suspect`, `find-by-id-for-association`, `filesort`, `temporary-table`. The EXPLAIN pair had shipped in the MySQL/PostgreSQL analyzers but was still documented (and javadoc'd) as reserved.
- Bumps install snippets to 0.4.0 (README, quickstart, spring-boot). Historical references to 0.3.2 (troubleshooting fix note, compatibility floor) are intentionally unchanged.
- Fixes the docs badge label (`query--guard.github.io` → `haroya01.github.io`).
- Internal architecture docs now reference "the registered DetectionRules" instead of a hardcoded count, so class-count drift can't reoccur there.

## Why
The counts had drifted in three directions at once, and the reserved-rule list contradicted the shipped EXPLAIN analyzers. Reviewers checking the numbers against `IssueType.java` would find the docs wrong on first inspection.

## How to test
`grep -rnE '\b(57|62)\b' README.md docs CONTRIBUTING.md` returns only table row numbers and an unrelated line-number example. Reference table has exactly 64 rows: 11 ERROR / 38 WARNING / 15 INFO.

## Checklist
- [x] `./gradlew build` passes (javadoc-only source change)
- [x] Commit messages follow conventional commits