### PR TITLE
test(spring-boot-starter): verify the #134 multi-context lifecycle on a real Spring Boot 4.x classpath

### DIFF
--- a/query-audit-spring-boot-starter/build.gradle
+++ b/query-audit-spring-boot-starter/build.gradle
@@ -1,3 +1,19 @@
+// Issue #134 is reported against Spring Boot 4.x while this module compiles and tests
+// against the 3.4.x baseline. The boot4Test source set runs the reported multi-context
+// scenario on an actual Boot 4.x classpath, isolated from the regular test task so the
+// baseline toolchain and the verification toolchain never mix.
+sourceSets {
+    boot4Test {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    boot4TestImplementation.extendsFrom implementation
+    boot4TestRuntimeOnly.extendsFrom runtimeOnly
+}
+
 dependencies {
     api project(':query-audit-core')
     api project(':query-audit-junit5')
@@ -14,4 +30,25 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-jdbc:3.4.1'
     testImplementation 'com.zaxxer:HikariCP:5.1.0'
     testImplementation 'com.h2database:h2:2.3.232'
+
+    boot4TestImplementation 'org.springframework.boot:spring-boot-starter-data-jpa:4.0.6'
+    boot4TestImplementation 'org.springframework.boot:spring-boot-starter-web:4.0.6'
+    boot4TestImplementation 'org.springframework.boot:spring-boot-starter-test:4.0.6'
+    // Boot 4.x split MockMvc test support out of spring-boot-test-autoconfigure
+    boot4TestImplementation 'org.springframework.boot:spring-boot-webmvc-test:4.0.6'
+    boot4TestImplementation 'com.h2database:h2:2.3.232'
+    boot4TestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.register('boot4Test', Test) {
+    description = 'Runs the issue #134 multi-context lifecycle scenario against Spring Boot 4.x.'
+    group = 'verification'
+    testClassesDirs = sourceSets.boot4Test.output.classesDirs
+    classpath = sourceSets.boot4Test.runtimeClasspath
+    useJUnitPlatform()
+    // Cache size 1 forces TestContext eviction between every signature switch — the
+    // cache pressure the #134 report only reached at 49 test classes against the
+    // default cache size of 32. (Pool creation count confirms contexts are rebuilt.)
+    systemProperty 'spring.test.context.cache.maxSize', '1'
+    shouldRunAfter tasks.named('test')
 }

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/AppTests.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/AppTests.java
@@ -1,0 +1,21 @@
+package io.queryaudit.spring.boot4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/** Context signature 1 of the issue #134 reproduction: plain {@code @SpringBootTest}. */
+@SpringBootTest
+@ActiveProfiles("test")
+class AppTests {
+
+  @Autowired private ItemService service;
+
+  @Test
+  void contextLoadsAndQueries() {
+    assertThat(service.findAll()).isNotNull();
+  }
+}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/Boot4Application.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/Boot4Application.java
@@ -1,0 +1,12 @@
+package io.queryaudit.spring.boot4;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal JPA + web application used to reproduce the multi-context DataSource lifecycle scenario
+ * from issue #134 on an actual Spring Boot 4.x classpath. The QueryAudit autoconfiguration is
+ * picked up from the starter's {@code AutoConfiguration.imports} exactly as in a user project — no
+ * {@code @QueryAudit} annotation anywhere, matching the report.
+ */
+@SpringBootApplication
+public class Boot4Application {}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ControllerTest.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ControllerTest.java
@@ -1,0 +1,30 @@
+package io.queryaudit.spring.boot4;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Context signature 2 of the issue #134 reproduction: {@code @AutoConfigureMockMvc} changes the
+ * TestContext cache key, so this class gets its own ApplicationContext and its own connection pool.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void itemsEndpointHitsTheDatabase() throws Exception {
+    mockMvc.perform(get("/items")).andExpect(status().isOk());
+  }
+}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/Item.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/Item.java
@@ -1,0 +1,30 @@
+package io.queryaudit.spring.boot4;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Item {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String name;
+
+  protected Item() {}
+
+  public Item(String name) {
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ItemController.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ItemController.java
@@ -1,0 +1,20 @@
+package io.queryaudit.spring.boot4;
+
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ItemController {
+
+  private final ItemService service;
+
+  public ItemController(ItemService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/items")
+  public List<Item> items() {
+    return service.findAll();
+  }
+}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ItemRepository.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ItemRepository.java
@@ -1,0 +1,5 @@
+package io.queryaudit.spring.boot4;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ItemService.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ItemService.java
@@ -1,0 +1,25 @@
+package io.queryaudit.spring.boot4;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ItemService {
+
+  private final ItemRepository repository;
+
+  public ItemService(ItemRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional
+  public Item create(String name) {
+    return repository.save(new Item(name));
+  }
+
+  @Transactional(readOnly = true)
+  public List<Item> findAll() {
+    return repository.findAll();
+  }
+}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/RepoTest.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/RepoTest.java
@@ -1,0 +1,27 @@
+package io.queryaudit.spring.boot4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Context signature 3 of the issue #134 reproduction: {@code @Transactional} test around the
+ * repository. Runs before {@link ServiceTest} (class-name order) and shares its cached context.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class RepoTest {
+
+  @Autowired private ItemRepository repository;
+
+  @Test
+  void saveAndLoad() {
+    repository.save(new Item("repo"));
+    assertThat(repository.findAll()).isNotEmpty();
+  }
+}

--- a/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ServiceTest.java
+++ b/query-audit-spring-boot-starter/src/boot4Test/java/io/queryaudit/spring/boot4/ServiceTest.java
@@ -1,0 +1,33 @@
+package io.queryaudit.spring.boot4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The reported victim of issue #134: runs last (class-name order), reuses the context cached by
+ * {@link RepoTest}, and in the report failed with {@code HikariDataSource has been closed} because
+ * a sibling context's shutdown had cascaded into this context's pool.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ServiceTest {
+
+  @Autowired private ItemService service;
+
+  @Test
+  void createAndList() {
+    service.create("svc");
+    assertThat(service.findAll()).isNotEmpty();
+  }
+
+  @Test
+  void listAgainOnReusedContext() {
+    assertThat(service.findAll()).isNotNull();
+  }
+}

--- a/query-audit-spring-boot-starter/src/boot4Test/resources/application-test.properties
+++ b/query-audit-spring-boot-starter/src/boot4Test/resources/application-test.properties
@@ -1,0 +1,8 @@
+# Shared in-memory database across all cached contexts, mirroring the single shared
+# MySQL instance in the issue #134 report. DB_CLOSE_DELAY keeps the schema alive
+# independent of any one pool's connections.
+spring.datasource.url=jdbc:h2:mem:boot4shared;DB_CLOSE_DELAY=-1;MODE=MySQL
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=update

--- a/query-audit-spring-boot-starter/src/boot4Test/resources/junit-platform.properties
+++ b/query-audit-spring-boot-starter/src/boot4Test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+# Deterministic class order so the scenario always runs as
+# AppTests -> ControllerTest -> RepoTest -> ServiceTest (the reported victim last).
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$ClassName


### PR DESCRIPTION
## Summary

Closes #134.

The root-cause fix shipped in 0.3.2 (#153, `NonClosingDataSource`), but it had only ever been verified on the Spring Boot 3.4.x baseline this module compiles against — never on the Boot 4.x classpath where the bug was reported. This PR adds that verification surface and documents the downstream A/B evidence that the fix resolves the reported failure.

## What's in the PR

A `boot4Test` source set in `query-audit-spring-boot-starter` that runs the report's exact topology on **Spring Boot 4.0.6**:

- Four `@SpringBootTest` classes mirroring the report's table (plain / `@Transactional` ×2 / `@AutoConfigureMockMvc`), deterministic class order, shared database, starter autoconfigured from the classpath — no `@QueryAudit` anywhere, matching the report.
- `spring.test.context.cache.maxSize=1` so TestContext eviction pressure occurs on every signature switch (the report only reached eviction at 49 test classes vs. the default cache size of 32).
- Run with `./gradlew :query-audit-spring-boot-starter:boot4Test`. Isolated from the regular `test` task so the 3.4.x baseline toolchain and the 4.x verification toolchain never mix.

Honest scope note: this suite **pins the lifecycle contract** on Boot 4.x — it does not reproduce the original crash. Reverting the #153 fix locally still passes this synthetic scenario; the failure only manifests at downstream scale. That's what the A/B below is for.

## Downstream A/B evidence (the original reporter's app, current suite)

Same machine, same database containers, same suite (3,045 tests across 125 `@SpringBootTest` classes), only the query-audit version changed:

| query-audit | Result |
|---|---|
| **0.3.1** (pre-fix) | **415 tests failed across 75 test classes** — every one `CannotCreateTransactionException` → `SQLException: HikariDataSource (HikariPool-3) has been closed` at `HikariDataSource.java:95`, the exact #134 stack |
| **0.4.0** (with #153) | **0 lifecycle failures.** 16 residual failures, all `SQLIntegrityConstraintViolationException` in one feed-search fixture family — stale local-DB rows from the aborted 0.3.1 runs, no lifecycle signature (the same suite is green in the app's CI) |

CI on the downstream app's main branch (0.4.0, Boot 4.0.6) has also been green continuously.

## Conclusion

- The #134 failure reproduces deterministically at scale on 0.3.1 and is gone on 0.4.0 with no other change — #153's `NonClosingDataSource` was the fix.
- The new `boot4Test` suite keeps the Boot 4.x multi-context lifecycle pinned in-repo so a future Spring upgrade or wrapping change that regresses it is caught here instead of downstream.
