### PR TITLE
feat(core): delta verdict — compare two report.json runs into a machine-readable resolution verdict

### DIFF
--- a/docs/guide/reports.md
+++ b/docs/guide/reports.md
@@ -216,6 +216,44 @@ The machine-readable contract lives at
 
 ---
 
+## Delta Verdict (compare two runs)
+
+Every fix loop ends with the same question: *did my change resolve the finding without
+introducing new ones?* The compare command answers it from two `report.json` files alone —
+no re-analysis, no database access:
+
+```bash
+java -cp query-audit-core-<version>.jar \
+    io.queryaudit.core.reporter.ReportComparator before.json after.json verdict.json
+```
+
+```
+[QueryAudit] compare: 0 new, 1 resolved, 0 persisting; queries 11 -> 7
+  RESOLVED n-plus-one (table: order_items) in OrderServiceTest.findOrders
+```
+
+- **Exit contract**: `0` when no new findings, `1` when new findings exist (the diff-aware CI
+  gate: fail a PR only on *new* issues), `2` on usage/parse errors.
+- **`verdict.json`**: `{newFindings, resolved, persisting, queryCountDelta, executionTimeMsDelta}` —
+  the termination condition for automated fix loops.
+- **Matching key**: `testClass|testName|type|normalized-pattern|sourceLocation`, so findings
+  survive unrelated refactors as long as the statement shape and call site are stable.
+- Only **confirmed** findings participate; INFO advisories don't gate fix loops.
+- Requires the versioned envelope (schema 1.x, QueryAudit 0.5.0+); pre-envelope reports are
+  rejected with a hint.
+
+As a Gradle task in the consuming project:
+
+```groovy
+tasks.register('queryAuditCompare', JavaExec) {
+    classpath = configurations.testRuntimeClasspath
+    mainClass = 'io.queryaudit.core.reporter.ReportComparator'
+    args 'baseline-report.json', 'build/reports/query-audit/report.json', 'build/verdict.json'
+}
+```
+
+---
+
 ## HTML Report
 
 The HTML report aggregator accumulates results across all test classes and produces a

