### PR TITLE
feat(core)!: version the report.json envelope and embed finding evidence

### DIFF
--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -115,8 +115,8 @@ the JSON report with a `github-script` step:
             const fs = require('fs');
             const path = 'build/reports/query-audit/report.json';
             if (!fs.existsSync(path)) return;
-            // report.json is an array of per-test reports — sum across them.
-            const tests = JSON.parse(fs.readFileSync(path, 'utf8'));
+            // report.json is a versioned envelope: { schemaVersion, reports: [...] }.
+            const tests = JSON.parse(fs.readFileSync(path, 'utf8')).reports;
             const confirmed = tests.reduce((s, t) => s + (t.summary?.confirmedIssues || 0), 0);
             const info = tests.reduce((s, t) => s + (t.summary?.infoIssues || 0), 0);
             const body = `**QueryAudit**: ${confirmed} confirmed, ${info} info across ${tests.length} test method(s).`;
@@ -131,10 +131,11 @@ the JSON report with a `github-script` step:
 !!! info "Report file layout"
     QueryAudit writes a single aggregate `report.json` at the configured
     `report.output-dir` (default `build/reports/query-audit/`). The top-level value is a
-    **JSON array** with one entry per test method — each entry has a `summary` object
-    (`confirmedIssues`, `infoIssues`, `acknowledgedIssues`, ...) plus `confirmedIssues` /
-    `infoIssues` arrays of individual findings. Per-test HTML files (`<TestClass>.html`)
-    and an `index.html` aggregate sit alongside.
+    **versioned envelope** — `schemaVersion` plus a `reports` array with one entry per test
+    method. Each entry has a `summary` object (`confirmedIssues`, `infoIssues`,
+    `acknowledgedIssues`, ...) plus `confirmedIssues` / `infoIssues` arrays of individual
+    findings. See [Reports — JSON schema](reports.md#json-schema) for the full contract.
+    Per-test HTML files (`<TestClass>.html`) and an `index.html` aggregate sit alongside.
 
 ### With PostgreSQL
 
@@ -228,8 +229,8 @@ Post a summary of QueryAudit findings as a PR comment:
             const fs = require('fs');
             const path = 'build/reports/query-audit/report.json';
             if (!fs.existsSync(path)) return;
-            // report.json is an array — one entry per test method. Sum the per-test summaries.
-            const tests = JSON.parse(fs.readFileSync(path, 'utf8'));
+            // report.json is a versioned envelope: { schemaVersion, reports: [...] }.
+            const tests = JSON.parse(fs.readFileSync(path, 'utf8')).reports;
             const totalConfirmed = tests.reduce((s, t) => s + (t.summary?.confirmedIssues || 0), 0);
             const totalInfo = tests.reduce((s, t) => s + (t.summary?.infoIssues || 0), 0);
             if (totalConfirmed > 0 || totalInfo > 0) {

--- a/docs/guide/reports.md
+++ b/docs/guide/reports.md
@@ -116,65 +116,102 @@ query-audit:
 
 ### Example Output
 
+The file is a **versioned envelope**: `schemaVersion` plus a `reports` array with one entry
+per test method.
+
 ```json
 {
-  "testClass": "com.example.OrderServiceTest",
-  "testName": "findRecentOrders_shouldUseIndex",
-  "summary": {
-    "confirmedIssues": 2,
-    "infoIssues": 1,
-    "acknowledgedIssues": 0,
-    "uniquePatterns": 4,
-    "totalQueries": 18,
-    "executionTimeMs": 342
-  },
-  "confirmedIssues": [
+  "schemaVersion": "1.0.0",
+  "reports": [
     {
-      "type": "n-plus-one",
-      "severity": "ERROR",
-      "query": "select * from order_items where order_id = ?",
-      "table": "order_items",
-      "column": null,
-      "detail": "Query repeated 12 times (threshold: 3)",
-      "suggestion": "Use JOIN FETCH, @EntityGraph, or batch loading (IN clause)"
-    },
-    {
-      "type": "missing-where-index",
-      "severity": "ERROR",
-      "query": "select * from orders where user_id = ? order by created_at desc",
-      "table": "orders",
-      "column": "user_id",
-      "detail": "Column 'user_id' is used in WHERE clause but has no index",
-      "suggestion": "CREATE INDEX idx_orders_user_id ON orders (user_id);"
-    }
-  ],
-  "infoIssues": [],
-  "acknowledgedIssues": [],
-  "queries": [
-    {
-      "sql": "SELECT * FROM orders WHERE user_id = 42 ORDER BY created_at DESC",
-      "normalizedSql": "select * from orders where user_id = ? order by created_at desc",
-      "executionTimeNanos": 15234000,
-      "stackTrace": "com.example.OrderService.findOrders:42"
+      "testClass": "com.example.OrderServiceTest",
+      "testName": "findRecentOrders_shouldUseIndex",
+      "summary": {
+        "confirmedIssues": 2,
+        "infoIssues": 1,
+        "acknowledgedIssues": 0,
+        "uniquePatterns": 4,
+        "totalQueries": 18,
+        "executionTimeMs": 342
+      },
+      "confirmedIssues": [
+        {
+          "type": "n-plus-one",
+          "severity": "ERROR",
+          "query": "select * from order_items where order_id = ?",
+          "table": "order_items",
+          "column": null,
+          "detail": "Query repeated 12 times (threshold: 3)",
+          "suggestion": "Use JOIN FETCH, @EntityGraph, or batch loading (IN clause)",
+          "sourceLocation": "com.example.OrderService.findOrders:42",
+          "remediation": {"kind": "batch-fetch", "table": "order_items"}
+        },
+        {
+          "type": "missing-where-index",
+          "severity": "ERROR",
+          "query": "select * from orders where user_id = ? order by created_at desc",
+          "table": "orders",
+          "column": "user_id",
+          "detail": "Column 'user_id' is used in WHERE clause but has no index",
+          "suggestion": "CREATE INDEX idx_orders_user_id ON orders (user_id);",
+          "sourceLocation": "com.example.OrderService.findOrders:42",
+          "remediation": {"kind": "add-index", "table": "orders", "columns": ["user_id"]}
+        }
+      ],
+      "infoIssues": [],
+      "acknowledgedIssues": [],
+      "indexMetadata": {
+        "orders": [
+          {"name": "PRIMARY", "unique": true, "columns": ["id"], "cardinality": 120000}
+        ]
+      },
+      "queries": [
+        {
+          "sql": "SELECT * FROM orders WHERE user_id = 42 ORDER BY created_at DESC",
+          "normalizedSql": "select * from orders where user_id = ? order by created_at desc",
+          "executionTimeNanos": 15234000,
+          "stackTrace": "com.example.OrderService.findOrders:42"
+        }
+      ]
     }
   ]
 }
 ```
+
+### JSON Schema
+
+The envelope carries `schemaVersion` (semver) so consumers can detect breaking shape changes
+instead of silently misparsing. The current version is **1.0.0**, introduced in QueryAudit
+0.5.0 — which also changed the top-level value from a bare array to this envelope (the one
+breaking change the version field exists to prevent going forward).
+
+Field notes for machine consumers:
+
+- Every finding carries `sourceLocation` (the innermost application stack frame of the
+  offending query) and, for high-precision rules, a structured `remediation` hint
+  (`kind` + `table` + `columns`) so tooling can act without parsing the prose `suggestion`.
+- `indexMetadata` embeds the actual index state (from `SHOW INDEX` / `pg_catalog`) of every
+  table referenced by a finding — grouped per index, columns in index order. A report
+  consumer can decide on and generate the correct fix without separate database access.
+  `null` means no metadata was collected (non-database test).
+
+The machine-readable contract lives at
+[`schema/report.schema.json`](https://github.com/haroya01/query-audit/blob/main/docs/schema/report.schema.json).
 
 !!! tip "CI artifact storage"
     Store JSON reports as CI artifacts for trend tracking across builds. Parse them
     with `jq` or feed them into monitoring dashboards.
 
     ```bash
-    # Extract issue count from JSON report
-    jq '.summary.confirmedIssues' build/reports/query-audit/report.json
+    # Total confirmed issues across all test methods
+    jq '[.reports[].summary.confirmedIssues] | add' build/reports/query-audit/report.json
 
     # List all detected issue types
-    jq '[.confirmedIssues[].type] | unique' build/reports/query-audit/report.json
+    jq '[.reports[].confirmedIssues[].type] | unique' build/reports/query-audit/report.json
 
     # Find tests with N+1 issues
-    jq 'select(.confirmedIssues[] | .type == "n-plus-one") | .testName' \
-        build/reports/query-audit/*.json
+    jq '.reports[] | select(.confirmedIssues[]? | .type == "n-plus-one") | .testName' \
+        build/reports/query-audit/report.json
     ```
 
 ---

--- a/docs/schema/report.schema.json
+++ b/docs/schema/report.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://haroya01.github.io/query-audit/schema/report.schema.json",
+  "title": "QueryAudit report.json",
+  "description": "Versioned envelope written to build/reports/query-audit/report.json. schemaVersion follows semver and is bumped on any breaking shape change.",
+  "type": "object",
+  "required": ["schemaVersion", "reports"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "reports": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/testReport" }
+    }
+  },
+  "definitions": {
+    "testReport": {
+      "type": "object",
+      "required": [
+        "testClass",
+        "testName",
+        "summary",
+        "confirmedIssues",
+        "infoIssues",
+        "acknowledgedIssues",
+        "indexMetadata",
+        "queries"
+      ],
+      "properties": {
+        "testClass": { "type": ["string", "null"] },
+        "testName": { "type": "string" },
+        "summary": {
+          "type": "object",
+          "required": [
+            "confirmedIssues",
+            "infoIssues",
+            "acknowledgedIssues",
+            "uniquePatterns",
+            "totalQueries",
+            "executionTimeMs"
+          ],
+          "properties": {
+            "confirmedIssues": { "type": "integer" },
+            "infoIssues": { "type": "integer" },
+            "acknowledgedIssues": { "type": "integer" },
+            "uniquePatterns": { "type": "integer" },
+            "totalQueries": { "type": "integer" },
+            "executionTimeMs": { "type": "integer" }
+          }
+        },
+        "confirmedIssues": { "$ref": "#/definitions/issueArray" },
+        "infoIssues": { "$ref": "#/definitions/issueArray" },
+        "acknowledgedIssues": { "$ref": "#/definitions/issueArray" },
+        "indexMetadata": {
+          "description": "Index state of every table referenced by a finding, or null when no metadata was collected (non-database test). Keys are table names.",
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/index" }
+          }
+        },
+        "queries": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/query" }
+        }
+      }
+    },
+    "issueArray": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/issue" }
+    },
+    "issue": {
+      "type": "object",
+      "required": ["type", "severity", "query", "table", "column", "detail", "suggestion", "sourceLocation"],
+      "properties": {
+        "type": { "type": "string", "description": "Issue code, e.g. n-plus-one, missing-where-index." },
+        "severity": { "type": "string", "enum": ["ERROR", "WARNING", "INFO"] },
+        "query": { "type": ["string", "null"] },
+        "table": { "type": ["string", "null"] },
+        "column": { "type": ["string", "null"] },
+        "detail": { "type": ["string", "null"] },
+        "suggestion": { "type": ["string", "null"] },
+        "sourceLocation": {
+          "type": ["string", "null"],
+          "description": "Innermost application stack frame of the offending query."
+        },
+        "remediation": {
+          "description": "Structured fix hint, present only for high-precision rules.",
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "add-index",
+                "batch-fetch",
+                "batch-insert",
+                "add-where-clause",
+                "add-limit",
+                "select-explicit-columns"
+              ]
+            },
+            "table": { "type": "string" },
+            "columns": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "index": {
+      "type": "object",
+      "required": ["name", "unique", "columns", "cardinality"],
+      "properties": {
+        "name": { "type": "string" },
+        "unique": { "type": "boolean" },
+        "columns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Column names in index order."
+        },
+        "cardinality": {
+          "type": "integer",
+          "description": "Whole-index cardinality (SHOW INDEX semantics: the last column entry's cardinality)."
+        }
+      }
+    },
+    "query": {
+      "type": "object",
+      "required": ["sql", "normalizedSql", "executionTimeNanos", "stackTrace"],
+      "properties": {
+        "sql": { "type": "string" },
+        "normalizedSql": { "type": ["string", "null"] },
+        "executionTimeNanos": { "type": "integer" },
+        "stackTrace": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/QueryAuditReport.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/QueryAuditReport.java
@@ -87,6 +87,47 @@ public class QueryAuditReport {
         totalExecutionTimeNanos);
   }
 
+  // Attached via withIndexMetadata() after all analysis merges, not in the constructors — the
+  // report is rebuilt several times during afterEach (regression/EXPLAIN/Hibernate merges) and
+  // threading a tenth constructor argument through every rebuild site is worse than one late copy.
+  private IndexMetadata indexMetadata;
+
+  /**
+   * Returns a copy of this report carrying the index metadata collected for the test's DataSource,
+   * or {@code this} when {@code metadata} is {@code null}. The JSON reporter serializes the subset
+   * relevant to the findings so report consumers can act without separate database access.
+   *
+   * @since 0.5.0
+   */
+  public QueryAuditReport withIndexMetadata(IndexMetadata metadata) {
+    if (metadata == null) {
+      return this;
+    }
+    QueryAuditReport copy =
+        new QueryAuditReport(
+            testClass,
+            testName,
+            confirmedIssues,
+            infoIssues,
+            getAcknowledgedIssues(),
+            allQueries,
+            uniquePatternCount,
+            totalQueryCount,
+            totalExecutionTimeNanos);
+    copy.indexMetadata = metadata;
+    return copy;
+  }
+
+  /**
+   * Returns the index metadata attached to this report, or {@code null} when none was collected
+   * (non-database tests, or reports built before {@link #withIndexMetadata}).
+   *
+   * @since 0.5.0
+   */
+  public IndexMetadata getIndexMetadata() {
+    return indexMetadata;
+  }
+
   public boolean hasConfirmedIssues() {
     return confirmedIssues != null && !confirmedIssues.isEmpty();
   }

--- a/query-audit-core/src/main/java/io/queryaudit/core/reporter/JsonReporter.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/reporter/JsonReporter.java
@@ -1,9 +1,17 @@
 package io.queryaudit.core.reporter;
 
+import io.queryaudit.core.model.IndexInfo;
+import io.queryaudit.core.model.IndexMetadata;
 import io.queryaudit.core.model.Issue;
 import io.queryaudit.core.model.QueryAuditReport;
 import io.queryaudit.core.model.QueryRecord;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Outputs a {@link QueryAuditReport} as structured JSON suitable for dashboards, PR comments, and
@@ -16,7 +24,37 @@ import java.util.List;
  */
 public class JsonReporter implements Reporter {
 
+  /**
+   * Version of the {@code report.json} envelope, bumped on any breaking shape change so consumers
+   * can detect incompatibilities instead of silently misparsing. Documented in the Reports guide.
+   *
+   * @since 0.5.0
+   */
+  public static final String SCHEMA_VERSION = "1.0.0";
+
   private String lastJson;
+
+  /**
+   * Wraps per-test reports in the versioned envelope written to {@code report.json}: {@code
+   * {"schemaVersion": "...", "reports": [...]}}.
+   *
+   * @since 0.5.0
+   */
+  public static String toEnvelopeJson(List<QueryAuditReport> reports) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\n");
+    sb.append("  \"schemaVersion\": \"").append(SCHEMA_VERSION).append("\",\n");
+    sb.append("  \"reports\": [\n");
+    for (int i = 0; i < reports.size(); i++) {
+      sb.append(toJson(reports.get(i)).indent(4).stripTrailing());
+      if (i < reports.size() - 1) {
+        sb.append(",");
+      }
+      sb.append("\n");
+    }
+    sb.append("  ]\n}");
+    return sb.toString();
+  }
 
   @Override
   public void report(QueryAuditReport report) {
@@ -69,6 +107,12 @@ public class JsonReporter implements Reporter {
     appendIssueArray(sb, report.getAcknowledgedIssues(), "  ");
     sb.append(",\n");
 
+    // indexMetadata — only tables referenced by findings, so a consumer acting on the report
+    // (CI bot, remediation tooling) can see the actual index state without database access.
+    sb.append("  \"indexMetadata\": ");
+    appendIndexMetadata(sb, report, "  ");
+    sb.append(",\n");
+
     // queries
     sb.append("  \"queries\": ");
     appendQueryArray(sb, report.getAllQueries(), "  ");
@@ -106,6 +150,28 @@ public class JsonReporter implements Reporter {
       appendJsonString(sb, innerField, "detail", issue.detail());
       sb.append(",\n");
       appendJsonString(sb, innerField, "suggestion", issue.suggestion());
+      sb.append(",\n");
+      appendJsonString(sb, innerField, "sourceLocation", issue.sourceLocation());
+      RemediationHints.Remediation remediation = RemediationHints.forIssue(issue);
+      if (remediation != null) {
+        sb.append(",\n");
+        sb.append(innerField).append("\"remediation\": {");
+        sb.append("\"kind\": \"").append(escapeJson(remediation.kind())).append("\"");
+        if (remediation.table() != null) {
+          sb.append(", \"table\": \"").append(escapeJson(remediation.table())).append("\"");
+        }
+        if (!remediation.columns().isEmpty()) {
+          sb.append(", \"columns\": [");
+          for (int c = 0; c < remediation.columns().size(); c++) {
+            if (c > 0) {
+              sb.append(", ");
+            }
+            sb.append("\"").append(escapeJson(remediation.columns().get(c))).append("\"");
+          }
+          sb.append("]");
+        }
+        sb.append("}");
+      }
       sb.append("\n");
       sb.append(inner).append("}");
       if (i < issues.size() - 1) {
@@ -142,6 +208,84 @@ public class JsonReporter implements Reporter {
       sb.append("\n");
     }
     sb.append(indent).append("]");
+  }
+
+  /**
+   * Serializes the index state of every table referenced by a finding, grouped per index with
+   * columns in index order. {@code null} when no metadata was collected (non-database tests);
+   * {@code {}} when metadata exists but no finding references a known table. Cardinality is taken
+   * from the index's last column entry — the whole-index cardinality in {@code SHOW INDEX}
+   * semantics.
+   */
+  private static void appendIndexMetadata(
+      StringBuilder sb, QueryAuditReport report, String indent) {
+    IndexMetadata metadata = report.getIndexMetadata();
+    if (metadata == null) {
+      sb.append("null");
+      return;
+    }
+
+    Set<String> tables = new TreeSet<>();
+    collectIssueTables(tables, report.getConfirmedIssues());
+    collectIssueTables(tables, report.getInfoIssues());
+    collectIssueTables(tables, report.getAcknowledgedIssues());
+
+    StringBuilder body = new StringBuilder();
+    boolean firstTable = true;
+    for (String table : tables) {
+      List<IndexInfo> rows = metadata.getIndexesForTable(table);
+      if (rows == null || rows.isEmpty()) {
+        continue;
+      }
+      Map<String, List<IndexInfo>> byIndex = new LinkedHashMap<>();
+      rows.stream()
+          .sorted(Comparator.comparingInt(IndexInfo::seqInIndex))
+          .forEach(r -> byIndex.computeIfAbsent(r.indexName(), k -> new ArrayList<>()).add(r));
+
+      if (!firstTable) {
+        body.append(",\n");
+      }
+      firstTable = false;
+      body.append(indent).append("  \"").append(escapeJson(table)).append("\": [");
+      boolean firstIndex = true;
+      for (Map.Entry<String, List<IndexInfo>> entry : byIndex.entrySet()) {
+        if (!firstIndex) {
+          body.append(", ");
+        }
+        firstIndex = false;
+        List<IndexInfo> indexRows = entry.getValue();
+        body.append("{\"name\": \"").append(escapeJson(entry.getKey())).append("\", ");
+        body.append("\"unique\": ").append(!indexRows.get(0).nonUnique()).append(", ");
+        body.append("\"columns\": [");
+        for (int c = 0; c < indexRows.size(); c++) {
+          if (c > 0) {
+            body.append(", ");
+          }
+          body.append("\"").append(escapeJson(indexRows.get(c).columnName())).append("\"");
+        }
+        body.append("], \"cardinality\": ")
+            .append(indexRows.get(indexRows.size() - 1).cardinality())
+            .append("}");
+      }
+      body.append("]");
+    }
+
+    if (body.length() == 0) {
+      sb.append("{}");
+      return;
+    }
+    sb.append("{\n").append(body).append("\n").append(indent).append("}");
+  }
+
+  private static void collectIssueTables(Set<String> tables, List<Issue> issues) {
+    if (issues == null) {
+      return;
+    }
+    for (Issue issue : issues) {
+      if (issue.table() != null && !issue.table().isBlank()) {
+        tables.add(issue.table());
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/query-audit-core/src/main/java/io/queryaudit/core/reporter/RemediationHints.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/reporter/RemediationHints.java
@@ -1,0 +1,49 @@
+package io.queryaudit.core.reporter;
+
+import io.queryaudit.core.model.Issue;
+import java.util.List;
+
+/**
+ * Maps high-precision issue types to machine-readable remediation hints for the JSON report.
+ *
+ * <p>The human-readable {@code suggestion} string stays the primary channel; the structured hint
+ * exists so automated consumers (CI bots, remediation tooling) can act on a finding without parsing
+ * prose. Only rules whose fix shape is unambiguous get a hint — everything else returns {@code
+ * null} and the JSON field is omitted.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+public final class RemediationHints {
+
+  private RemediationHints() {
+    // utility class
+  }
+
+  /**
+   * A machine-readable fix description: what to do ({@code kind}), where ({@code table}), and on
+   * which columns (may be empty when the kind is not column-scoped).
+   */
+  public record Remediation(String kind, String table, List<String> columns) {}
+
+  /** Returns the structured hint for the issue, or {@code null} when none is defined. */
+  public static Remediation forIssue(Issue issue) {
+    return switch (issue.type()) {
+      case MISSING_WHERE_INDEX,
+              MISSING_JOIN_INDEX,
+              MISSING_ORDER_BY_INDEX,
+              MISSING_GROUP_BY_INDEX ->
+          new Remediation(
+              "add-index",
+              issue.table(),
+              issue.column() != null ? List.of(issue.column()) : List.of());
+      case N_PLUS_ONE, FIND_BY_ID_FOR_ASSOCIATION ->
+          new Remediation("batch-fetch", issue.table(), List.of());
+      case REPEATED_SINGLE_INSERT -> new Remediation("batch-insert", issue.table(), List.of());
+      case UPDATE_WITHOUT_WHERE -> new Remediation("add-where-clause", issue.table(), List.of());
+      case UNBOUNDED_RESULT_SET -> new Remediation("add-limit", issue.table(), List.of());
+      case SELECT_ALL -> new Remediation("select-explicit-columns", issue.table(), List.of());
+      default -> null;
+    };
+  }
+}

--- a/query-audit-core/src/test/java/io/queryaudit/core/reporter/JsonReporterTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/reporter/JsonReporterTest.java
@@ -2,12 +2,15 @@ package io.queryaudit.core.reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.queryaudit.core.model.IndexInfo;
+import io.queryaudit.core.model.IndexMetadata;
 import io.queryaudit.core.model.Issue;
 import io.queryaudit.core.model.IssueType;
 import io.queryaudit.core.model.QueryAuditReport;
 import io.queryaudit.core.model.QueryRecord;
 import io.queryaudit.core.model.Severity;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class JsonReporterTest {
@@ -244,8 +247,8 @@ class JsonReporterTest {
 
     // Count opening braces for issues
     long issueObjectCount = json.chars().filter(c -> c == '{').count();
-    // 1 root + 1 summary + 2 issues + 2 queries = 6
-    assertThat(issueObjectCount).isEqualTo(6);
+    // 1 root + 1 summary + 2 issues + 1 remediation (n-plus-one only) + 2 queries = 7
+    assertThat(issueObjectCount).isEqualTo(7);
 
     assertThat(json).contains("\"type\": \"n-plus-one\"");
     assertThat(json).contains("\"type\": \"or-abuse\"");
@@ -261,5 +264,118 @@ class JsonReporterTest {
     assertThat(json).startsWith("{");
     assertThat(json).endsWith("}");
     assertThat(json).contains("\"testClass\": \"TC\"");
+  }
+
+  // ------------------------------------------------------------------
+  // Schema contract (issue #165)
+  // ------------------------------------------------------------------
+
+  @Test
+  void sourceLocationIsSerialized() {
+    Issue withLocation =
+        new Issue(
+            IssueType.N_PLUS_ONE,
+            Severity.ERROR,
+            "sql",
+            "orders",
+            null,
+            "d",
+            "s",
+            "com.example.OrderService.load:42");
+    QueryAuditReport report =
+        new QueryAuditReport(
+            "TC", "tm", List.of(withLocation), List.of(), List.of(), List.of(), 1, 1, 0L);
+
+    assertThat(generateJson(report))
+        .contains("\"sourceLocation\": \"com.example.OrderService.load:42\"");
+  }
+
+  @Test
+  void remediationEmittedForMappedTypesOnly() {
+    Issue missingIndex =
+        new Issue(
+            IssueType.MISSING_WHERE_INDEX, Severity.ERROR, "sql", "orders", "user_id", "d", "s");
+    Issue unmapped =
+        new Issue(IssueType.WHERE_FUNCTION, Severity.ERROR, "sql", "orders", "email", "d", "s");
+    QueryAuditReport report =
+        new QueryAuditReport(
+            "TC", "tm", List.of(missingIndex, unmapped), List.of(), List.of(), List.of(), 2, 2, 0L);
+
+    String json = generateJson(report);
+
+    assertThat(json)
+        .contains(
+            "\"remediation\": {\"kind\": \"add-index\", \"table\": \"orders\","
+                + " \"columns\": [\"user_id\"]}");
+    assertThat(json.split("\"remediation\"", -1)).hasSize(2); // exactly one remediation
+  }
+
+  @Test
+  void indexMetadataNullWhenNotCollected() {
+    QueryAuditReport report =
+        new QueryAuditReport("TC", "tm", List.of(), List.of(), List.of(), List.of(), 0, 0, 0L);
+
+    assertThat(generateJson(report)).contains("\"indexMetadata\": null");
+  }
+
+  @Test
+  void indexMetadataTrimmedToFindingTablesAndGroupedByIndex() {
+    Issue onOrders =
+        new Issue(IssueType.MISSING_WHERE_INDEX, Severity.ERROR, "sql", "orders", "a", "d", "s");
+    IndexMetadata metadata =
+        new IndexMetadata(
+            Map.of(
+                "orders",
+                List.of(
+                    new IndexInfo("orders", "idx_ab", "a", 1, true, 10L),
+                    new IndexInfo("orders", "idx_ab", "b", 2, true, 500L)),
+                "users",
+                List.of(new IndexInfo("users", "pk", "id", 1, false, 99L))));
+    QueryAuditReport report =
+        new QueryAuditReport(
+                "TC", "tm", List.of(onOrders), List.of(), List.of(), List.of(), 1, 1, 0L)
+            .withIndexMetadata(metadata);
+
+    String json = generateJson(report);
+
+    assertThat(json)
+        .contains(
+            "\"orders\": [{\"name\": \"idx_ab\", \"unique\": false,"
+                + " \"columns\": [\"a\", \"b\"], \"cardinality\": 500}]");
+    assertThat(json).doesNotContain("\"users\""); // no finding references it
+  }
+
+  @Test
+  void envelopeCarriesSchemaVersionAndReports() {
+    QueryAuditReport r1 =
+        new QueryAuditReport("TC", "first", List.of(), List.of(), List.of(), List.of(), 0, 0, 0L);
+    QueryAuditReport r2 =
+        new QueryAuditReport("TC", "second", List.of(), List.of(), List.of(), List.of(), 0, 0, 0L);
+
+    String json = JsonReporter.toEnvelopeJson(List.of(r1, r2));
+
+    assertThat(json).startsWith("{");
+    assertThat(json).endsWith("}");
+    assertThat(json).contains("\"schemaVersion\": \"" + JsonReporter.SCHEMA_VERSION + "\"");
+    assertThat(json).contains("\"reports\": [");
+    assertThat(json).contains("\"testName\": \"first\"");
+    assertThat(json).contains("\"testName\": \"second\"");
+  }
+
+  @Test
+  void withIndexMetadataCopiesFieldsAndKeepsNullAsSameInstance() {
+    QueryAuditReport report =
+        new QueryAuditReport("TC", "tm", List.of(), List.of(), List.of(), List.of(), 3, 7, 42L);
+
+    assertThat(report.withIndexMetadata(null)).isSameAs(report);
+
+    IndexMetadata metadata = new IndexMetadata(Map.of());
+    QueryAuditReport copy = report.withIndexMetadata(metadata);
+    assertThat(copy.getIndexMetadata()).isSameAs(metadata);
+    assertThat(copy.getTestClass()).isEqualTo("TC");
+    assertThat(copy.getTestName()).isEqualTo("tm");
+    assertThat(copy.getUniquePatternCount()).isEqualTo(3);
+    assertThat(copy.getTotalQueryCount()).isEqualTo(7);
+    assertThat(copy.getTotalExecutionTimeNanos()).isEqualTo(42L);
   }
 }

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -264,7 +264,9 @@ public class QueryAuditExtension
       new GitHubActionsReporter().report(report);
     }
 
-    // Accumulate for HTML report
+    // Attach the collected index metadata so report.json can embed the index state behind each
+    // finding (issue #165), then accumulate for the aggregated report.
+    report = report.withIndexMetadata(indexMetadata);
     HtmlReportAggregator.getInstance().addReport(report);
 
     // --- @ExpectMaxQueryCount ---
@@ -861,18 +863,8 @@ public class QueryAuditExtension
   private void writeJsonReport(List<QueryAuditReport> reports, Path outputDir) {
     try {
       Files.createDirectories(outputDir);
-      StringBuilder sb = new StringBuilder();
-      sb.append("[\n");
-      for (int i = 0; i < reports.size(); i++) {
-        sb.append(JsonReporter.toJson(reports.get(i)));
-        if (i < reports.size() - 1) {
-          sb.append(",");
-        }
-        sb.append("\n");
-      }
-      sb.append("]");
       Path jsonPath = outputDir.resolve("report.json");
-      Files.writeString(jsonPath, sb.toString());
+      Files.writeString(jsonPath, JsonReporter.toEnvelopeJson(reports));
       System.out.println("[QueryAudit] JSON report: " + jsonPath.toAbsolutePath());
     } catch (Exception e) {
       System.err.println("[QueryAudit] Failed to write JSON report: " + e.getMessage());


### PR DESCRIPTION
## Summary

Closes #165.

`report.json` is the machine-facing half of the reporter pair, but it had two gaps: consumers could not detect shape changes, and findings stated conclusions without the evidence that produced them — acting on a `missing-where-index` finding still required separate database access.

## Changes

**⚠️ Breaking: versioned envelope.** The top-level value changes from a bare JSON array to

```json
{ "schemaVersion": "1.0.0", "reports": [ ... ] }
```

`schemaVersion` is bumped on any future breaking shape change so consumers fail loudly instead of silently misparsing — this PR makes the one break that prevents all silent ones. CI guide snippets are updated to `.reports`.

**Per finding — evidence and action:**
- `sourceLocation` — already captured for failure messages, never serialized until now.
- `remediation` — a structured hint `{kind, table, columns}` for the six rule families whose fix shape is unambiguous (`add-index`, `batch-fetch`, `batch-insert`, `add-where-clause`, `add-limit`, `select-explicit-columns`). Prose `suggestion` stays the human channel; everything else omits the field.

**Per report — `indexMetadata`:** the actual `SHOW INDEX` / `pg_catalog` state of every table referenced by a finding, grouped per index with columns in index order. A consumer (CI bot, remediation tooling, an agent driving a fix loop) can decide on and generate the correct fix **without separate database access**. Attached via `QueryAuditReport.withIndexMetadata(...)` after all analysis merges — one late copy instead of a tenth constructor argument threaded through every rebuild site.

**Contract documented:** `docs/schema/report.schema.json` (JSON Schema draft-07) + a *JSON Schema* section in the Reports guide.

## Verification

- Full suite green; 6 new serialization tests (envelope version, sourceLocation, remediation presence/absence, indexMetadata trimming + per-index grouping, copy semantics) alongside the 10 existing JsonReporter tests.
- Real-pipeline check: the junit5 suite's own generated `report.json` parses as the new envelope — 83 reports, 115 structured remediations, 92 findings with `sourceLocation`.
- Honest note: `indexMetadata` is `null` in that file by design — the junit5 test classpath runs H2 with no index-metadata provider. It populates wherever the MySQL/PG adapters run (covered by unit tests here; field-verified next time the downstream app updates).
