### PR TITLE
feat(junit5): audit coverage mode 'all' with @QueryAuditExclude opt-out

### DIFF
--- a/docs/guide/annotations.md
+++ b/docs/guide/annotations.md
@@ -14,6 +14,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 | `@DetectNPlusOne` | Class / Method | N+1 detection only | Yes (on N+1 only) |
 | `@ExpectMaxQueryCount` | Method | Assert max query count | Yes (on count exceeded) |
 | `@ExpectQueries` | Method | Assert per-type query budgets (SELECT/INSERT/UPDATE/DELETE) | Yes (on budget exceeded) |
+| `@QueryAuditExclude` | Class / Method | Opt a test out of auditing (the `mode: all` escape hatch) | No |
 
 ### Annotation Attributes at a Glance
 
@@ -185,6 +186,37 @@ class OrderServiceTest {
 !!! tip "Use this for gradual adoption"
     Start with `@EnableQueryInspector` to see what QueryAudit finds without breaking
     your builds. Once you've reviewed the issues, switch to `@QueryAudit` to enforce them.
+
+---
+
+## @QueryAuditExclude
+
+Opts a test class or method out of auditing.
+
+Built for `mode: all` suites (see [Audit Coverage Mode](configuration.md#audit-coverage-mode)),
+where every test is audited by default and this is the escape hatch for tests that
+intentionally violate a rule — load-shape fixtures, migration replays, bulk seed helpers.
+
+```java
+@QueryAuditExclude   // intentionally replays thousands of single-row inserts
+class SeedDataReplayTest { ... }
+```
+
+Also honored in the default `annotated` mode: a method carrying `@QueryAuditExclude` is
+skipped even when its class is annotated with `@QueryAudit`.
+
+```java
+@QueryAudit
+class OrderServiceTest {
+
+    @Test
+    void findOrders() { ... }          // audited
+
+    @QueryAuditExclude
+    @Test
+    void bulkFixtureReplay() { ... }   // skipped
+}
+```
 
 ---
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -17,6 +17,7 @@ All properties are optional. The table below lists every supported key under the
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | `boolean` | `true` | Master switch for the entire auto-configuration. When `false`, the `QueryInterceptor` bean and the wrapping `BeanPostProcessor` are both skipped — the `@QueryAudit` annotation will not work either. Use `wrap-data-source.enabled: false` instead if you want to keep the interceptor active but skip the auto-wrap. |
+| `mode` | `String` | `"annotated"` | Which tests the JUnit extension audits: `annotated` (opt-in via `@QueryAudit`) or `all` (every test, opt-out via `@QueryAuditExclude`). `all` additionally requires JUnit extension autodetection — see [Audit Coverage Mode](#audit-coverage-mode). |
 | `wrap-data-source.enabled` | `boolean` | `true` | Surgical escape hatch (issue #134) — disables only the auto-wrap `BeanPostProcessor` while keeping `QueryInterceptor` and `QueryAuditConfig` beans active. Use this when integrating with an existing datasource-proxy (e.g. gavlyukovskiy). |
 | `fail-on-detection` | `boolean` | `true` | Whether confirmed issues (ERROR/WARNING) should cause the test to fail with an `AssertionError`. |
 | `count-instead-of-exists.enabled` | `boolean` | `false` | Enable the `count-instead-of-exists` INFO detector. Off by default because it can fire on legitimate aggregate counts. |
@@ -84,6 +85,51 @@ query-audit:
     output-dir: build/reports/query-audit
     show-info: true
 ```
+
+---
+
+## Audit Coverage Mode
+
+By default only tests that opt in via `@QueryAudit` (or a related annotation) are audited
+(`mode: annotated`). This keeps adoption friction low, but every unannotated test is a blind
+spot — a regression in an uncovered domain merges silently.
+
+`mode: all` flips the coverage model: **every test is audited**, and individual tests opt
+*out* with `@QueryAuditExclude`.
+
+Two switches are required:
+
+1. Register the extension suite-wide via JUnit's extension autodetection. In
+   `src/test/resources/junit-platform.properties`:
+
+   ```properties
+   junit.jupiter.extensions.autodetection.enabled=true
+   ```
+
+2. Set the mode — in `application.yml` for Spring projects:
+
+   ```yaml
+   query-audit:
+     mode: all
+   ```
+
+   or as a system property for any project: `./gradlew test -DqueryAudit.mode=all`
+   (the system property wins over the yml value).
+
+Enabling autodetection alone does **not** widen coverage: in the default `annotated` mode the
+extension stays inactive for classes that never opted in, and a class that ends up registered
+twice (autodetection + `@QueryAudit`) is audited exactly once.
+
+### Brownfield onboarding
+
+Turning `mode: all` on for an existing suite usually surfaces a wall of findings at once. The
+supported adoption path pairs it with the baseline:
+
+1. Enable `mode: all` as above.
+2. Record the current findings once into the baseline (see [Suppressing Issues](suppressing.md)).
+3. From then on, existing findings are frozen — only **new** violations fail the build.
+
+Coverage first, cleanup incrementally — the audit becomes a ratchet instead of a wall.
 
 ---
 
@@ -321,6 +367,7 @@ These can be passed via `-D` flags on the command line:
 
 | Property | Description |
 |---|---|
+| `-DqueryAudit.mode=all` | Audit every test regardless of annotations — see [Audit Coverage Mode](#audit-coverage-mode) |
 | `-DqueryAudit.updateBaseline=true` | Update the query count baseline file after test run |
 | `-DqueryAudit.countBaselinePath=path` | Override the query count baseline file path |
 | `-Dqueryaudit.autoOpenReport=true` | Force open HTML report in browser |

--- a/query-audit-core/src/main/java/io/queryaudit/core/config/AuditMode.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/AuditMode.java
@@ -1,0 +1,41 @@
+package io.queryaudit.core.config;
+
+import java.util.Locale;
+
+/**
+ * Controls which tests the JUnit extension audits.
+ *
+ * <ul>
+ *   <li>{@link #ANNOTATED} — only tests that opt in via {@code @QueryAudit} (or a related
+ *       annotation / direct {@code @ExtendWith}). The default, and the only behavior before 0.5.0.
+ *   <li>{@link #ALL} — every test in the suite is audited unless it opts out with
+ *       {@code @QueryAuditExclude}. Requires the extension to be registered globally, typically via
+ *       JUnit's extension autodetection ({@code junit.jupiter.extensions.autodetection.enabled}).
+ * </ul>
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+public enum AuditMode {
+  ANNOTATED,
+  ALL;
+
+  /**
+   * Parses a configuration value into an {@code AuditMode}. Case-insensitive; {@code null} and
+   * blank map to {@link #ANNOTATED} so absent configuration keeps the pre-0.5.0 behavior.
+   *
+   * @throws IllegalArgumentException on any other value, naming the accepted ones
+   */
+  public static AuditMode parse(String value) {
+    if (value == null || value.isBlank()) {
+      return ANNOTATED;
+    }
+    return switch (value.trim().toLowerCase(Locale.ROOT)) {
+      case "annotated" -> ANNOTATED;
+      case "all" -> ALL;
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown query-audit mode '" + value + "' — expected 'annotated' or 'all'");
+    };
+  }
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
@@ -48,6 +48,7 @@ public class QueryAuditConfig {
   private final RepositoryReturnTypeResolver repositoryReturnTypeResolver;
   private final boolean includeSetupQueries;
   private final boolean countInsteadOfExistsEnabled;
+  private final AuditMode auditMode;
 
   private QueryAuditConfig(Builder builder) {
     this.enabled = builder.enabled;
@@ -75,6 +76,7 @@ public class QueryAuditConfig {
     this.repositoryReturnTypeResolver = builder.repositoryReturnTypeResolver;
     this.includeSetupQueries = builder.includeSetupQueries;
     this.countInsteadOfExistsEnabled = builder.countInsteadOfExistsEnabled;
+    this.auditMode = builder.auditMode;
   }
 
   public static Builder builder() {
@@ -237,6 +239,16 @@ public class QueryAuditConfig {
     return countInsteadOfExistsEnabled;
   }
 
+  /**
+   * Returns which tests the JUnit extension audits: {@link AuditMode#ANNOTATED} (opt-in, the
+   * default) or {@link AuditMode#ALL} (opt-out via {@code @QueryAuditExclude}).
+   *
+   * @since 0.5.0
+   */
+  public AuditMode getAuditMode() {
+    return auditMode;
+  }
+
   public boolean isSuppressed(String issueCode, String table, String column) {
     if (suppressPatterns.isEmpty()) {
       return false;
@@ -254,9 +266,9 @@ public class QueryAuditConfig {
   }
 
   /**
-   * Cache of compiled word-boundary regexes for {@link #suppressQueries} patterns. The patterns
-   * are user-supplied, immutable for the lifetime of this config, and small (one entry per
-   * suppression rule); a plain {@link ConcurrentHashMap} is sufficient.
+   * Cache of compiled word-boundary regexes for {@link #suppressQueries} patterns. The patterns are
+   * user-supplied, immutable for the lifetime of this config, and small (one entry per suppression
+   * rule); a plain {@link ConcurrentHashMap} is sufficient.
    */
   private static final Map<String, Pattern> SUPPRESS_PATTERN_CACHE = new ConcurrentHashMap<>();
 
@@ -312,6 +324,7 @@ public class QueryAuditConfig {
     private RepositoryReturnTypeResolver repositoryReturnTypeResolver = null;
     private boolean includeSetupQueries = false;
     private boolean countInsteadOfExistsEnabled = false;
+    private AuditMode auditMode = AuditMode.ANNOTATED;
 
     /**
      * Creates a new builder pre-populated with all values from the given config. Useful for
@@ -343,6 +356,7 @@ public class QueryAuditConfig {
       b.slowQueryErrorMs = source.slowQueryErrorMs;
       b.repositoryReturnTypeResolver = source.repositoryReturnTypeResolver;
       b.countInsteadOfExistsEnabled = source.countInsteadOfExistsEnabled;
+      b.auditMode = source.auditMode;
       return b;
     }
 
@@ -506,6 +520,19 @@ public class QueryAuditConfig {
      */
     public Builder countInsteadOfExistsEnabled(boolean enabled) {
       this.countInsteadOfExistsEnabled = enabled;
+      return this;
+    }
+
+    /**
+     * Sets which tests the JUnit extension audits. {@code null} keeps the default ({@link
+     * AuditMode#ANNOTATED}).
+     *
+     * @since 0.5.0
+     */
+    public Builder auditMode(AuditMode auditMode) {
+      if (auditMode != null) {
+        this.auditMode = auditMode;
+      }
       return this;
     }
 

--- a/query-audit-core/src/test/java/io/queryaudit/core/config/AuditModeTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/config/AuditModeTest.java
@@ -1,0 +1,80 @@
+package io.queryaudit.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AuditMode (issue #163)")
+class AuditModeTest {
+
+  @Nested
+  @DisplayName("parse()")
+  class Parse {
+
+    @Test
+    @DisplayName("'all' parses to ALL, case- and whitespace-insensitive")
+    void parsesAll() {
+      assertThat(AuditMode.parse("all")).isEqualTo(AuditMode.ALL);
+      assertThat(AuditMode.parse("ALL")).isEqualTo(AuditMode.ALL);
+      assertThat(AuditMode.parse("  All ")).isEqualTo(AuditMode.ALL);
+    }
+
+    @Test
+    @DisplayName("'annotated' parses to ANNOTATED")
+    void parsesAnnotated() {
+      assertThat(AuditMode.parse("annotated")).isEqualTo(AuditMode.ANNOTATED);
+      assertThat(AuditMode.parse("ANNOTATED")).isEqualTo(AuditMode.ANNOTATED);
+    }
+
+    @Test
+    @DisplayName("null and blank keep the pre-0.5.0 default (ANNOTATED)")
+    void nullAndBlankDefaultToAnnotated() {
+      assertThat(AuditMode.parse(null)).isEqualTo(AuditMode.ANNOTATED);
+      assertThat(AuditMode.parse("")).isEqualTo(AuditMode.ANNOTATED);
+      assertThat(AuditMode.parse("   ")).isEqualTo(AuditMode.ANNOTATED);
+    }
+
+    @Test
+    @DisplayName("unknown values fail loudly, naming the accepted ones")
+    void unknownValueThrows() {
+      assertThatThrownBy(() -> AuditMode.parse("everything"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("everything")
+          .hasMessageContaining("annotated")
+          .hasMessageContaining("all");
+    }
+  }
+
+  @Nested
+  @DisplayName("QueryAuditConfig wiring")
+  class ConfigWiring {
+
+    @Test
+    @DisplayName("defaults to ANNOTATED")
+    void defaultsToAnnotated() {
+      assertThat(QueryAuditConfig.defaults().getAuditMode()).isEqualTo(AuditMode.ANNOTATED);
+    }
+
+    @Test
+    @DisplayName("builder sets ALL; null keeps the current value")
+    void builderSetsAndIgnoresNull() {
+      QueryAuditConfig all = QueryAuditConfig.builder().auditMode(AuditMode.ALL).build();
+      assertThat(all.getAuditMode()).isEqualTo(AuditMode.ALL);
+
+      QueryAuditConfig nullKept =
+          QueryAuditConfig.builder().auditMode(AuditMode.ALL).auditMode(null).build();
+      assertThat(nullKept.getAuditMode()).isEqualTo(AuditMode.ALL);
+    }
+
+    @Test
+    @DisplayName("Builder.from() copies the audit mode")
+    void builderFromCopies() {
+      QueryAuditConfig source = QueryAuditConfig.builder().auditMode(AuditMode.ALL).build();
+      assertThat(QueryAuditConfig.Builder.from(source).build().getAuditMode())
+          .isEqualTo(AuditMode.ALL);
+    }
+  }
+}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExclude.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExclude.java
@@ -1,0 +1,21 @@
+package io.queryaudit.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Opts a test class or method out of QueryAudit analysis.
+ *
+ * <p>Primarily for {@code mode: all} suites, where every test is audited by default and this is the
+ * escape hatch for tests that intentionally violate a rule (load-shape fixtures, migration replays,
+ * etc.). Also honored in the default {@code annotated} mode: a method carrying this annotation is
+ * skipped even when its class is annotated with {@code @QueryAudit}.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QueryAuditExclude {}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -3,6 +3,7 @@ package io.queryaudit.junit5;
 import io.queryaudit.core.analyzer.ExplainAnalyzer;
 import io.queryaudit.core.baseline.Baseline;
 import io.queryaudit.core.baseline.BaselineEntry;
+import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
 import io.queryaudit.core.detector.QueryAuditAnalyzer;
 import io.queryaudit.core.detector.RepositoryReturnTypeResolver;
@@ -64,6 +65,8 @@ public class QueryAuditExtension
   private static final String KEY_DATASOURCE = "dataSource";
   private static final String KEY_RETURN_TYPE_RESOLVER = "returnTypeResolver";
   private static final String KEY_DATASOURCE_HOOK_CLEANUP = "dataSourceHookCleanup";
+  private static final String KEY_ACTIVE = "auditActive";
+  private static final String KEY_AFTER_EACH_DONE = "afterEachDone";
 
   private static final QueryCountRegressionDetector REGRESSION_DETECTOR =
       new QueryCountRegressionDetector();
@@ -76,6 +79,22 @@ public class QueryAuditExtension
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
+    // With the ServiceLoader registration + JUnit extension autodetection, this callback runs for
+    // every test class in the suite. The activation decision (audit mode + annotations +
+    // @QueryAuditExclude) is made once per class and stored so the per-method callbacks can read
+    // it without re-resolving the Spring context.
+    ExtensionContext.Store activeStore = context.getStore(NAMESPACE);
+    boolean active = computeActive(context);
+    activeStore.put(KEY_ACTIVE, active);
+    if (!active) {
+      return;
+    }
+    if (activeStore.get(KEY_INTERCEPTOR) != null) {
+      // Extension registered twice for this class (autodetection + @ExtendWith/@QueryAudit) —
+      // the second instance must not re-wrap the DataSource or double-hook listeners.
+      return;
+    }
+
     QueryInterceptor interceptor = new QueryInterceptor();
 
     // Apply memory configuration from @QueryAudit or defaults
@@ -125,6 +144,9 @@ public class QueryAuditExtension
 
   @Override
   public void beforeEach(ExtensionContext context) {
+    if (!isAuditActive(context)) {
+      return;
+    }
     QueryInterceptor interceptor = getInterceptor(context);
     if (interceptor != null) {
       interceptor.start();
@@ -142,6 +164,9 @@ public class QueryAuditExtension
 
   @Override
   public void beforeTestExecution(ExtensionContext context) {
+    if (!isAuditActive(context)) {
+      return;
+    }
     QueryInterceptor interceptor = getInterceptor(context);
     if (interceptor != null) {
       interceptor.setPhase(LifecyclePhase.TEST);
@@ -153,6 +178,9 @@ public class QueryAuditExtension
 
   @Override
   public void afterTestExecution(ExtensionContext context) {
+    if (!isAuditActive(context)) {
+      return;
+    }
     QueryInterceptor interceptor = getInterceptor(context);
     if (interceptor != null) {
       interceptor.setPhase(LifecyclePhase.TEARDOWN);
@@ -163,6 +191,17 @@ public class QueryAuditExtension
 
   @Override
   public void afterEach(ExtensionContext context) {
+    if (!isAuditActive(context)) {
+      return;
+    }
+    // Method-level store: guards against double analysis when the extension is registered twice
+    // (autodetection + @ExtendWith/@QueryAudit).
+    ExtensionContext.Store methodStore = context.getStore(NAMESPACE);
+    if (methodStore.get(KEY_AFTER_EACH_DONE) != null) {
+      return;
+    }
+    methodStore.put(KEY_AFTER_EACH_DONE, Boolean.TRUE);
+
     QueryInterceptor interceptor = getInterceptor(context);
     if (interceptor == null) {
       return;
@@ -568,6 +607,94 @@ public class QueryAuditExtension
       }
       throw new AssertionError(sb.toString());
     }
+  }
+
+  // ── Audit activation (issue #163) ──────────────────────────────────
+
+  /**
+   * Decides whether this test class is audited. {@code @QueryAuditExclude} always wins. In {@link
+   * AuditMode#ALL} every non-excluded class is audited; in {@link AuditMode#ANNOTATED} (the
+   * default) only classes that opted in — via {@code @QueryAudit}, {@code @EnableQueryInspector},
+   * or a direct {@code @ExtendWith(QueryAuditExtension.class)} — are. The annotated-mode check
+   * exists because the ServiceLoader registration makes JUnit's extension autodetection register
+   * this extension suite-wide; without it, merely enabling autodetection would audit everything.
+   */
+  private boolean computeActive(ExtensionContext context) {
+    if (isClassExcluded(context.getRequiredTestClass())) {
+      return false;
+    }
+    if (resolveAuditMode(context) == AuditMode.ALL) {
+      return true;
+    }
+    return findAnnotation(context) != null
+        || hasEnableQueryInspector(context)
+        || hasDirectExtendWith(context);
+  }
+
+  /**
+   * Per-callback gate: the class-level decision cached by {@code beforeAll}, plus method-level
+   * {@code @QueryAuditExclude}. Falls back to computing when no cached flag exists — the case for
+   * method-level {@code @QueryAudit}, where the extension is registered for the method only and
+   * {@code beforeAll} never ran.
+   */
+  private boolean isAuditActive(ExtensionContext context) {
+    Optional<Method> method = context.getTestMethod();
+    if (method.isPresent() && method.get().isAnnotationPresent(QueryAuditExclude.class)) {
+      return false;
+    }
+
+    ExtensionContext current = context;
+    while (current != null) {
+      Boolean active = current.getStore(NAMESPACE).get(KEY_ACTIVE, Boolean.class);
+      if (active != null) {
+        return active;
+      }
+      current = current.getParent().orElse(null);
+    }
+    return computeActive(context);
+  }
+
+  private static boolean isClassExcluded(Class<?> testClass) {
+    Class<?> clazz = testClass;
+    while (clazz != null) {
+      if (clazz.isAnnotationPresent(QueryAuditExclude.class)) {
+        return true;
+      }
+      clazz = clazz.getEnclosingClass();
+    }
+    return false;
+  }
+
+  /**
+   * Resolves the audit mode: the {@code queryAudit.mode} system property wins, then the Spring
+   * {@code query-audit.mode} property (via the {@code QueryAuditConfig} bean), then the {@link
+   * AuditMode#ANNOTATED} default.
+   */
+  private AuditMode resolveAuditMode(ExtensionContext context) {
+    String sysProp = resolveSystemProperty("queryAudit.mode", "queryGuard.mode");
+    if (sysProp != null && !sysProp.isBlank()) {
+      return AuditMode.parse(sysProp);
+    }
+    QueryAuditConfig springConfig = resolveSpringConfig(context);
+    if (springConfig != null) {
+      return springConfig.getAuditMode();
+    }
+    return AuditMode.ANNOTATED;
+  }
+
+  private static boolean hasDirectExtendWith(ExtensionContext context) {
+    Class<?> clazz = context.getRequiredTestClass();
+    while (clazz != null) {
+      for (ExtendWith extendWith : clazz.getAnnotationsByType(ExtendWith.class)) {
+        for (Class<?> registered : extendWith.value()) {
+          if (registered == QueryAuditExtension.class) {
+            return true;
+          }
+        }
+      }
+      clazz = clazz.getEnclosingClass();
+    }
+    return false;
   }
 
   // ── Config building ────────────────────────────────────────────────

--- a/query-audit-junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/query-audit-junit5/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.queryaudit.junit5.QueryAuditExtension

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/ExtensionAutoRegistrationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/ExtensionAutoRegistrationTest.java
@@ -1,0 +1,28 @@
+package io.queryaudit.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the ServiceLoader registration that {@code mode: all} depends on: JUnit's extension
+ * autodetection can only pick the extension up for unannotated tests if this resource names it.
+ */
+@DisplayName("Issue #163: ServiceLoader registration for extension autodetection")
+class ExtensionAutoRegistrationTest {
+
+  @Test
+  @DisplayName("META-INF/services registers QueryAuditExtension")
+  void serviceFileRegistersExtension() throws Exception {
+    try (InputStream in =
+        getClass()
+            .getResourceAsStream("/META-INF/services/org.junit.jupiter.api.extension.Extension")) {
+      assertThat(in).as("ServiceLoader registration file must be on the classpath").isNotNull();
+      String content = new String(in.readAllBytes(), StandardCharsets.UTF_8).trim();
+      assertThat(content).isEqualTo(QueryAuditExtension.class.getName());
+    }
+  }
+}

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/AnnotationOverridesYmlReproductionTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/AnnotationOverridesYmlReproductionTest.java
@@ -2,6 +2,7 @@ package io.queryaudit.junit5.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
 import io.queryaudit.core.model.Severity;
 import io.queryaudit.junit5.BooleanOverride;
@@ -81,7 +82,7 @@ class AnnotationOverridesYmlReproductionTest {
     }
 
     @Test
-    @DisplayName("Builder.from() copies ALL 20 fields from source config")
+    @DisplayName("Builder.from() copies ALL fields from source config")
     void builderFromCopiesAllFields() {
       // Build a config with ALL non-default values
       QueryAuditConfig source =
@@ -109,6 +110,7 @@ class AnnotationOverridesYmlReproductionTest {
               .writeAmplificationThreshold(22)
               .slowQueryWarningMs(1234L)
               .slowQueryErrorMs(5678L)
+              .auditMode(AuditMode.ALL)
               .build();
 
       QueryAuditConfig copy = QueryAuditConfig.Builder.from(source).build();
@@ -162,6 +164,7 @@ class AnnotationOverridesYmlReproductionTest {
       assertThat(copy.getSlowQueryErrorMs())
           .as("slowQueryErrorMs")
           .isEqualTo(source.getSlowQueryErrorMs());
+      assertThat(copy.getAuditMode()).as("auditMode").isEqualTo(source.getAuditMode());
     }
   }
 

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/AuditModeActivationTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/AuditModeActivationTest.java
@@ -1,0 +1,172 @@
+package io.queryaudit.junit5.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.queryaudit.junit5.EnableQueryInspector;
+import io.queryaudit.junit5.QueryAudit;
+import io.queryaudit.junit5.QueryAuditExclude;
+import io.queryaudit.junit5.QueryAuditExtension;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Activation-decision tests for audit modes (issue #163): which test classes and methods the
+ * extension audits under {@code annotated} (default) vs {@code all} mode, and how
+ * {@code @QueryAuditExclude} interacts with both.
+ */
+@DisplayName("Issue #163: audit mode activation decision")
+class AuditModeActivationTest {
+
+  @AfterEach
+  void clearModeProperty() {
+    System.clearProperty("queryAudit.mode");
+    System.clearProperty("queryGuard.mode");
+  }
+
+  // ── Fixture classes (never discovered as tests — no @Test methods) ──
+
+  static class PlainFixture {
+    @SuppressWarnings("unused")
+    void probe() {}
+  }
+
+  @QueryAuditExclude
+  static class ExcludedFixture {}
+
+  @QueryAudit
+  static class AnnotatedFixture {
+    @SuppressWarnings("unused")
+    void probe() {}
+
+    @QueryAuditExclude
+    @SuppressWarnings("unused")
+    void excludedProbe() {}
+  }
+
+  @ExtendWith(QueryAuditExtension.class)
+  static class DirectExtendWithFixture {}
+
+  @EnableQueryInspector
+  static class InspectorFixture {}
+
+  @QueryAudit
+  static class AnnotatedOuterFixture {
+    class NestedFixture {}
+  }
+
+  // ── annotated mode (default) ──────────────────────────────────────
+
+  @Nested
+  @DisplayName("annotated mode (default)")
+  class AnnotatedMode {
+
+    @Test
+    @DisplayName("a plain class is NOT audited — autodetection alone must not widen coverage")
+    void plainClassInactive() throws Exception {
+      assertThat(computeActive(PlainFixture.class)).isFalse();
+    }
+
+    @Test
+    @DisplayName("@QueryAudit, @EnableQueryInspector, and direct @ExtendWith opt in")
+    void optInsActivate() throws Exception {
+      assertThat(computeActive(AnnotatedFixture.class)).isTrue();
+      assertThat(computeActive(InspectorFixture.class)).isTrue();
+      assertThat(computeActive(DirectExtendWithFixture.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("a nested class inherits activation from its annotated enclosing class")
+    void nestedInheritsFromEnclosing() throws Exception {
+      assertThat(computeActive(AnnotatedOuterFixture.NestedFixture.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("a method-level @QueryAuditExclude wins over a class-level @QueryAudit")
+    void methodExcludeWinsOverClassAnnotation() throws Exception {
+      assertThat(isAuditActive(AnnotatedFixture.class, "probe")).isTrue();
+      assertThat(isAuditActive(AnnotatedFixture.class, "excludedProbe")).isFalse();
+    }
+  }
+
+  // ── all mode ──────────────────────────────────────────────────────
+
+  @Nested
+  @DisplayName("all mode (queryAudit.mode=all)")
+  class AllMode {
+
+    @Test
+    @DisplayName("a plain class IS audited")
+    void plainClassActive() throws Exception {
+      System.setProperty("queryAudit.mode", "all");
+      assertThat(computeActive(PlainFixture.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("@QueryAuditExclude on the class opts out")
+    void excludedClassInactive() throws Exception {
+      System.setProperty("queryAudit.mode", "all");
+      assertThat(computeActive(ExcludedFixture.class)).isFalse();
+    }
+
+    @Test
+    @DisplayName("the legacy queryGuard.mode property is honored")
+    void legacyPropertyHonored() throws Exception {
+      System.setProperty("queryGuard.mode", "all");
+      assertThat(computeActive(PlainFixture.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("an invalid mode value fails loudly instead of being silently ignored")
+    void invalidModeThrows() {
+      System.setProperty("queryAudit.mode", "banana");
+      assertThatThrownBy(() -> computeActive(PlainFixture.class))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("banana");
+    }
+  }
+
+  // ── Reflection plumbing ───────────────────────────────────────────
+
+  private static boolean computeActive(Class<?> fixture) throws Exception {
+    return invoke("computeActive", new StubExtensionContext(fixture));
+  }
+
+  private static boolean isAuditActive(Class<?> fixture, String methodName) throws Exception {
+    return invoke("isAuditActive", new StubWithMethod(fixture, methodName));
+  }
+
+  private static boolean invoke(String name, ExtensionContext context) throws Exception {
+    QueryAuditExtension extension = new QueryAuditExtension();
+    Method method = QueryAuditExtension.class.getDeclaredMethod(name, ExtensionContext.class);
+    method.setAccessible(true);
+    try {
+      return (boolean) method.invoke(extension, context);
+    } catch (InvocationTargetException e) {
+      throw (Exception) e.getCause();
+    }
+  }
+
+  /** Stub variant that also exposes a test method, for method-level exclusion checks. */
+  private static class StubWithMethod extends StubExtensionContext {
+
+    private final Method method;
+
+    StubWithMethod(Class<?> testClass, String methodName) throws NoSuchMethodException {
+      super(testClass);
+      this.method = testClass.getDeclaredMethod(methodName);
+    }
+
+    @Override
+    public Optional<Method> getTestMethod() {
+      return Optional.of(method);
+    }
+  }
+}

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
@@ -1,5 +1,6 @@
 package io.queryaudit.spring;
 
+import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
 import io.queryaudit.core.interceptor.DataSourceProxyFactory;
 import io.queryaudit.core.interceptor.QueryInterceptor;
@@ -40,6 +41,7 @@ public class QueryAuditAutoConfiguration {
     return QueryAuditConfig.builder()
         .enabled(properties.isEnabled())
         .failOnDetection(properties.isFailOnDetection())
+        .auditMode(AuditMode.parse(properties.getMode()))
         .nPlusOneThreshold(properties.getNPlusOne().getThreshold())
         .offsetPaginationThreshold(properties.getOffsetPagination().getThreshold())
         .orClauseThreshold(properties.getOrClause().getThreshold())
@@ -76,8 +78,8 @@ public class QueryAuditAutoConfiguration {
    * query-audit.enabled} and {@code query-audit.wrap-data-source.enabled} default to {@code true};
    * either can be flipped to {@code false} to skip the wrap. {@code wrap-data-source.enabled =
    * false} is the documented escape hatch for issue #134 — it disables only the auto-wrap while
-   * keeping {@link QueryAuditConfig} and {@link QueryInterceptor} available, so {@code
-   * @QueryAudit} per-test wrapping still works.
+   * keeping {@link QueryAuditConfig} and {@link QueryInterceptor} available, so {@code @QueryAudit}
+   * per-test wrapping still works.
    */
   @Bean(name = {"queryAuditDataSourcePostProcessor", "queryGuardDataSourcePostProcessor"})
   @ConditionalOnProperty(

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
@@ -18,6 +18,15 @@ public class QueryAuditProperties {
 
   private boolean enabled = true;
   private boolean failOnDetection = true;
+
+  /**
+   * Which tests the JUnit extension audits: {@code annotated} (opt-in via {@code @QueryAudit}, the
+   * default) or {@code all} (every test, opt-out via {@code @QueryAuditExclude}). {@code all}
+   * additionally requires JUnit extension autodetection so the extension is registered for
+   * unannotated tests.
+   */
+  private String mode = "annotated";
+
   private NPlusOne nPlusOne = new NPlusOne();
   private OffsetPagination offsetPagination = new OffsetPagination();
   private OrClause orClause = new OrClause();
@@ -54,6 +63,14 @@ public class QueryAuditProperties {
 
   public void setFailOnDetection(boolean failOnDetection) {
     this.failOnDetection = failOnDetection;
+  }
+
+  public String getMode() {
+    return mode;
+  }
+
+  public void setMode(String mode) {
+    this.mode = mode;
   }
 
   public NPlusOne getNPlusOne() {
@@ -356,12 +373,11 @@ public class QueryAuditProperties {
   }
 
   /**
-   * Controls the autoconfigured {@link
-   * org.springframework.beans.factory.config.BeanPostProcessor} that wraps every {@code DataSource}
-   * bean. Set {@code query-audit.wrap-data-source.enabled: false} as the documented escape hatch
-   * for issue #134 — when 3+ {@code @SpringBootTest} cache signatures coexist, the wrap interacts
-   * badly with Spring TestContext caching and the underlying {@code HikariDataSource} can be
-   * closed prematurely. Disabling this leaves {@link
+   * Controls the autoconfigured {@link org.springframework.beans.factory.config.BeanPostProcessor}
+   * that wraps every {@code DataSource} bean. Set {@code query-audit.wrap-data-source.enabled:
+   * false} as the documented escape hatch for issue #134 — when 3+ {@code @SpringBootTest} cache
+   * signatures coexist, the wrap interacts badly with Spring TestContext caching and the underlying
+   * {@code HikariDataSource} can be closed prematurely. Disabling this leaves {@link
    * io.queryaudit.core.config.QueryAuditConfig} and {@link
    * io.queryaudit.core.interceptor.QueryInterceptor} active so {@code @QueryAudit} per-test still
    * works.

--- a/query-audit-spring-boot-starter/src/test/java/io/queryaudit/spring/QueryAuditAutoConfigurationTest.java
+++ b/query-audit-spring-boot-starter/src/test/java/io/queryaudit/spring/QueryAuditAutoConfigurationTest.java
@@ -3,6 +3,7 @@ package io.queryaudit.spring;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import javax.sql.DataSource;
@@ -17,6 +18,43 @@ class QueryAuditAutoConfigurationTest {
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
           .withConfiguration(AutoConfigurations.of(QueryAuditAutoConfiguration.class));
+
+  @Nested
+  @DisplayName("Audit mode property (issue #163)")
+  class AuditModeProperty {
+
+    @Test
+    @DisplayName("defaults to ANNOTATED")
+    void defaultsToAnnotated() {
+      contextRunner.run(
+          context ->
+              assertThat(context.getBean(QueryAuditConfig.class).getAuditMode())
+                  .isEqualTo(AuditMode.ANNOTATED));
+    }
+
+    @Test
+    @DisplayName("query-audit.mode=all binds to ALL")
+    void bindsAll() {
+      contextRunner
+          .withPropertyValues("query-audit.mode=all")
+          .run(
+              context ->
+                  assertThat(context.getBean(QueryAuditConfig.class).getAuditMode())
+                      .isEqualTo(AuditMode.ALL));
+    }
+
+    @Test
+    @DisplayName("an invalid mode fails context startup instead of being silently ignored")
+    void invalidModeFailsStartup() {
+      contextRunner
+          .withPropertyValues("query-audit.mode=banana")
+          .run(
+              context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure()).rootCause().hasMessageContaining("banana");
+              });
+    }
+  }
 
   @Nested
   @DisplayName("QueryAuditProperties default values")


### PR DESCRIPTION
## Summary

Closes #163.

Coverage was opt-in only: every test without `@QueryAudit` was a silent blind spot, and a write-path N+1 in an uncovered domain merges green. `mode: all` flips the coverage model — **every test is audited, individual tests opt out explicitly** with `@QueryAuditExclude`.

## How it works

Two switches, both documented in the new *Audit Coverage Mode* section:

1. `junit.jupiter.extensions.autodetection.enabled=true` — a new ServiceLoader registration lets JUnit register the extension suite-wide.
2. `query-audit.mode: all` (Spring) or `-DqueryAudit.mode=all` (any project; the system property wins).

The activation decision is made once per class in `beforeAll` and cached in the extension store:

| | `annotated` (default) | `all` |
|---|---|---|
| `@QueryAudit` / `@EnableQueryInspector` / direct `@ExtendWith` | audited | audited |
| plain class | **not audited** | audited |
| `@QueryAuditExclude` (class or method) | skipped | skipped |

## Backward-compatibility guarantees

- Absent/blank mode parses to `annotated`; unknown values fail loudly (context startup failure in Spring, `IllegalArgumentException` otherwise) instead of being silently ignored.
- **Enabling autodetection alone does not widen coverage**: in `annotated` mode the extension stays inactive for classes that never opted in. Without this gate, shipping the ServiceLoader file would have been a behavior change for every project that already runs with autodetection on.
- Double registration (autodetection + `@QueryAudit` on the same class) is guarded: one DataSource wrap, one analysis per test.

## Verification

- Full suite green across all modules; new unit coverage for the parse rules, the activation decision matrix (both modes × all annotation shapes × class/method exclusion), the ServiceLoader resource, and the Spring property binding (including startup failure on an invalid value).
- End-to-end with a scratch unannotated `@SpringBootTest` probe carrying `@ExpectMaxQueryCount(0)`:
  - defaults → passes (extension inactive),
  - autodetection on, mode unset → passes (annotated-mode gate),
  - autodetection + `queryAudit.mode=all` → fails with `executed 1 queries, expected at most 0` — the budget fired on a test that never mentioned QueryAudit.

## Docs

- `guide/configuration.md`: `mode` property, `-DqueryAudit.mode` system property, new **Audit Coverage Mode** section with the brownfield onboarding path (`mode: all` + baseline freeze → only new violations fail).
- `guide/annotations.md`: `@QueryAuditExclude` reference and examples.
