### PR TITLE
feat(core): rule profiles — strict, recommended, minimal tiers

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -17,6 +17,8 @@ All properties are optional. The table below lists every supported key under the
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | `boolean` | `true` | Master switch for the entire auto-configuration. When `false`, the `QueryInterceptor` bean and the wrapping `BeanPostProcessor` are both skipped — the `@QueryAudit` annotation will not work either. Use `wrap-data-source.enabled: false` instead if you want to keep the interceptor active but skip the auto-wrap. |
+| `profile` | `String` | `"strict"` | Rule tier: `strict` (all rules), `recommended` (opinionated rules off), or `minimal` (safety-critical only). See [Rule Profiles](#rule-profiles). |
+| `enabled-rules` | `List<String>` | `[]` | Rule codes to run even when the profile tier excludes them. `disabled-rules` still wins. |
 | `mode` | `String` | `"annotated"` | Which tests the JUnit extension audits: `annotated` (opt-in via `@QueryAudit`) or `all` (every test, opt-out via `@QueryAuditExclude`). `all` additionally requires JUnit extension autodetection — see [Audit Coverage Mode](#audit-coverage-mode). |
 | `wrap-data-source.enabled` | `boolean` | `true` | Surgical escape hatch (issue #134) — disables only the auto-wrap `BeanPostProcessor` while keeping `QueryInterceptor` and `QueryAuditConfig` beans active. Use this when integrating with an existing datasource-proxy (e.g. gavlyukovskiy). |
 | `fail-on-detection` | `boolean` | `true` | Whether confirmed issues (ERROR/WARNING) should cause the test to fail with an `AssertionError`. |
@@ -85,6 +87,39 @@ query-audit:
     output-dir: build/reports/query-audit
     show-info: true
 ```
+
+---
+
+## Rule Profiles
+
+All rules enabled at once is the honest default, but on a first run against a real codebase it
+buries the high-precision findings under style opinions. Profiles are named tiers:
+
+| Profile | What runs | Use it for |
+|---|---|---|
+| `strict` (default) | Every rule — the pre-0.5.0 behavior | Maximum coverage, mature suppression setup |
+| `recommended` | Everything except ~20 opinionated / context-dependent rules | First adoption, day-to-day CI |
+| `minimal` | Safety-critical rules only (`n-plus-one`, `missing-where-index`, `missing-join-index`, `cartesian-join`, `update-without-where`, `unbounded-result-set`, `slow-query`) | A lean, non-negotiable gate |
+
+```yaml
+query-audit:
+  profile: recommended
+  enabled-rules:
+    - force-index-hint   # re-activate a rule the profile excludes
+```
+
+Precedence: `disabled-rules` > `enabled-rules` > profile tier.
+
+The `recommended` exclusions are rules that legitimately fire on correct SQL — index hints,
+offset pagination at small scale, leading LIKE wildcards, EXPLAIN advisories
+(`full-scan`/`filesort`/`temporary-table`), and style opinions such as `or-abuse` or
+`regexp-usage`. The full list with per-rule rationale lives in the `RuleProfile` source. The
+tier assignment is v1 and will be revised as per-rule false-positive statistics accumulate —
+[false-positive reports](https://github.com/haroya01/query-audit/issues) directly shape it.
+
+`recommended` is deny-list based: a newly added rule joins it automatically unless flagged as
+opinionated. External rules registered via `ServiceLoader` without a rule code are never
+filtered by profiles.
 
 ---
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
@@ -49,6 +49,8 @@ public class QueryAuditConfig {
   private final boolean includeSetupQueries;
   private final boolean countInsteadOfExistsEnabled;
   private final AuditMode auditMode;
+  private final RuleProfile ruleProfile;
+  private final Set<String> enabledRules;
 
   private QueryAuditConfig(Builder builder) {
     this.enabled = builder.enabled;
@@ -77,6 +79,8 @@ public class QueryAuditConfig {
     this.includeSetupQueries = builder.includeSetupQueries;
     this.countInsteadOfExistsEnabled = builder.countInsteadOfExistsEnabled;
     this.auditMode = builder.auditMode;
+    this.ruleProfile = builder.ruleProfile;
+    this.enabledRules = Collections.unmodifiableSet(new HashSet<>(builder.enabledRules));
   }
 
   public static Builder builder() {
@@ -151,6 +155,23 @@ public class QueryAuditConfig {
    *
    * @param ruleCode the issue type code (e.g., "select-all", "n-plus-one")
    */
+  /**
+   * Returns whether the rule should not run, combining the profile with explicit overrides.
+   * Precedence: {@code disabled-rules} wins over {@code enabled-rules}, which wins over the profile
+   * tier.
+   *
+   * @since 0.5.0
+   */
+  public boolean isRuleExcluded(String issueCode) {
+    if (disabledRules.contains(issueCode)) {
+      return true;
+    }
+    if (enabledRules.contains(issueCode)) {
+      return false;
+    }
+    return !ruleProfile.includes(issueCode);
+  }
+
   public boolean isRuleDisabled(String ruleCode) {
     return disabledRules.contains(ruleCode);
   }
@@ -249,6 +270,24 @@ public class QueryAuditConfig {
     return auditMode;
   }
 
+  /**
+   * Returns the active rule profile tier. Defaults to {@link RuleProfile#STRICT} (all rules).
+   *
+   * @since 0.5.0
+   */
+  public RuleProfile getRuleProfile() {
+    return ruleProfile;
+  }
+
+  /**
+   * Returns rule codes explicitly re-enabled on top of the profile tier.
+   *
+   * @since 0.5.0
+   */
+  public Set<String> getEnabledRules() {
+    return enabledRules;
+  }
+
   public boolean isSuppressed(String issueCode, String table, String column) {
     if (suppressPatterns.isEmpty()) {
       return false;
@@ -325,6 +364,8 @@ public class QueryAuditConfig {
     private boolean includeSetupQueries = false;
     private boolean countInsteadOfExistsEnabled = false;
     private AuditMode auditMode = AuditMode.ANNOTATED;
+    private RuleProfile ruleProfile = RuleProfile.STRICT;
+    private Set<String> enabledRules = new HashSet<>();
 
     /**
      * Creates a new builder pre-populated with all values from the given config. Useful for
@@ -357,6 +398,8 @@ public class QueryAuditConfig {
       b.repositoryReturnTypeResolver = source.repositoryReturnTypeResolver;
       b.countInsteadOfExistsEnabled = source.countInsteadOfExistsEnabled;
       b.auditMode = source.auditMode;
+      b.ruleProfile = source.ruleProfile;
+      b.enabledRules = new HashSet<>(source.enabledRules);
       return b;
     }
 
@@ -529,6 +572,34 @@ public class QueryAuditConfig {
      *
      * @since 0.5.0
      */
+    /**
+     * Sets the rule profile tier. {@code null} keeps the default ({@link RuleProfile#STRICT}).
+     *
+     * @since 0.5.0
+     */
+    public Builder ruleProfile(RuleProfile ruleProfile) {
+      if (ruleProfile != null) {
+        this.ruleProfile = ruleProfile;
+      }
+      return this;
+    }
+
+    /**
+     * Rule codes to run even when the profile tier excludes them.
+     *
+     * @since 0.5.0
+     */
+    public Builder enabledRules(Set<String> enabledRules) {
+      this.enabledRules = new HashSet<>(enabledRules);
+      return this;
+    }
+
+    /** Adds a single rule code to run even when the profile tier excludes it. */
+    public Builder addEnabledRule(String ruleCode) {
+      this.enabledRules.add(ruleCode);
+      return this;
+    }
+
     public Builder auditMode(AuditMode auditMode) {
       if (auditMode != null) {
         this.auditMode = auditMode;

--- a/query-audit-core/src/main/java/io/queryaudit/core/config/RuleProfile.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/RuleProfile.java
@@ -1,0 +1,103 @@
+package io.queryaudit.core.config;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Named rule tiers controlling which detection rules run by default.
+ *
+ * <ul>
+ *   <li>{@link #STRICT} — every rule (the pre-0.5.0 behavior, and the default).
+ *   <li>{@link #RECOMMENDED} — everything except the opinionated / context-dependent rules that
+ *       legitimately fire on correct SQL. Built for a quiet, trustworthy first run.
+ *   <li>{@link #MINIMAL} — safety-critical rules only, for a lean CI gate.
+ * </ul>
+ *
+ * <p>{@code RECOMMENDED} is deny-list based: a new rule joins it automatically unless it is added
+ * to the opinionated set. Explicit {@code disabled-rules} / {@code enabled-rules} configuration
+ * always wins over the profile. External rules registered via {@code ServiceLoader} without a rule
+ * code are never filtered by profiles.
+ *
+ * <p>The tier assignment below is v1, derived from rule severity and the false-positive history in
+ * the issue tracker; it is expected to be revised as per-rule hit/FP statistics accumulate.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+public enum RuleProfile {
+  STRICT,
+  RECOMMENDED,
+  MINIMAL;
+
+  /**
+   * Rules excluded from {@link #RECOMMENDED}: style opinions, context-dependent judgments, and
+   * report-only advisories that fire on legitimate SQL often enough to erode trust on first run.
+   */
+  private static final Set<String> OPINIONATED =
+      Set.of(
+          "force-index-hint", // hints are sometimes the right call
+          "offset-pagination", // fine at small scale
+          "like-leading-wildcard", // leading wildcards are often intentional
+          "or-abuse", // style opinion
+          "case-in-where", // style opinion
+          "regexp-usage", // style opinion
+          "find-in-set", // style opinion
+          "having-misuse", // heuristic
+          "distinct-misuse", // heuristic
+          "union-without-all", // deduplication is often wanted
+          "count-star-no-where", // legitimate table statistics
+          "count-instead-of-exists", // cannot tell aggregates from existence checks (issue #126)
+          "full-scan", // EXPLAIN advisory, environment-dependent
+          "filesort", // EXPLAIN advisory, environment-dependent
+          "temporary-table", // EXPLAIN advisory, environment-dependent
+          "covering-index-opportunity", // advice, not a defect
+          "n-plus-one-suspect", // SQL-level heuristic; the confirmed rule stays
+          "mergeable-queries", // advice, not a defect
+          "for-update-no-timeout", // environment-dependent
+          "window-no-partition" // often deliberate over the full result
+          );
+
+  /**
+   * The {@link #MINIMAL} allow-list: rules whose findings are near-certain production incidents.
+   */
+  private static final Set<String> SAFETY_CRITICAL =
+      Set.of(
+          "n-plus-one",
+          "missing-where-index",
+          "missing-join-index",
+          "cartesian-join",
+          "update-without-where",
+          "unbounded-result-set",
+          "slow-query");
+
+  /** Returns whether this profile runs the rule with the given issue code. */
+  public boolean includes(String issueCode) {
+    return switch (this) {
+      case STRICT -> true;
+      case RECOMMENDED -> !OPINIONATED.contains(issueCode);
+      case MINIMAL -> SAFETY_CRITICAL.contains(issueCode);
+    };
+  }
+
+  /**
+   * Parses a configuration value. Case-insensitive; {@code null} and blank map to {@link #STRICT}
+   * so absent configuration keeps the pre-0.5.0 behavior.
+   *
+   * @throws IllegalArgumentException on any other value, naming the accepted ones
+   */
+  public static RuleProfile parse(String value) {
+    if (value == null || value.isBlank()) {
+      return STRICT;
+    }
+    return switch (value.trim().toLowerCase(Locale.ROOT)) {
+      case "strict" -> STRICT;
+      case "recommended" -> RECOMMENDED;
+      case "minimal" -> MINIMAL;
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown query-audit profile '"
+                  + value
+                  + "' — expected 'strict', 'recommended', or 'minimal'");
+    };
+  }
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
@@ -188,10 +188,8 @@ public class QueryAuditAnalyzer {
       ruleList.add(rule);
     }
 
-    // Filter out disabled rules
-    if (!config.getDisabledRules().isEmpty()) {
-      ruleList.removeIf(rule -> isRuleDisabled(rule, config));
-    }
+    // Filter out rules excluded by the profile tier or explicit disables
+    ruleList.removeIf(rule -> isRuleDisabled(rule, config));
 
     return ruleList;
   }
@@ -201,10 +199,10 @@ public class QueryAuditAnalyzer {
    * codes for filtering.
    */
   private boolean isRuleDisabled(DetectionRule rule, QueryAuditConfig config) {
-    // Prefer the explicit rule code when available (exact match)
+    // Prefer the explicit rule code when available: profile-aware decision (exact match)
     String ruleCode = rule.getRuleCode();
     if (ruleCode != null) {
-      return config.getDisabledRules().contains(ruleCode);
+      return config.isRuleExcluded(ruleCode);
     }
 
     // Fallback: heuristic match based on class name for external/legacy rules
@@ -305,6 +303,12 @@ public class QueryAuditAnalyzer {
     List<Issue> acknowledgedIssues = new ArrayList<>();
 
     for (Issue issue : allIssues) {
+      // Profile tier / enabled-rules / disabled-rules decision on the exact issue code. This is
+      // the correctness net: rule-level filtering above can only exclude detectors that declare
+      // getRuleCode(), and most built-ins rely on the class-name heuristic instead.
+      if (config.isRuleExcluded(issue.type().getCode())) {
+        continue;
+      }
       if (config.isSuppressed(issue.type().getCode(), issue.table(), issue.column())) {
         continue;
       }

--- a/query-audit-core/src/test/java/io/queryaudit/core/config/RuleProfileTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/config/RuleProfileTest.java
@@ -1,0 +1,180 @@
+package io.queryaudit.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.queryaudit.core.detector.QueryAuditAnalyzer;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryAuditReport;
+import io.queryaudit.core.model.QueryRecord;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("RuleProfile (issue #164)")
+class RuleProfileTest {
+
+  @Nested
+  @DisplayName("parse()")
+  class Parse {
+
+    @Test
+    @DisplayName("all three tiers parse case-insensitively")
+    void parsesTiers() {
+      assertThat(RuleProfile.parse("strict")).isEqualTo(RuleProfile.STRICT);
+      assertThat(RuleProfile.parse("RECOMMENDED")).isEqualTo(RuleProfile.RECOMMENDED);
+      assertThat(RuleProfile.parse(" Minimal ")).isEqualTo(RuleProfile.MINIMAL);
+    }
+
+    @Test
+    @DisplayName("null and blank keep the pre-0.5.0 default (STRICT)")
+    void nullAndBlankDefaultToStrict() {
+      assertThat(RuleProfile.parse(null)).isEqualTo(RuleProfile.STRICT);
+      assertThat(RuleProfile.parse(" ")).isEqualTo(RuleProfile.STRICT);
+    }
+
+    @Test
+    @DisplayName("unknown values fail loudly, naming the accepted ones")
+    void unknownValueThrows() {
+      assertThatThrownBy(() -> RuleProfile.parse("paranoid"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("paranoid")
+          .hasMessageContaining("strict")
+          .hasMessageContaining("recommended")
+          .hasMessageContaining("minimal");
+    }
+  }
+
+  @Nested
+  @DisplayName("includes()")
+  class Includes {
+
+    @Test
+    @DisplayName("STRICT runs everything, including opinionated rules")
+    void strictIncludesEverything() {
+      assertThat(RuleProfile.STRICT.includes("force-index-hint")).isTrue();
+      assertThat(RuleProfile.STRICT.includes("n-plus-one")).isTrue();
+    }
+
+    @Test
+    @DisplayName("RECOMMENDED drops the opinionated set but keeps high-precision rules")
+    void recommendedDropsOpinionated() {
+      assertThat(RuleProfile.RECOMMENDED.includes("force-index-hint")).isFalse();
+      assertThat(RuleProfile.RECOMMENDED.includes("offset-pagination")).isFalse();
+      assertThat(RuleProfile.RECOMMENDED.includes("like-leading-wildcard")).isFalse();
+      assertThat(RuleProfile.RECOMMENDED.includes("n-plus-one")).isTrue();
+      assertThat(RuleProfile.RECOMMENDED.includes("missing-where-index")).isTrue();
+      assertThat(RuleProfile.RECOMMENDED.includes("update-without-where")).isTrue();
+    }
+
+    @Test
+    @DisplayName("MINIMAL runs only the safety-critical allow-list")
+    void minimalIsAllowListOnly() {
+      assertThat(RuleProfile.MINIMAL.includes("n-plus-one")).isTrue();
+      assertThat(RuleProfile.MINIMAL.includes("update-without-where")).isTrue();
+      assertThat(RuleProfile.MINIMAL.includes("select-all")).isFalse();
+      assertThat(RuleProfile.MINIMAL.includes("duplicate-query")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("QueryAuditConfig.isRuleExcluded() precedence")
+  class Precedence {
+
+    @Test
+    @DisplayName("disabled-rules wins over enabled-rules, which wins over the profile")
+    void precedenceOrder() {
+      QueryAuditConfig config =
+          QueryAuditConfig.builder()
+              .ruleProfile(RuleProfile.RECOMMENDED)
+              .addEnabledRule("force-index-hint")
+              .addEnabledRule("n-plus-one")
+              .addDisabledRule("n-plus-one")
+              .build();
+
+      // explicitly disabled beats everything, even an explicit enable
+      assertThat(config.isRuleExcluded("n-plus-one")).isTrue();
+      // explicitly enabled beats the profile exclusion
+      assertThat(config.isRuleExcluded("force-index-hint")).isFalse();
+      // profile decides the rest
+      assertThat(config.isRuleExcluded("offset-pagination")).isTrue();
+      assertThat(config.isRuleExcluded("missing-where-index")).isFalse();
+    }
+
+    @Test
+    @DisplayName("STRICT default keeps pre-0.5.0 behavior: nothing excluded without disabled-rules")
+    void strictDefaultExcludesNothing() {
+      QueryAuditConfig config = QueryAuditConfig.defaults();
+      assertThat(config.getRuleProfile()).isEqualTo(RuleProfile.STRICT);
+      assertThat(config.isRuleExcluded("force-index-hint")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Builder.from() copies profile and enabled rules")
+    void builderFromCopies() {
+      QueryAuditConfig source =
+          QueryAuditConfig.builder()
+              .ruleProfile(RuleProfile.MINIMAL)
+              .enabledRules(Set.of("select-all"))
+              .build();
+      QueryAuditConfig copy = QueryAuditConfig.Builder.from(source).build();
+      assertThat(copy.getRuleProfile()).isEqualTo(RuleProfile.MINIMAL);
+      assertThat(copy.getEnabledRules()).containsExactly("select-all");
+    }
+  }
+
+  @Nested
+  @DisplayName("End-to-end through QueryAuditAnalyzer")
+  class ThroughAnalyzer {
+
+    @TempDir Path tempDir;
+
+    private QueryAuditReport analyze(QueryAuditConfig config, String sql) {
+      QueryAuditAnalyzer analyzer =
+          new QueryAuditAnalyzer(config, tempDir.resolve("baseline.json"));
+      QueryRecord record = new QueryRecord(sql, 1_000L, 0L, "at com.example.T.m(T.java:1)");
+      return analyzer.analyze("TC", "tm", List.of(record), null);
+    }
+
+    private static final String FORCE_INDEX_SQL =
+        "SELECT id FROM orders FORCE INDEX (idx_user) WHERE user_id = 1";
+
+    @Test
+    @DisplayName("RECOMMENDED profile silences an opinionated detector")
+    void recommendedSilencesOpinionatedDetector() {
+      QueryAuditConfig strict = QueryAuditConfig.builder().build();
+      QueryAuditConfig recommended =
+          QueryAuditConfig.builder().ruleProfile(RuleProfile.RECOMMENDED).build();
+
+      assertThat(hasIssue(analyze(strict, FORCE_INDEX_SQL), IssueType.FORCE_INDEX_HINT))
+          .as("strict fires force-index-hint")
+          .isTrue();
+      assertThat(hasIssue(analyze(recommended, FORCE_INDEX_SQL), IssueType.FORCE_INDEX_HINT))
+          .as("recommended silences force-index-hint")
+          .isFalse();
+    }
+
+    @Test
+    @DisplayName("enabled-rules re-activates a rule the profile excludes")
+    void enabledRulesReactivates() {
+      QueryAuditConfig reEnabled =
+          QueryAuditConfig.builder()
+              .ruleProfile(RuleProfile.RECOMMENDED)
+              .addEnabledRule("force-index-hint")
+              .build();
+
+      assertThat(hasIssue(analyze(reEnabled, FORCE_INDEX_SQL), IssueType.FORCE_INDEX_HINT))
+          .isTrue();
+    }
+
+    private boolean hasIssue(QueryAuditReport report, IssueType type) {
+      return java.util.stream.Stream.concat(
+              report.getConfirmedIssues().stream(), report.getInfoIssues().stream())
+          .anyMatch(issue -> issue.type() == type);
+    }
+  }
+}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -303,6 +303,13 @@ public class QueryAuditExtension
       for (ExplainAnalyzer explainAnalyzer : loader) {
         if (dbProduct.contains(explainAnalyzer.supportedDatabase())) {
           List<Issue> explainIssues = explainAnalyzer.analyze(connection, queries);
+          // EXPLAIN-based issues bypass the detector registry, so the profile/disabled-rules
+          // decision is applied here.
+          QueryAuditConfig explainConfig = buildConfig(context);
+          explainIssues =
+              explainIssues.stream()
+                  .filter(issue -> !explainConfig.isRuleExcluded(issue.type().getCode()))
+                  .toList();
           if (!explainIssues.isEmpty()) {
             List<Issue> mergedInfo = new ArrayList<>(report.getInfoIssues());
             mergedInfo.addAll(explainIssues);

--- a/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/AnnotationOverridesYmlReproductionTest.java
+++ b/query-audit-junit5/src/test/java/io/queryaudit/junit5/integration/AnnotationOverridesYmlReproductionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
+import io.queryaudit.core.config.RuleProfile;
 import io.queryaudit.core.model.Severity;
 import io.queryaudit.junit5.BooleanOverride;
 import io.queryaudit.junit5.DetectNPlusOne;
@@ -111,6 +112,8 @@ class AnnotationOverridesYmlReproductionTest {
               .slowQueryWarningMs(1234L)
               .slowQueryErrorMs(5678L)
               .auditMode(AuditMode.ALL)
+              .ruleProfile(RuleProfile.RECOMMENDED)
+              .addEnabledRule("force-index-hint")
               .build();
 
       QueryAuditConfig copy = QueryAuditConfig.Builder.from(source).build();
@@ -165,6 +168,8 @@ class AnnotationOverridesYmlReproductionTest {
           .as("slowQueryErrorMs")
           .isEqualTo(source.getSlowQueryErrorMs());
       assertThat(copy.getAuditMode()).as("auditMode").isEqualTo(source.getAuditMode());
+      assertThat(copy.getRuleProfile()).as("ruleProfile").isEqualTo(source.getRuleProfile());
+      assertThat(copy.getEnabledRules()).as("enabledRules").isEqualTo(source.getEnabledRules());
     }
   }
 

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
@@ -2,6 +2,7 @@ package io.queryaudit.spring;
 
 import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
+import io.queryaudit.core.config.RuleProfile;
 import io.queryaudit.core.interceptor.DataSourceProxyFactory;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import io.queryaudit.core.model.Severity;
@@ -42,6 +43,8 @@ public class QueryAuditAutoConfiguration {
         .enabled(properties.isEnabled())
         .failOnDetection(properties.isFailOnDetection())
         .auditMode(AuditMode.parse(properties.getMode()))
+        .ruleProfile(RuleProfile.parse(properties.getProfile()))
+        .enabledRules(new HashSet<>(properties.getEnabledRules()))
         .nPlusOneThreshold(properties.getNPlusOne().getThreshold())
         .offsetPaginationThreshold(properties.getOffsetPagination().getThreshold())
         .orClauseThreshold(properties.getOrClause().getThreshold())

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
@@ -27,6 +27,16 @@ public class QueryAuditProperties {
    */
   private String mode = "annotated";
 
+  /**
+   * Rule profile tier: {@code strict} (all rules, the default), {@code recommended} (opinionated
+   * rules off), or {@code minimal} (safety-critical only). {@code disabled-rules} / {@code
+   * enabled-rules} always win over the profile.
+   */
+  private String profile = "strict";
+
+  /** Rule codes to run even when the profile tier excludes them. */
+  private List<String> enabledRules = new ArrayList<>();
+
   private NPlusOne nPlusOne = new NPlusOne();
   private OffsetPagination offsetPagination = new OffsetPagination();
   private OrClause orClause = new OrClause();
@@ -71,6 +81,22 @@ public class QueryAuditProperties {
 
   public void setMode(String mode) {
     this.mode = mode;
+  }
+
+  public String getProfile() {
+    return profile;
+  }
+
+  public void setProfile(String profile) {
+    this.profile = profile;
+  }
+
+  public List<String> getEnabledRules() {
+    return enabledRules;
+  }
+
+  public void setEnabledRules(List<String> enabledRules) {
+    this.enabledRules = enabledRules;
   }
 
   public NPlusOne getNPlusOne() {

--- a/query-audit-spring-boot-starter/src/test/java/io/queryaudit/spring/QueryAuditAutoConfigurationTest.java
+++ b/query-audit-spring-boot-starter/src/test/java/io/queryaudit/spring/QueryAuditAutoConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
+import io.queryaudit.core.config.RuleProfile;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,49 @@ class QueryAuditAutoConfigurationTest {
   private final ApplicationContextRunner contextRunner =
       new ApplicationContextRunner()
           .withConfiguration(AutoConfigurations.of(QueryAuditAutoConfiguration.class));
+
+  @Nested
+  @DisplayName("Rule profile properties (issue #164)")
+  class RuleProfileProperties {
+
+    @Test
+    @DisplayName("defaults to STRICT")
+    void defaultsToStrict() {
+      contextRunner.run(
+          context ->
+              assertThat(context.getBean(QueryAuditConfig.class).getRuleProfile())
+                  .isEqualTo(RuleProfile.STRICT));
+    }
+
+    @Test
+    @DisplayName("query-audit.profile=recommended binds, enabled-rules re-activates")
+    void bindsProfileAndEnabledRules() {
+      contextRunner
+          .withPropertyValues(
+              "query-audit.profile=recommended", "query-audit.enabled-rules=force-index-hint")
+          .run(
+              context -> {
+                QueryAuditConfig config = context.getBean(QueryAuditConfig.class);
+                assertThat(config.getRuleProfile()).isEqualTo(RuleProfile.RECOMMENDED);
+                assertThat(config.isRuleExcluded("force-index-hint")).isFalse();
+                assertThat(config.isRuleExcluded("offset-pagination")).isTrue();
+              });
+    }
+
+    @Test
+    @DisplayName("an invalid profile fails context startup instead of being silently ignored")
+    void invalidProfileFailsStartup() {
+      contextRunner
+          .withPropertyValues("query-audit.profile=paranoid")
+          .run(
+              context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .hasMessageContaining("paranoid");
+              });
+    }
+  }
 
   @Nested
   @DisplayName("Audit mode property (issue #163)")


### PR DESCRIPTION
## Summary

Closes #164.

First-run noise is the primary adoption killer for any linter-class tool: all 64 rules fire at once and the high-precision findings drown in style opinions. Profiles are named tiers, selectable via `query-audit.profile`, with explicit precedence: **`disabled-rules` > `enabled-rules` > profile**.

| Profile | What runs | Intended use |
|---|---|---|
| `strict` (default) | Every rule — the pre-0.5.0 behavior, zero change for existing users | Maximum coverage |
| `recommended` | Everything except ~20 opinionated / context-dependent rules | First adoption, day-to-day CI |
| `minimal` | 7 safety-critical rules (`n-plus-one`, `missing-where-index`, `missing-join-index`, `cartesian-join`, `update-without-where`, `unbounded-result-set`, `slow-query`) | Lean non-negotiable gate |

`enabled-rules` (new) re-activates individual rules a tier excludes, so the profile is a starting point, not a cage.

## Design decisions

- **Deny-list for `recommended`**: a newly added rule joins the tier automatically unless flagged opinionated — more maintainable than a 45-entry allow-list, and the exclusion list *is* the documentation (per-rule rationale comments in `RuleProfile`).
- **Issue-level enforcement as the correctness net**: only 2 of 64 detectors declare `getRuleCode()`, and the class-name fallback has real holes (`regexp-usage` never matches `RegexpInsteadOfLikeDetector`). The profile decision is therefore applied on the exact issue code during classification; rule-level filtering stays as a fast path. EXPLAIN-sourced issues, which bypass the detector registry entirely, get the same decision in the extension.
- **Tier assignment is v1** — derived from rule severity and false-positive history, and documented as subject to revision as per-rule hit/FP statistics accumulate (dogfooding data from a 3,000-test downstream suite is the planned evidence source). Deviation from the issue text: `recommended` keeps ~45 rules rather than "~25" — exclusion-based tiering made the larger high-precision set the natural cut.

## Verification

- Full suite green. New tests: parse rules, tier membership spot checks, precedence order (disable > enable > profile), Builder copy semantics, Spring binding incl. startup failure on an invalid value.
- End-to-end through `QueryAuditAnalyzer` with real SQL: `strict` fires `force-index-hint` on `FORCE INDEX` SQL, `recommended` silences it, `enabled-rules: [force-index-hint]` re-activates it.

## Docs

`guide/configuration.md`: `profile` / `enabled-rules` property rows + a **Rule Profiles** section with the tier table, precedence, and the honest v1-assignment caveat inviting FP reports.