--- a/query-audit-core/src/main/java/io/queryaudit/core/reporter/MiniJsonParser.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/reporter/MiniJsonParser.java
@@ -1,0 +1,218 @@
+package io.queryaudit.core.reporter;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal recursive-descent JSON parser for reading back {@code report.json} in the compare
+ * command. Exists because core is deliberately dependency-free — the same reason the writer side
+ * ({@link JsonReporter}) is {@code StringBuilder}-based.
+ *
+ * <p>Parses the full JSON grammar (RFC 8259): objects as {@link LinkedHashMap}, arrays as {@link
+ * ArrayList}, strings with all escape sequences, numbers as {@link Long} when integral and {@link
+ * Double} otherwise, booleans, and {@code null}. Not tuned for adversarial input — the input is
+ * QueryAudit's own reporter output.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+final class MiniJsonParser {
+
+  private final String input;
+  private int pos;
+
+  private MiniJsonParser(String input) {
+    this.input = input;
+  }
+
+  /** Parses a complete JSON document; trailing non-whitespace is an error. */
+  static Object parse(String json) {
+    MiniJsonParser parser = new MiniJsonParser(json);
+    parser.skipWhitespace();
+    Object value = parser.parseValue();
+    parser.skipWhitespace();
+    if (parser.pos != json.length()) {
+      throw parser.error("trailing content");
+    }
+    return value;
+  }
+
+  private Object parseValue() {
+    char c = peek();
+    return switch (c) {
+      case '{' -> parseObject();
+      case '[' -> parseArray();
+      case '"' -> parseString();
+      case 't', 'f' -> parseBoolean();
+      case 'n' -> parseNull();
+      default -> parseNumber();
+    };
+  }
+
+  private Map<String, Object> parseObject() {
+    expect('{');
+    Map<String, Object> result = new LinkedHashMap<>();
+    skipWhitespace();
+    if (peek() == '}') {
+      pos++;
+      return result;
+    }
+    while (true) {
+      skipWhitespace();
+      String key = parseString();
+      skipWhitespace();
+      expect(':');
+      skipWhitespace();
+      result.put(key, parseValue());
+      skipWhitespace();
+      char c = next();
+      if (c == '}') {
+        return result;
+      }
+      if (c != ',') {
+        throw error("expected ',' or '}' in object");
+      }
+    }
+  }
+
+  private List<Object> parseArray() {
+    expect('[');
+    List<Object> result = new ArrayList<>();
+    skipWhitespace();
+    if (peek() == ']') {
+      pos++;
+      return result;
+    }
+    while (true) {
+      skipWhitespace();
+      result.add(parseValue());
+      skipWhitespace();
+      char c = next();
+      if (c == ']') {
+        return result;
+      }
+      if (c != ',') {
+        throw error("expected ',' or ']' in array");
+      }
+    }
+  }
+
+  private String parseString() {
+    expect('"');
+    StringBuilder sb = new StringBuilder();
+    while (true) {
+      char c = next();
+      if (c == '"') {
+        return sb.toString();
+      }
+      if (c == '\\') {
+        char esc = next();
+        switch (esc) {
+          case '"' -> sb.append('"');
+          case '\\' -> sb.append('\\');
+          case '/' -> sb.append('/');
+          case 'b' -> sb.append('\b');
+          case 'f' -> sb.append('\f');
+          case 'n' -> sb.append('\n');
+          case 'r' -> sb.append('\r');
+          case 't' -> sb.append('\t');
+          case 'u' -> {
+            if (pos + 4 > input.length()) {
+              throw error("truncated \\u escape");
+            }
+            sb.append((char) Integer.parseInt(input.substring(pos, pos + 4), 16));
+            pos += 4;
+          }
+          default -> throw error("invalid escape '\\" + esc + "'");
+        }
+      } else {
+        sb.append(c);
+      }
+    }
+  }
+
+  private Boolean parseBoolean() {
+    if (input.startsWith("true", pos)) {
+      pos += 4;
+      return Boolean.TRUE;
+    }
+    if (input.startsWith("false", pos)) {
+      pos += 5;
+      return Boolean.FALSE;
+    }
+    throw error("invalid literal");
+  }
+
+  private Object parseNull() {
+    if (input.startsWith("null", pos)) {
+      pos += 4;
+      return null;
+    }
+    throw error("invalid literal");
+  }
+
+  private Object parseNumber() {
+    int start = pos;
+    if (peek() == '-') {
+      pos++;
+    }
+    boolean integral = true;
+    while (pos < input.length()) {
+      char c = input.charAt(pos);
+      if (c >= '0' && c <= '9') {
+        pos++;
+      } else if (c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-') {
+        integral = false;
+        pos++;
+      } else {
+        break;
+      }
+    }
+    if (pos == start) {
+      throw error("expected a value");
+    }
+    String number = input.substring(start, pos);
+    try {
+      return integral ? (Object) Long.parseLong(number) : (Object) Double.parseDouble(number);
+    } catch (NumberFormatException e) {
+      throw error("invalid number '" + number + "'");
+    }
+  }
+
+  private char peek() {
+    if (pos >= input.length()) {
+      throw error("unexpected end of input");
+    }
+    return input.charAt(pos);
+  }
+
+  private char next() {
+    char c = peek();
+    pos++;
+    return c;
+  }
+
+  private void expect(char expected) {
+    char c = next();
+    if (c != expected) {
+      throw error("expected '" + expected + "' but found '" + c + "'");
+    }
+  }
+
+  private void skipWhitespace() {
+    while (pos < input.length()) {
+      char c = input.charAt(pos);
+      if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+        pos++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  private IllegalArgumentException error(String message) {
+    return new IllegalArgumentException("Malformed JSON at offset " + pos + ": " + message);
+  }
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/reporter/ReportComparator.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/reporter/ReportComparator.java
@@ -1,0 +1,243 @@
+package io.queryaudit.core.reporter;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Compares two {@code report.json} runs into a machine-readable resolution verdict (issue #167).
+ *
+ * <p>Every fix loop — human or automated — ends with the same question: <em>did my change resolve
+ * the finding without introducing new ones?</em> The verdict answers it from the two reports alone:
+ * which confirmed findings were resolved, which are new, which persist, and how the query profile
+ * moved.
+ *
+ * <p><strong>Matching key:</strong> {@code testClass|testName|type|query|sourceLocation}. The query
+ * field holds the normalized statement pattern, so findings survive unrelated refactors as long as
+ * the statement shape and call site are stable. Only <em>confirmed</em> findings participate — INFO
+ * advisories don't gate fix loops.
+ *
+ * <p><strong>Exit contract</strong> (CLI): {@code 0} when no new findings, {@code 1} when new
+ * findings exist, {@code 2} on usage or parse errors.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+public final class ReportComparator {
+
+  private ReportComparator() {
+    // static entry points only
+  }
+
+  /** One confirmed finding, reduced to its matching key plus display fields. */
+  public record Finding(
+      String testClass, String testName, String type, String table, String detail, String key) {}
+
+  /** The comparison result; {@code newFindings} non-empty means the gate should fail. */
+  public record Verdict(
+      List<Finding> resolved,
+      List<Finding> newFindings,
+      List<Finding> persisting,
+      long queriesBefore,
+      long queriesAfter,
+      long executionTimeMsBefore,
+      long executionTimeMsAfter) {}
+
+  /** Compares two envelope documents (the string content of two {@code report.json} files). */
+  public static Verdict compare(String beforeJson, String afterJson) {
+    List<Finding> before = confirmedFindings(beforeJson);
+    List<Finding> after = confirmedFindings(afterJson);
+
+    Set<String> beforeKeys = new LinkedHashSet<>();
+    before.forEach(f -> beforeKeys.add(f.key()));
+    Set<String> afterKeys = new LinkedHashSet<>();
+    after.forEach(f -> afterKeys.add(f.key()));
+
+    List<Finding> resolved = before.stream().filter(f -> !afterKeys.contains(f.key())).toList();
+    List<Finding> fresh = after.stream().filter(f -> !beforeKeys.contains(f.key())).toList();
+    List<Finding> persisting = after.stream().filter(f -> beforeKeys.contains(f.key())).toList();
+
+    return new Verdict(
+        resolved,
+        fresh,
+        persisting,
+        sumSummary(beforeJson, "totalQueries"),
+        sumSummary(afterJson, "totalQueries"),
+        sumSummary(beforeJson, "executionTimeMs"),
+        sumSummary(afterJson, "executionTimeMs"));
+  }
+
+  /** Renders the verdict as JSON (the {@code verdict.json} contract). */
+  public static String toJson(Verdict verdict) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\n");
+    sb.append("  \"newFindings\": ");
+    appendFindings(sb, verdict.newFindings());
+    sb.append(",\n  \"resolved\": ");
+    appendFindings(sb, verdict.resolved());
+    sb.append(",\n  \"persisting\": ");
+    appendFindings(sb, verdict.persisting());
+    sb.append(",\n  \"queryCountDelta\": {\"before\": ")
+        .append(verdict.queriesBefore())
+        .append(", \"after\": ")
+        .append(verdict.queriesAfter())
+        .append("},\n");
+    sb.append("  \"executionTimeMsDelta\": {\"before\": ")
+        .append(verdict.executionTimeMsBefore())
+        .append(", \"after\": ")
+        .append(verdict.executionTimeMsAfter())
+        .append("}\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /** One-screen console summary. */
+  public static String toSummary(Verdict verdict) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[QueryAudit] compare: ")
+        .append(verdict.newFindings().size())
+        .append(" new, ")
+        .append(verdict.resolved().size())
+        .append(" resolved, ")
+        .append(verdict.persisting().size())
+        .append(" persisting; queries ")
+        .append(verdict.queriesBefore())
+        .append(" -> ")
+        .append(verdict.queriesAfter());
+    for (Finding f : verdict.newFindings()) {
+      sb.append("\n  NEW      ").append(describe(f));
+    }
+    for (Finding f : verdict.resolved()) {
+      sb.append("\n  RESOLVED ").append(describe(f));
+    }
+    return sb.toString();
+  }
+
+  /**
+   * CLI entry point: {@code ReportComparator <before.json> <after.json> [verdict.json]}. Prints the
+   * summary; writes {@code verdict.json} when the third argument is given.
+   */
+  public static void main(String[] args) throws Exception {
+    if (args.length < 2 || args.length > 3) {
+      System.err.println(
+          "usage: java io.queryaudit.core.reporter.ReportComparator"
+              + " <before.json> <after.json> [verdict.json]");
+      System.exit(2);
+      return;
+    }
+    Verdict verdict;
+    try {
+      verdict =
+          compare(
+              Files.readString(Path.of(args[0]), StandardCharsets.UTF_8),
+              Files.readString(Path.of(args[1]), StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      System.err.println("[QueryAudit] compare failed: " + e.getMessage());
+      System.exit(2);
+      return;
+    }
+    System.out.println(toSummary(verdict));
+    if (args.length == 3) {
+      Files.writeString(Path.of(args[2]), toJson(verdict), StandardCharsets.UTF_8);
+      System.out.println("[QueryAudit] verdict: " + Path.of(args[2]).toAbsolutePath());
+    }
+    System.exit(verdict.newFindings().isEmpty() ? 0 : 1);
+  }
+
+  // ── Envelope reading ───────────────────────────────────────────────
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> reports(String envelopeJson) {
+    Object root = MiniJsonParser.parse(envelopeJson);
+    if (!(root instanceof Map<?, ?> envelope) || !(envelope.get("reports") instanceof List<?>)) {
+      throw new IllegalArgumentException(
+          "not a report.json envelope — expected {\"schemaVersion\", \"reports\": [...]}"
+              + " (schema 1.x, QueryAudit 0.5.0+)");
+    }
+    return (List<Map<String, Object>>) envelope.get("reports");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Finding> confirmedFindings(String envelopeJson) {
+    List<Finding> findings = new ArrayList<>();
+    for (Map<String, Object> report : reports(envelopeJson)) {
+      String testClass = (String) report.get("testClass");
+      String testName = (String) report.get("testName");
+      Object confirmed = report.get("confirmedIssues");
+      if (!(confirmed instanceof List<?> list)) {
+        continue;
+      }
+      for (Object entry : list) {
+        Map<String, Object> issue = (Map<String, Object>) entry;
+        String type = (String) issue.get("type");
+        String query = (String) issue.get("query");
+        String sourceLocation = (String) issue.get("sourceLocation");
+        String key = testClass + "|" + testName + "|" + type + "|" + query + "|" + sourceLocation;
+        findings.add(
+            new Finding(
+                testClass,
+                testName,
+                type,
+                (String) issue.get("table"),
+                (String) issue.get("detail"),
+                key));
+      }
+    }
+    return findings;
+  }
+
+  private static long sumSummary(String envelopeJson, String field) {
+    long sum = 0;
+    for (Map<String, Object> report : reports(envelopeJson)) {
+      if (report.get("summary") instanceof Map<?, ?> summary
+          && summary.get(field) instanceof Long value) {
+        sum += value;
+      }
+    }
+    return sum;
+  }
+
+  // ── Rendering helpers ──────────────────────────────────────────────
+
+  private static void appendFindings(StringBuilder sb, List<Finding> findings) {
+    if (findings.isEmpty()) {
+      sb.append("[]");
+      return;
+    }
+    sb.append("[\n");
+    for (int i = 0; i < findings.size(); i++) {
+      Finding f = findings.get(i);
+      sb.append("    {\"test\": \"")
+          .append(JsonReporter.escapeJson(f.testClass() + "." + f.testName()))
+          .append("\", \"type\": \"")
+          .append(JsonReporter.escapeJson(f.type()))
+          .append("\"");
+      if (f.table() != null) {
+        sb.append(", \"table\": \"").append(JsonReporter.escapeJson(f.table())).append("\"");
+      }
+      if (f.detail() != null) {
+        sb.append(", \"detail\": \"").append(JsonReporter.escapeJson(f.detail())).append("\"");
+      }
+      sb.append("}");
+      if (i < findings.size() - 1) {
+        sb.append(",");
+      }
+      sb.append("\n");
+    }
+    sb.append("  ]");
+  }
+
+  private static String describe(Finding f) {
+    return f.type()
+        + (f.table() != null ? " (table: " + f.table() + ")" : "")
+        + " in "
+        + f.testClass()
+        + "."
+        + f.testName();
+  }
+}

--- a/query-audit-core/src/test/java/io/queryaudit/core/reporter/ReportComparatorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/reporter/ReportComparatorTest.java
@@ -1,0 +1,169 @@
+package io.queryaudit.core.reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryAuditReport;
+import io.queryaudit.core.model.QueryRecord;
+import io.queryaudit.core.model.Severity;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trip tests for the delta verdict (issue #167): envelopes are produced by the real {@link
+ * JsonReporter} writer and read back through the real parser, so writer and reader can never
+ * silently drift apart.
+ */
+@DisplayName("ReportComparator (issue #167)")
+class ReportComparatorTest {
+
+  private static Issue nPlusOne(String pattern, String location) {
+    return new Issue(
+        IssueType.N_PLUS_ONE,
+        Severity.ERROR,
+        pattern,
+        "order_items",
+        null,
+        "Query repeated 5 times",
+        "Batch it",
+        location);
+  }
+
+  private static String envelope(QueryAuditReport... reports) {
+    return JsonReporter.toEnvelopeJson(List.of(reports));
+  }
+
+  private static QueryAuditReport report(String testName, List<Issue> confirmed, int queries) {
+    return new QueryAuditReport(
+        "OrderServiceTest",
+        testName,
+        confirmed,
+        List.of(),
+        List.of(),
+        List.of(new QueryRecord("SELECT 1", 2_000_000L, 0L, "at T.m:1")),
+        1,
+        queries,
+        2_000_000L);
+  }
+
+  @Nested
+  @DisplayName("MiniJsonParser")
+  class Parser {
+
+    @Test
+    @DisplayName("parses objects, arrays, escapes, numbers, booleans, null")
+    void parsesFullGrammar() {
+      Object parsed =
+          MiniJsonParser.parse(
+              "{\"s\": \"a\\\"b\\\\c\\nd\\u0041\", \"n\": -3, \"d\": 1.5e2,"
+                  + " \"b\": true, \"x\": null, \"arr\": [1, {\"k\": []}, false]}");
+      Map<?, ?> map = (Map<?, ?>) parsed;
+      assertThat(map.get("s")).isEqualTo("a\"b\\c\ndA");
+      assertThat(map.get("n")).isEqualTo(-3L);
+      assertThat(map.get("d")).isEqualTo(150.0);
+      assertThat(map.get("b")).isEqualTo(Boolean.TRUE);
+      assertThat(map.containsKey("x")).isTrue();
+      assertThat(map.get("x")).isNull();
+      assertThat((List<?>) map.get("arr")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("rejects trailing content and truncated input")
+    void rejectsMalformed() {
+      assertThatThrownBy(() -> MiniJsonParser.parse("{} extra"))
+          .isInstanceOf(IllegalArgumentException.class);
+      assertThatThrownBy(() -> MiniJsonParser.parse("{\"a\": "))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("compare()")
+  class Compare {
+
+    @Test
+    @DisplayName("classifies resolved, new, and persisting findings by stable key")
+    void classifiesFindings() {
+      Issue stays = nPlusOne("select * from order_items where order_id = ?", "S.load:10");
+      Issue fixed = nPlusOne("select * from payments where order_id = ?", "S.pay:20");
+      Issue introduced = nPlusOne("select * from refunds where order_id = ?", "S.refund:30");
+
+      String before = envelope(report("findOrders", List.of(stays, fixed), 11));
+      String after = envelope(report("findOrders", List.of(stays, introduced), 7));
+
+      ReportComparator.Verdict verdict = ReportComparator.compare(before, after);
+
+      assertThat(verdict.resolved()).hasSize(1);
+      assertThat(verdict.resolved().get(0).detail()).isEqualTo("Query repeated 5 times");
+      assertThat(verdict.newFindings()).hasSize(1);
+      assertThat(verdict.persisting()).hasSize(1);
+      assertThat(verdict.queriesBefore()).isEqualTo(11);
+      assertThat(verdict.queriesAfter()).isEqualTo(7);
+      assertThat(verdict.executionTimeMsBefore()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("a clean fix: resolved findings, nothing new — the loop's success signal")
+    void cleanFix() {
+      Issue finding = nPlusOne("select * from order_items where order_id = ?", "S.load:10");
+      String before = envelope(report("findOrders", List.of(finding), 11));
+      String after = envelope(report("findOrders", List.of(), 7));
+
+      ReportComparator.Verdict verdict = ReportComparator.compare(before, after);
+
+      assertThat(verdict.newFindings()).isEmpty();
+      assertThat(verdict.resolved()).hasSize(1);
+      assertThat(verdict.persisting()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("rejects a pre-envelope (bare array) report with a versioning hint")
+    void rejectsBareArray() {
+      assertThatThrownBy(() -> ReportComparator.compare("[]", "[]"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("envelope");
+    }
+  }
+
+  @Nested
+  @DisplayName("verdict rendering")
+  class Rendering {
+
+    @Test
+    @DisplayName("verdict.json parses back and carries the classification")
+    void verdictJsonRoundTrips() {
+      Issue introduced = nPlusOne("select * from refunds where order_id = ?", "S.refund:30");
+      String before = envelope(report("findOrders", List.of(), 5));
+      String after = envelope(report("findOrders", List.of(introduced), 9));
+
+      ReportComparator.Verdict verdict = ReportComparator.compare(before, after);
+      String json = ReportComparator.toJson(verdict);
+
+      Map<?, ?> parsed = (Map<?, ?>) MiniJsonParser.parse(json);
+      assertThat((List<?>) parsed.get("newFindings")).hasSize(1);
+      assertThat((List<?>) parsed.get("resolved")).isEmpty();
+      Map<?, ?> delta = (Map<?, ?>) parsed.get("queryCountDelta");
+      assertThat(delta.get("before")).isEqualTo(5L);
+      assertThat(delta.get("after")).isEqualTo(9L);
+    }
+
+    @Test
+    @DisplayName("console summary names new and resolved findings")
+    void summaryNamesFindings() {
+      Issue finding = nPlusOne("select * from refunds where order_id = ?", "S.refund:30");
+      ReportComparator.Verdict verdict =
+          ReportComparator.compare(
+              envelope(report("findOrders", List.of(finding), 5)),
+              envelope(report("findOrders", List.of(), 5)));
+
+      String summary = ReportComparator.toSummary(verdict);
+      assertThat(summary).contains("0 new, 1 resolved, 0 persisting");
+      assertThat(summary).contains("RESOLVED n-plus-one (table: order_items)");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #167.

Every fix loop — human or automated — ends with the same question: **did my change resolve the finding without introducing new ones?** The compare command answers it from two `report.json` files alone — no re-analysis, no database access.

## What's in it

- `ReportComparator.compare(before, after)` classifies **confirmed** findings into `newFindings` / `resolved` / `persisting` by the stable key `testClass|testName|type|normalized-pattern|sourceLocation`, plus query-count and execution-time deltas. INFO advisories don't gate fix loops.
- **CLI with a documented exit contract**: `0` = no new findings, `1` = new findings exist (the diff-aware CI gate primitive for v0.5's Action work), `2` = usage/parse errors. Optional third arg writes `verdict.json` — the termination condition for automated fix loops.
- `MiniJsonParser`: ~200-line recursive-descent JSON reader, because core is deliberately dependency-free (the writer side is StringBuilder-based for the same reason). Full RFC 8259 grammar; pre-envelope (bare array) reports are rejected with a versioning hint. Depends on #165's envelope.

## Verification

- Tests round-trip through the **real** `JsonReporter` writer and the **real** parser, so the two can never silently drift apart. Parser grammar tests (escapes, numbers, nesting, malformed input) + classification + verdict.json round-trip + console summary.
- CLI verified on real files: clean fix → exit 0, `0 new, 1 resolved`; reverse direction → exit 1 with the new finding named; `verdict.json` parses with the expected classification.

## Docs

Reports guide gained a **Delta Verdict** section: usage, matching key, exit contract, and a copy-paste `JavaExec` Gradle task for consuming projects.