### PR TITLE
feat(junit5): query snapshot contracts — record and enforce per-test query behavior

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -404,6 +404,8 @@ These can be passed via `-D` flags on the command line:
 |---|---|
 | `-DqueryAudit.mode=all` | Audit every test regardless of annotations — see [Audit Coverage Mode](#audit-coverage-mode) |
 | `-DqueryAudit.updateBaseline=true` | Update the query count baseline file after test run |
+| `-DqueryAudit.contracts.record=true` | Record/refresh [query snapshot contracts](contracts.md) instead of enforcing them |
+| `-DqueryAudit.contractsPath=path` | Override the contracts file location |
 | `-DqueryAudit.countBaselinePath=path` | Override the query count baseline file path |
 | `-Dqueryaudit.autoOpenReport=true` | Force open HTML report in browser |
 

--- a/docs/guide/contracts.md
+++ b/docs/guide/contracts.md
@@ -1,0 +1,100 @@
+# Query Snapshot Contracts
+
+Snapshot testing for database behavior: record every test's query profile once, then fail any
+change — in either direction — until the contract is explicitly re-recorded.
+
+What the [baseline](suppressing.md) does for *findings*, contracts do for *behavior*. A
+regression detector only catches increases; a contract catches **every deviation**, which is
+what makes it reviewable: after a legitimate change you re-record, and the contracts file's
+diff *is* the behavior change, sitting in the PR next to the code that caused it.
+
+This matters most when code is written or modified by automation: a generated change that
+turns one UPDATE into N, or quietly adds writes to a read path, is invisible in a code diff
+and green in ordinary tests. With contracts, any DB-behavior change must surface as an
+explicit contract update.
+
+---
+
+## Recording
+
+Run the suite once with the record flag:
+
+```bash
+./gradlew test -DqueryAudit.contracts.record=true
+```
+
+Every audited test's SELECT/INSERT/UPDATE/DELETE counts are written to
+`.query-audit-contracts` in the working directory (pipe-separated, sorted, human-reviewable):
+
+```
+# QueryAudit Query Contracts
+# Format: testClass | testMethod | selectCount | insertCount | updateCount | deleteCount | totalCount
+OrderServiceTest | findOrders() | 3 | 0 | 0 | 0 | 3
+OrderServiceTest | placeOrder() | 2 | 1 | 1 | 0 | 4
+```
+
+Commit the file. Pair with [`mode: all`](configuration.md#audit-coverage-mode) to freeze the
+whole suite's behavior in one run.
+
+!!! note "Gradle daemon and `-D` flags"
+    Gradle only forwards `-D` system properties to the test JVM if your `test` task is
+    configured to do so. If the flag doesn't seem to take effect, pass it explicitly:
+
+    ```groovy
+    tasks.named('test') {
+        systemProperty 'queryAudit.contracts.record',
+            providers.gradleProperty('recordContracts').getOrElse('false')
+    }
+    ```
+
+    and run `./gradlew test -PrecordContracts=true`.
+
+## Enforcement
+
+On every subsequent run, each test with a recorded entry is compared against its contract.
+Any deviation fails with the full delta, the offending SQL, and its call site:
+
+```
+QueryAudit: placeOrder() deviates from its recorded query contract (.query-audit-contracts).
+  INSERT: contract 1, executed 3 (+2)
+    insert into order_items (order_id, sku) values (?, ?)
+      at com.example.OrderService.placeOrder(OrderService.java:87)
+If the change is intended, re-record the contracts with -DqueryAudit.contracts.record=true and review the file diff.
+```
+
+Rules of enforcement:
+
+- **Both directions fail.** Fewer queries than the contract also fails — snapshot semantics.
+  An improvement is still a behavior change that belongs in the contract diff.
+- **Tests without an entry are not enforced.** New tests never fail retroactively;
+  re-recording picks them up.
+- **`@ExpectQueries` wins.** A method carrying an inline budget is exempt from the file
+  contract — the annotation is the more specific declaration.
+- **Record mode skips enforcement**, so a red suite can always re-record.
+
+## Updating
+
+Re-record and review the diff:
+
+```bash
+./gradlew test -DqueryAudit.contracts.record=true
+git diff .query-audit-contracts
+```
+
+Recording merges: tests that ran are updated, entries for tests that didn't run are kept.
+
+## Configuration
+
+| System property | Description |
+|---|---|
+| `-DqueryAudit.contracts.record=true` | Record/refresh contracts instead of enforcing them |
+| `-DqueryAudit.contractsPath=path` | Override the contracts file location |
+
+## Contracts vs. related features
+
+| | Scope | Fails on | Update flow |
+|---|---|---|---|
+| **Contracts** | every recorded test | any count deviation, both directions | re-record, review file diff |
+| [`@ExpectQueries`](annotations.md#expectqueries) | one method | budget exceeded | edit the annotation |
+| Count baseline (`-DqueryAudit.updateBaseline`) | every test | count **regression** (increase) | update baseline |
+| [Issue baseline](suppressing.md) | findings | new findings | acknowledge |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
     - Configuration: guide/configuration.md
     - Reports: guide/reports.md
     - Suppressing Issues: guide/suppressing.md
+    - Query Contracts: guide/contracts.md
     - CI/CD Integration: guide/ci-cd.md
     - Troubleshooting: guide/troubleshooting.md
   - Architecture:

--- a/query-audit-core/src/main/java/io/queryaudit/core/regression/QueryContracts.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/regression/QueryContracts.java
@@ -1,0 +1,136 @@
+package io.queryaudit.core.regression;
+
+import io.queryaudit.core.model.QueryRecord;
+import io.queryaudit.core.parser.SqlParser;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Snapshot contracts for per-test query behavior (issue #166).
+ *
+ * <p>What the baseline does for <em>findings</em>, contracts do for <em>behavior</em>: a recorded
+ * contract freezes each test's query profile (SELECT/INSERT/UPDATE/DELETE counts), and any change —
+ * in either direction — fails with a delta until the contract is explicitly re-recorded. A
+ * regression detector only catches increases; a contract catches every deviation, which is what
+ * makes it reviewable: the re-recorded file's diff is the change.
+ *
+ * <p>Storage reuses the {@link QueryCountBaseline} pipe-separated format on a separate file
+ * ({@value #DEFAULT_FILE_NAME}). Tests without a recorded entry are not enforced — new tests never
+ * fail retroactively; re-recording picks them up.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+public final class QueryContracts {
+
+  /** Default contracts file name. */
+  public static final String DEFAULT_FILE_NAME = ".query-audit-contracts";
+
+  private QueryContracts() {
+    /* utility class */
+  }
+
+  /**
+   * Compares a test's actual counts against its recorded contract.
+   *
+   * @return a human-readable failure message with the full delta, or {@code null} when the contract
+   *     is met or no contract exists for this test
+   */
+  public static String verify(
+      String testClass,
+      String testName,
+      QueryCounts actual,
+      Map<String, QueryCounts> contracts,
+      List<QueryRecord> queries) {
+    QueryCounts contract = contracts.get(QueryCountBaseline.key(testClass, testName));
+    if (contract == null || contract.equals(actual)) {
+      return null;
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("QueryAudit: ")
+        .append(testName)
+        .append(" deviates from its recorded query contract (")
+        .append(DEFAULT_FILE_NAME)
+        .append(").\n");
+    appendTypeDelta(
+        sb,
+        "SELECT",
+        contract.selectCount(),
+        actual.selectCount(),
+        queries,
+        SqlParser::isSelectQuery);
+    appendTypeDelta(
+        sb,
+        "INSERT",
+        contract.insertCount(),
+        actual.insertCount(),
+        queries,
+        SqlParser::isInsertQuery);
+    appendTypeDelta(
+        sb,
+        "UPDATE",
+        contract.updateCount(),
+        actual.updateCount(),
+        queries,
+        SqlParser::isUpdateQuery);
+    appendTypeDelta(
+        sb,
+        "DELETE",
+        contract.deleteCount(),
+        actual.deleteCount(),
+        queries,
+        SqlParser::isDeleteQuery);
+    sb.append(
+        "If the change is intended, re-record the contracts with"
+            + " -DqueryAudit.contracts.record=true and review the file diff.");
+    return sb.toString();
+  }
+
+  /**
+   * Appends one delta line when the type deviates; when the count grew, every query of that type is
+   * listed with its call site so the offender is identifiable without re-running.
+   */
+  private static void appendTypeDelta(
+      StringBuilder sb,
+      String type,
+      int expected,
+      int actual,
+      List<QueryRecord> queries,
+      Predicate<String> typeMatcher) {
+    if (expected == actual) {
+      return;
+    }
+    sb.append("  ")
+        .append(type)
+        .append(": contract ")
+        .append(expected)
+        .append(", executed ")
+        .append(actual)
+        .append(actual > expected ? " (+" + (actual - expected) + ")" : "")
+        .append('\n');
+    if (actual > expected) {
+      for (QueryRecord query : queries) {
+        if (!typeMatcher.test(query.sql())) {
+          continue;
+        }
+        String sql = query.sql();
+        sb.append("    ").append(sql.length() > 100 ? sql.substring(0, 100) + "..." : sql);
+        String callSite = firstStackFrame(query.stackTrace());
+        if (callSite != null) {
+          sb.append("\n      at ").append(callSite);
+        }
+        sb.append('\n');
+      }
+    }
+  }
+
+  private static String firstStackFrame(String stackTrace) {
+    if (stackTrace == null || stackTrace.isEmpty()) {
+      return null;
+    }
+    int newline = stackTrace.indexOf('\n');
+    return newline < 0 ? stackTrace : stackTrace.substring(0, newline);
+  }
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/regression/QueryCountBaseline.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/regression/QueryCountBaseline.java
@@ -99,6 +99,17 @@ public final class QueryCountBaseline {
    * @throws IOException if the file cannot be written
    */
   public static void save(Path file, Map<String, QueryCounts> counts) throws IOException {
+    save(file, counts, "Query Guard Count Baseline");
+  }
+
+  /**
+   * Writes the counts with a caller-supplied header title, so other stores reusing this format
+   * (e.g. the query contracts file) stay self-describing.
+   *
+   * @since 0.5.0
+   */
+  public static void save(Path file, Map<String, QueryCounts> counts, String headerTitle)
+      throws IOException {
     if (file.getParent() != null) {
       Files.createDirectories(file.getParent());
     }
@@ -107,7 +118,7 @@ public final class QueryCountBaseline {
     Map<String, QueryCounts> sorted = new TreeMap<>(counts);
 
     try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
-      writer.write("# Query Guard Count Baseline");
+      writer.write("# " + headerTitle);
       writer.newLine();
       writer.write(
           "# Format: testClass | testMethod | selectCount | insertCount | updateCount | deleteCount | totalCount");

--- a/query-audit-core/src/test/java/io/queryaudit/core/regression/QueryContractsTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/regression/QueryContractsTest.java
@@ -1,0 +1,81 @@
+package io.queryaudit.core.regression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.QueryRecord;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("QueryContracts (issue #166)")
+class QueryContractsTest {
+
+  private static final String KEY_CLASS = "OrderServiceTest";
+  private static final String KEY_TEST = "findOrders";
+
+  private static Map<String, QueryCounts> contracts(QueryCounts counts) {
+    return Map.of(QueryCountBaseline.key(KEY_CLASS, KEY_TEST), counts);
+  }
+
+  @Test
+  @DisplayName("no contract for the test — not enforced")
+  void missingContractIsNotEnforced() {
+    String failure =
+        QueryContracts.verify(
+            KEY_CLASS,
+            "someOtherTest",
+            new QueryCounts(5, 0, 0, 0, 5),
+            contracts(new QueryCounts(1, 0, 0, 0, 1)),
+            List.of());
+    assertThat(failure).isNull();
+  }
+
+  @Test
+  @DisplayName("matching counts — contract met")
+  void matchingCountsPass() {
+    QueryCounts counts = new QueryCounts(3, 1, 0, 0, 4);
+    String failure =
+        QueryContracts.verify(KEY_CLASS, KEY_TEST, counts, contracts(counts), List.of());
+    assertThat(failure).isNull();
+  }
+
+  @Test
+  @DisplayName("an increase fails with the delta and the offending SQL + call site")
+  void increaseFailsWithDelta() {
+    QueryRecord select =
+        new QueryRecord(
+            "SELECT * FROM orders",
+            1_000L,
+            0L,
+            "com.example.OrderService.load(OrderService.java:42)");
+    String failure =
+        QueryContracts.verify(
+            KEY_CLASS,
+            KEY_TEST,
+            new QueryCounts(2, 0, 0, 0, 2),
+            contracts(new QueryCounts(1, 0, 0, 0, 1)),
+            List.of(select, select));
+
+    assertThat(failure).contains("deviates from its recorded query contract");
+    assertThat(failure).contains("SELECT: contract 1, executed 2 (+1)");
+    assertThat(failure).contains("SELECT * FROM orders");
+    assertThat(failure).contains("at com.example.OrderService.load(OrderService.java:42)");
+    assertThat(failure).contains("-DqueryAudit.contracts.record=true");
+  }
+
+  @Test
+  @DisplayName("a decrease also fails — snapshot semantics, both directions")
+  void decreaseAlsoFails() {
+    String failure =
+        QueryContracts.verify(
+            KEY_CLASS,
+            KEY_TEST,
+            new QueryCounts(1, 0, 0, 0, 1),
+            contracts(new QueryCounts(2, 1, 0, 0, 3)),
+            List.of());
+
+    assertThat(failure).contains("SELECT: contract 2, executed 1");
+    assertThat(failure).contains("INSERT: contract 1, executed 0");
+  }
+}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -12,6 +12,7 @@ import io.queryaudit.core.interceptor.QueryInterceptor;
 import io.queryaudit.core.model.*;
 import io.queryaudit.core.model.LifecyclePhase;
 import io.queryaudit.core.parser.SqlParser;
+import io.queryaudit.core.regression.QueryContracts;
 import io.queryaudit.core.regression.QueryCountBaseline;
 import io.queryaudit.core.regression.QueryCountRegressionDetector;
 import io.queryaudit.core.regression.QueryCounts;
@@ -67,6 +68,7 @@ public class QueryAuditExtension
   private static final String KEY_DATASOURCE_HOOK_CLEANUP = "dataSourceHookCleanup";
   private static final String KEY_ACTIVE = "auditActive";
   private static final String KEY_AFTER_EACH_DONE = "afterEachDone";
+  private static final String KEY_CONTRACTS = "queryContracts";
 
   private static final QueryCountRegressionDetector REGRESSION_DETECTOR =
       new QueryCountRegressionDetector();
@@ -132,6 +134,9 @@ public class QueryAuditExtension
     Map<String, QueryCounts> countBaseline = QueryCountBaseline.load(countBaselinePath);
     store.put(KEY_COUNT_BASELINE, countBaseline);
     store.put(KEY_CURRENT_COUNTS, new ConcurrentHashMap<String, QueryCounts>());
+
+    // Load recorded query contracts for snapshot enforcement (issue #166)
+    store.put(KEY_CONTRACTS, QueryCountBaseline.load(resolveContractsPath()));
 
     // Register Hibernate LazyLoadTracker if Hibernate is on the classpath
     LazyLoadTracker tracker = hibernateIntegration.registerTracker(context, NAMESPACE);
@@ -275,6 +280,9 @@ public class QueryAuditExtension
     // --- @ExpectQueries ---
     checkExpectQueries(context, queries, testName);
 
+    // --- Query snapshot contracts (issue #166) ---
+    checkQueryContracts(context, queries, testClass, testName);
+
     // --- @DetectNPlusOne ---
     checkDetectNPlusOne(context, report, testName);
 
@@ -405,6 +413,7 @@ public class QueryAuditExtension
     QueryAuditDataSourceStore.clear();
 
     writeCountBaselineIfRequested(context);
+    writeContractsIfRequested(context);
 
     // Register a ReportFinalizer in the root context store so that
     // writeReport + openReportInBrowser runs exactly once after ALL test classes finish,
@@ -487,6 +496,85 @@ public class QueryAuditExtension
         System.err.println("[QueryAudit] Failed to write HTML report: " + e.getMessage());
       }
     }
+  }
+
+  // ── Query snapshot contracts (issue #166) ─────────────────────────
+
+  /**
+   * Enforces the recorded query contract for this test, if one exists. Skipped in record mode (a
+   * red suite must still be able to re-record) and when the method declares {@code @ExpectQueries}
+   * — the inline budget is the more specific contract and wins.
+   */
+  private void checkQueryContracts(
+      ExtensionContext context, List<QueryRecord> queries, String testClass, String testName) {
+    if (isContractRecordMode()) {
+      return;
+    }
+    Optional<Method> method = context.getTestMethod();
+    if (method.isPresent() && method.get().getAnnotation(ExpectQueries.class) != null) {
+      return;
+    }
+    Map<String, QueryCounts> contracts = getContracts(context);
+    if (contracts == null || contracts.isEmpty()) {
+      return;
+    }
+    String failure =
+        QueryContracts.verify(testClass, testName, QueryCounts.from(queries), contracts, queries);
+    if (failure != null) {
+      throw new AssertionError(failure);
+    }
+  }
+
+  /** Merge-writes the accumulated per-test counts into the contracts file in record mode. */
+  private void writeContractsIfRequested(ExtensionContext context) {
+    if (!isContractRecordMode()) {
+      return;
+    }
+    Map<String, QueryCounts> currentCounts = getCurrentCounts(context);
+    if (currentCounts == null || currentCounts.isEmpty()) {
+      return;
+    }
+    try {
+      Path contractsPath = resolveContractsPath();
+      Map<String, QueryCounts> merged = new LinkedHashMap<>(QueryCountBaseline.load(contractsPath));
+      merged.putAll(currentCounts);
+      QueryCountBaseline.save(contractsPath, merged, "QueryAudit Query Contracts");
+      System.out.println(
+          "[QueryAudit] Query contracts recorded: "
+              + contractsPath.toAbsolutePath()
+              + " ("
+              + currentCounts.size()
+              + " test(s))");
+    } catch (Exception e) {
+      System.err.println("[QueryAudit] Failed to write query contracts: " + e.getMessage());
+    }
+  }
+
+  private static boolean isContractRecordMode() {
+    return Boolean.parseBoolean(
+        resolveSystemProperty(
+            "queryAudit.contracts.record", "queryGuard.contracts.record", "false"));
+  }
+
+  private static Path resolveContractsPath() {
+    String sysProp = resolveSystemProperty("queryAudit.contractsPath", "queryGuard.contractsPath");
+    if (sysProp != null && !sysProp.isEmpty()) {
+      return Path.of(sysProp);
+    }
+    return Path.of(QueryContracts.DEFAULT_FILE_NAME);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, QueryCounts> getContracts(ExtensionContext context) {
+    ExtensionContext current = context;
+    while (current != null) {
+      Object obj = current.getStore(NAMESPACE).get(KEY_CONTRACTS);
+      if (obj instanceof Map<?, ?> map) {
+        return (Map<String, QueryCounts>) map;
+      }
+      current = current.getParent().orElse(null);
+    }
+    return null;
   }
 
   // ── Annotation-specific checks ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #166.

Snapshot testing for database behavior. What the baseline does for *findings*, contracts do for *behavior*: record every test's query profile once, then **any deviation — in either direction — fails** with the full delta until the contract is explicitly re-recorded. After a legitimate change you re-record, and the contracts file's diff *is* the behavior change, reviewable in the PR next to the code that caused it.

This is the piece that matters most when code is written or modified by automation: a change that turns one UPDATE into N, or quietly adds writes to a read path, is invisible in a code diff and green in ordinary tests — with contracts it must surface as an explicit contract update.

## How it works

- **Record**: `./gradlew test -DqueryAudit.contracts.record=true` writes per-test SELECT/INSERT/UPDATE/DELETE counts to `.query-audit-contracts` — pipe-separated, sorted, human-reviewable (the proven `QueryCountBaseline` format on a separate file; `save()` gained a header-title overload so the file stays self-describing). Recording merge-writes: tests that ran are updated, other entries are kept.
- **Enforce**: on ordinary runs, a recorded test whose counts deviate fails with contract-vs-executed per type, the offending SQL, its call site, and the re-record instruction.
- **Semantics** (all documented):
  - decreases fail too — snapshot, not budget; an improvement is still a behavior change that belongs in the diff;
  - tests without an entry are not enforced — new tests never fail retroactively;
  - `@ExpectQueries` on the method wins over the file contract;
  - record mode skips enforcement so a red suite can always re-record.
- Pairs with `mode: all` (#163): one record run freezes the whole suite's DB behavior.

## Resolved open questions from the issue

- **Granularity**: counts-by-type only in v1. Normalized-pattern sets were considered and deferred — they'd make contracts brittle against harmless refactors before the FP economics are understood.
- **Storage**: sidecar file, not generated annotations — one reviewable artifact, no source rewriting.

## Verification

End-to-end with a scratch probe (record → tamper → enforce → restore):

- record run wrote `ZScratchContractProbeTest | probe() | 1 | 0 | 0 | 0 | 1`;
- after tampering the contract to 0 selects, the enforce run failed with `SELECT: contract 0, executed 1 (+1)` plus the actual SQL (`select t1_0.id,... from teams t1_0`) and call site;
- restoring the contract turned the run green.

Unit tests cover the verify semantics (missing entry, exact match, increase with offender listing, decrease). Full suite green.

Found along the way: `Files.createDirectories` on a contracts path under a symlinked directory (macOS `/tmp`) fails with `FileAlreadyExistsException` — pre-existing behavior shared with the baseline writer, left as is and worth a follow-up issue if it bites anyone in the field.

## Docs

New **Query Contracts** guide page (record/enforce/update flows, the Gradle daemon `-D` forwarding trap with a copy-paste fix, and a comparison table vs `@ExpectQueries` / count baseline / issue baseline), added to the nav; system-property rows in the configuration reference.
