### PR TITLE
feat(core): read-modify-write detector — check-then-act races without lock or constraint backing

### DIFF
--- a/docs/getting-started/spring-boot.md
+++ b/docs/getting-started/spring-boot.md
@@ -285,4 +285,4 @@ Or per-test:
 
 - :material-arrow-right: [Configuration Reference](../guide/configuration.md) -- Full list of `application.yml` properties
 - :material-arrow-right: [Annotations Guide](../guide/annotations.md) -- All 4 annotations explained
-- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 64 detection rules
+- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 65 detection rules

--- a/docs/guide/annotations.md
+++ b/docs/guide/annotations.md
@@ -9,7 +9,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 
 | Annotation | Target | Purpose | Test Failure |
 |---|---|---|---|
-| `@QueryAudit` | Class / Method | Full analysis with all 64 detection rules | Yes (configurable) |
+| `@QueryAudit` | Class / Method | Full analysis with all 65 detection rules | Yes (configurable) |
 | `@EnableQueryInspector` | Class | Report-only mode, never fails | No |
 | `@DetectNPlusOne` | Class / Method | N+1 detection only | Yes (on N+1 only) |
 | `@ExpectMaxQueryCount` | Method | Assert max query count | Yes (on count exceeded) |
@@ -45,7 +45,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 
 ## @QueryAudit
 
-The primary annotation. Enables full query analysis with all 64 detection rules across
+The primary annotation. Enables full query analysis with all 65 detection rules across
 SELECT, INSERT, UPDATE, and DELETE statements.
 
 ```java

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -417,7 +417,7 @@ These can be passed via `-D` flags on the command line:
 
 ## Issue Types Reference
 
-All 66 issue codes that can be used in `suppress`, `failOn`, and `suppress-patterns`.
+All 67 issue codes that can be used in `suppress`, `failOn`, and `suppress-patterns`.
 Of these, 64 are actively emitted; the remaining 2 are disabled or reserved (see
 [Detection Rules Overview](../detections/overview.md#disabled-reserved-rules)).
 
@@ -471,6 +471,7 @@ Of these, 64 are actively emitted; the remaining 2 are disabled or reserved (see
 | `string-concat-where` | `STRING_CONCAT_IN_WHERE` | String concatenation in WHERE prevents index |
 | `unused-join` | `UNUSED_JOIN` | LEFT JOIN table never referenced in query |
 | `for-update-non-unique` | `FOR_UPDATE_NON_UNIQUE` | FOR UPDATE on non-unique index causes gap locks |
+| `read-modify-write` | `READ_MODIFY_WRITE` | SELECT without a lock followed by INSERT/UPDATE on the same table, with no unique-constraint backing, upsert, atomic SET, or version column |
 | `group-by-function` | `GROUP_BY_FUNCTION` | Function in GROUP BY prevents index usage |
 | `regexp-usage` | `REGEXP_INSTEAD_OF_LIKE` | REGEXP/RLIKE prevents index usage |
 | `find-in-set` | `FIND_IN_SET_USAGE` | FIND_IN_SET indicates comma-separated values violating 1NF |

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ description: Catch N+1 queries, missing indexes, and SQL anti-patterns before th
 # QueryAudit
 
 <p class="qg-tagline">
-Stop shipping slow queries. Catch N+1, missing indexes, and dozens of other SQL anti-patterns automatically during your JUnit tests -- 64 detection rules in total.
+Stop shipping slow queries. Catch N+1, missing indexes, and dozens of other SQL anti-patterns automatically during your JUnit tests -- 65 detection rules in total.
 </p>
 
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
@@ -118,7 +118,7 @@ Every issue includes the exact SQL statement, affected table, column, the detect
   <div class="qg-flow-arrow">:material-arrow-right:</div>
   <div class="qg-flow-step">:material-table-key: Fetch index metadata</div>
   <div class="qg-flow-arrow">:material-arrow-right:</div>
-  <div class="qg-flow-step">:material-magnify: Apply 64 rules</div>
+  <div class="qg-flow-step">:material-magnify: Apply 65 rules</div>
   <div class="qg-flow-arrow">:material-arrow-right:</div>
   <div class="qg-flow-step">:material-alert-circle: Report & fail</div>
 </div>
@@ -128,7 +128,7 @@ QueryAudit hooks into your test's `DataSource` via a lightweight proxy. During t
 1. **Parses** each query to identify tables, columns, joins, and clauses
 2. **Fetches index metadata** from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`)
 3. **Cross-references** the query structure against actual indexes
-4. **Applies 64 detection rules** covering N+1, missing indexes, DML safety, locking risks, and more
+4. **Applies 65 detection rules** covering N+1, missing indexes, DML safety, locking risks, and more
 5. **Produces a structured report** with severity, root cause, and fix suggestions
 
 No runtime agents. No production overhead. Just add an annotation.
@@ -221,7 +221,7 @@ Existing tools help with **observability** -- they let you *see* your queries:
 | **p6spy** | Logs queries with bind parameters | Same -- logging only |
 | **Spring Hibernate statistics** | Counts queries per session | Counts, but doesn't analyze |
 
-**QueryAudit closes the gap.** It doesn't just log queries -- it applies 64 detection rules to every captured query, cross-references index metadata from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`), and produces a structured report with concrete fix suggestions.
+**QueryAudit closes the gap.** It doesn't just log queries -- it applies 65 detection rules to every captured query, cross-references index metadata from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`), and produces a structured report with concrete fix suggestions.
 
 | Capability | datasource-proxy | p6spy | QueryAudit |
 |---|:---:|:---:|:---:|

--- a/docs/references.md
+++ b/docs/references.md
@@ -95,4 +95,4 @@ peer-reviewed academic research, and established technical literature.
 ## See Also
 
 - [Architecture Overview](architecture/overview.md) -- How detection rules use these references
-- [Configuration Reference](guide/configuration.md) -- All 64 detection rules and their codes
+- [Configuration Reference](guide/configuration.md) -- All 65 detection rules and their codes

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/QueryAuditAnalyzer.java
@@ -148,6 +148,7 @@ public class QueryAuditAnalyzer {
     ruleList.add(new NullComparisonDetector());
     ruleList.add(new HavingMisuseDetector());
     ruleList.add(new RangeLockDetector());
+    ruleList.add(new ReadModifyWriteDetector());
     ruleList.add(new UpdateWithoutWhereDetector());
     ruleList.add(new DmlWithoutIndexDetector());
     ruleList.add(

--- a/query-audit-core/src/main/java/io/queryaudit/core/detector/ReadModifyWriteDetector.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/detector/ReadModifyWriteDetector.java
@@ -1,0 +1,256 @@
+package io.queryaudit.core.detector;
+
+import io.queryaudit.core.model.IndexMetadata;
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryRecord;
+import io.queryaudit.core.model.Severity;
+import io.queryaudit.core.parser.ColumnReference;
+import io.queryaudit.core.parser.EnhancedSqlParser;
+import io.queryaudit.core.parser.SqlParser;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects check-then-act races: a {@code SELECT} without a locking clause followed — in the same
+ * test — by an {@code INSERT}/{@code UPDATE} on the same table, with nothing converting the race
+ * into a safe operation (issue #169).
+ *
+ * <p>"Find-then-save" is the default shape of ORM service code, and single-threaded tests can never
+ * fail on it; the race only appears under concurrent load — lost updates and duplicate rows. This
+ * is the sequence-level completion of the lock-rule family: those judge locks that are taken, this
+ * rule judges the sequence where a lock (or constraint) is missing.
+ *
+ * <p>Exemptions, in the order they are checked:
+ *
+ * <ul>
+ *   <li>the SELECT used {@code FOR UPDATE}/{@code FOR SHARE} — pessimistic locking;
+ *   <li>the write is an upsert ({@code ON DUPLICATE KEY UPDATE} / {@code ON CONFLICT}) — the
+ *       constraint resolves the race;
+ *   <li>{@code INSERT} case: a unique index covers the SELECT's equality predicate — the constraint
+ *       converts the race into a catchable error. Without index metadata for the table the INSERT
+ *       case stays silent (conservative: no evidence, no finding);
+ *   <li>{@code UPDATE} case: the UPDATE's own {@code WHERE} references a version-style column
+ *       ({@code version}, {@code opt_lock}, {@code optlock}, {@code revision}) — optimistic
+ *       locking, the JPA {@code @Version} shape;
+ *   <li>{@code UPDATE} case: self-referential {@code SET col = col - ?} — the update is itself the
+ *       atomic form this rule's suggestion prescribes;
+ *   <li>{@code UPDATE} case: no equality-column overlap between the read's and the write's
+ *       predicates — a read on one key followed by a write on another is not the pattern.
+ * </ul>
+ *
+ * <p>INFO severity: deliberate last-write-wins semantics exist, and this rule cannot see them.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+public class ReadModifyWriteDetector implements DetectionRule {
+
+  private static final Pattern FOR_UPDATE_OR_SHARE =
+      Pattern.compile("\\bFOR\\s+(?:UPDATE|SHARE)\\b", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern UPSERT =
+      Pattern.compile(
+          "\\bON\\s+(?:DUPLICATE\\s+KEY\\s+UPDATE|CONFLICT)\\b", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern INSERT_TABLE =
+      Pattern.compile(
+          "\\bINSERT\\s+(?:IGNORE\\s+)?INTO\\s+[`\"]?([\\w.]+)[`\"]?", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern UPDATE_TABLE =
+      Pattern.compile("\\bUPDATE\\s+[`\"]?([\\w.]+)[`\"]?", Pattern.CASE_INSENSITIVE);
+
+  private static final Set<String> VERSION_COLUMNS =
+      Set.of("version", "opt_lock", "optlock", "revision");
+
+  /** SET col = col <op> ... — the update is itself an atomic read-modify-write; no race. */
+  private static final Pattern SELF_REFERENTIAL_SET =
+      Pattern.compile(
+          "\\bSET\\b[^=]*?[`\"]?(\\w+)[`\"]?\\s*=\\s*[`\"]?\\1[`\"]?\\s*[-+*/]",
+          Pattern.CASE_INSENSITIVE);
+
+  @Override
+  public String getRuleCode() {
+    return IssueType.READ_MODIFY_WRITE.getCode();
+  }
+
+  @Override
+  public List<Issue> evaluate(List<QueryRecord> queries, IndexMetadata indexMetadata) {
+    List<Issue> issues = new ArrayList<>();
+    // table -> the most recent unlocked equality-predicate SELECT on it
+    Map<String, UnlockedRead> unlockedReads = new HashMap<>();
+    Set<String> reported = new LinkedHashSet<>();
+
+    for (QueryRecord query : queries) {
+      String sql = query.sql();
+      if (sql == null || sql.isBlank()) {
+        continue;
+      }
+
+      if (SqlParser.isSelectQuery(sql)) {
+        recordUnlockedRead(query, unlockedReads);
+        continue;
+      }
+
+      String table = null;
+      boolean isInsert = false;
+      if (SqlParser.isInsertQuery(sql)) {
+        table = extractTable(INSERT_TABLE, sql);
+        isInsert = true;
+      } else if (SqlParser.isUpdateQuery(sql)) {
+        table = extractTable(UPDATE_TABLE, sql);
+      } else {
+        continue;
+      }
+      if (table == null) {
+        continue;
+      }
+
+      UnlockedRead read = unlockedReads.get(table);
+      if (read == null) {
+        continue;
+      }
+      if (UPSERT.matcher(sql).find()) {
+        continue; // the constraint resolves the race
+      }
+      if (isInsert && !insertIsRaceProne(table, read, indexMetadata)) {
+        continue;
+      }
+      if (!isInsert && updateUsesVersionColumn(sql)) {
+        continue; // optimistic locking
+      }
+      if (!isInsert && SELF_REFERENTIAL_SET.matcher(sql).find()) {
+        continue; // SET col = col - ? is already the atomic form
+      }
+      if (!isInsert && !predicatesOverlap(read, sql)) {
+        continue; // the write does not address the record the read checked
+      }
+
+      String reportKey =
+          read.normalizedSql + "->" + (query.normalizedSql() != null ? query.normalizedSql() : sql);
+      if (!reported.add(reportKey)) {
+        continue;
+      }
+
+      String action = isInsert ? "INSERT" : "UPDATE";
+      issues.add(
+          new Issue(
+              IssueType.READ_MODIFY_WRITE,
+              Severity.INFO,
+              read.normalizedSql,
+              table,
+              read.firstEqualityColumn,
+              "SELECT on '"
+                  + table
+                  + "' without a locking clause is followed by "
+                  + action
+                  + " on the same table — correct single-threaded, lost updates or duplicate rows under concurrency",
+              isInsert
+                  ? "Back the checked predicate with a unique constraint (and handle the violation), or use an upsert (INSERT ... ON DUPLICATE KEY UPDATE / ON CONFLICT)"
+                  : "Lock the read (SELECT ... FOR UPDATE), use optimistic locking (@Version), or fold the change into one atomic UPDATE",
+              read.stackTrace));
+    }
+
+    return issues;
+  }
+
+  private void recordUnlockedRead(QueryRecord query, Map<String, UnlockedRead> unlockedReads) {
+    String sql = query.sql();
+    List<ColumnReference> whereColumns = EnhancedSqlParser.extractWhereColumns(sql);
+    if (whereColumns.isEmpty()) {
+      return;
+    }
+    Map<String, String> aliasToTable = MissingIndexDetector.resolveAliases(sql);
+    String table = resolveTable(whereColumns.get(0).tableOrAlias(), aliasToTable);
+    if (table == null) {
+      return;
+    }
+    if (FOR_UPDATE_OR_SHARE.matcher(sql).find()) {
+      // a locked read supersedes any earlier unlocked one on the same table
+      unlockedReads.remove(table);
+      return;
+    }
+    Set<String> equalityColumns = new LinkedHashSet<>();
+    for (ColumnReference col : whereColumns) {
+      equalityColumns.add(col.columnName().toLowerCase(Locale.ROOT));
+    }
+    unlockedReads.put(
+        table,
+        new UnlockedRead(
+            query.normalizedSql() != null ? query.normalizedSql() : sql,
+            equalityColumns,
+            whereColumns.get(0).columnName(),
+            query.stackTrace()));
+  }
+
+  /**
+   * The INSERT case fires only with positive evidence: metadata for the table exists and no unique
+   * index covers the SELECT's equality predicate. No metadata, no finding.
+   */
+  private boolean insertIsRaceProne(String table, UnlockedRead read, IndexMetadata indexMetadata) {
+    if (indexMetadata == null || !indexMetadata.hasTable(table)) {
+      return false;
+    }
+    return !indexMetadata.columnsMatchUniqueIndex(table, read.equalityColumns);
+  }
+
+  /**
+   * The UPDATE case only fires when the write's equality predicate shares at least one column with
+   * the read's — the classic RMW touches the same key (select by id, update by id). A read on one
+   * key followed by a write on another (login by email, later update by id) is not the pattern.
+   */
+  private boolean predicatesOverlap(UnlockedRead read, String updateSql) {
+    for (ColumnReference col : EnhancedSqlParser.extractWhereColumns(updateSql)) {
+      if (read.equalityColumns.contains(col.columnName().toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean updateUsesVersionColumn(String updateSql) {
+    for (ColumnReference col : EnhancedSqlParser.extractWhereColumns(updateSql)) {
+      if (VERSION_COLUMNS.contains(col.columnName().toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String extractTable(Pattern pattern, String sql) {
+    Matcher matcher = pattern.matcher(sql);
+    if (!matcher.find()) {
+      return null;
+    }
+    String table = matcher.group(1).toLowerCase(Locale.ROOT);
+    int dot = table.lastIndexOf('.');
+    return dot >= 0 ? table.substring(dot + 1) : table;
+  }
+
+  private String resolveTable(String tableOrAlias, Map<String, String> aliasToTable) {
+    if (tableOrAlias != null) {
+      String resolved = aliasToTable.get(tableOrAlias.toLowerCase(Locale.ROOT));
+      if (resolved != null) {
+        return resolved;
+      }
+      return tableOrAlias.toLowerCase(Locale.ROOT);
+    }
+    if (aliasToTable.size() <= 2) {
+      return aliasToTable.values().stream().findFirst().orElse(null);
+    }
+    return null;
+  }
+
+  private record UnlockedRead(
+      String normalizedSql,
+      Set<String> equalityColumns,
+      String firstEqualityColumn,
+      String stackTrace) {}
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
@@ -64,6 +64,8 @@ public enum IssueType {
       "range-lock-risk",
       "Range condition with FOR UPDATE on unindexed column may cause gap locks",
       WARNING),
+  READ_MODIFY_WRITE(
+      "read-modify-write", "Read-modify-write without lock or unique-constraint backing", INFO),
   QUERY_COUNT_REGRESSION("query-count-regression", "Query count regression detected", WARNING),
   UPDATE_WITHOUT_WHERE(
       "update-without-where", "UPDATE/DELETE without WHERE clause affects all rows", ERROR),

--- a/query-audit-core/src/test/java/io/queryaudit/core/detector/ReadModifyWriteDetectorTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/detector/ReadModifyWriteDetectorTest.java
@@ -1,0 +1,184 @@
+package io.queryaudit.core.detector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.queryaudit.core.model.IndexInfo;
+import io.queryaudit.core.model.IndexMetadata;
+import io.queryaudit.core.model.Issue;
+import io.queryaudit.core.model.IssueType;
+import io.queryaudit.core.model.QueryRecord;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fixtures are the canonical shapes of the four production race conditions that motivated issue
+ * #169: find-then-insert without unique backing, read-then-update without a lock, and their safe
+ * counterparts (upsert, unique constraint, FOR UPDATE, optimistic version column).
+ */
+@DisplayName("ReadModifyWriteDetector (issue #169)")
+class ReadModifyWriteDetectorTest {
+
+  private final ReadModifyWriteDetector detector = new ReadModifyWriteDetector();
+
+  private static QueryRecord q(String sql) {
+    return new QueryRecord(sql, 1_000L, 0L, "at com.example.Service.m(Service.java:10)");
+  }
+
+  /** users(email) has only a NON-unique index; accounts(email) has a unique one. */
+  private static IndexMetadata metadata() {
+    return new IndexMetadata(
+        Map.of(
+            "users", List.of(new IndexInfo("users", "idx_email", "email", 1, true, 100L)),
+            "accounts", List.of(new IndexInfo("accounts", "uk_email", "email", 1, false, 100L))));
+  }
+
+  private List<Issue> evaluate(IndexMetadata meta, String... sqls) {
+    return detector.evaluate(
+        java.util.Arrays.stream(sqls).map(ReadModifyWriteDetectorTest::q).toList(), meta);
+  }
+
+  @Nested
+  @DisplayName("fires")
+  class Fires {
+
+    @Test
+    @DisplayName("find-then-insert without unique backing (duplicate-row race)")
+    void findThenInsertWithoutUniqueBacking() {
+      List<Issue> issues =
+          evaluate(
+              metadata(),
+              "SELECT id FROM users WHERE email = ?",
+              "INSERT INTO users (email, name) VALUES (?, ?)");
+
+      assertThat(issues).hasSize(1);
+      Issue issue = issues.get(0);
+      assertThat(issue.type()).isEqualTo(IssueType.READ_MODIFY_WRITE);
+      assertThat(issue.table()).isEqualTo("users");
+      assertThat(issue.suggestion()).contains("unique constraint");
+      assertThat(issue.sourceLocation()).contains("Service.java:10");
+    }
+
+    @Test
+    @DisplayName("read-then-update without a lock (lost-update race)")
+    void readThenUpdateWithoutLock() {
+      List<Issue> issues =
+          evaluate(
+              metadata(),
+              "SELECT balance FROM users WHERE id = ?",
+              "UPDATE users SET balance = ? WHERE id = ?");
+
+      assertThat(issues).hasSize(1);
+      assertThat(issues.get(0).suggestion()).contains("FOR UPDATE");
+    }
+
+    @Test
+    @DisplayName("the same sequence is reported once, not per repetition")
+    void deduplicatesRepeatedSequences() {
+      List<Issue> issues =
+          evaluate(
+              metadata(),
+              "SELECT balance FROM users WHERE id = ?",
+              "UPDATE users SET balance = ? WHERE id = ?",
+              "SELECT balance FROM users WHERE id = ?",
+              "UPDATE users SET balance = ? WHERE id = ?");
+
+      assertThat(issues).hasSize(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("stays silent")
+  class StaysSilent {
+
+    @Test
+    @DisplayName("SELECT ... FOR UPDATE — pessimistic lock taken")
+    void forUpdateIsSafe() {
+      assertThat(
+              evaluate(
+                  metadata(),
+                  "SELECT balance FROM users WHERE id = ? FOR UPDATE",
+                  "UPDATE users SET balance = ? WHERE id = ?"))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("upsert — the constraint resolves the race")
+    void upsertIsSafe() {
+      assertThat(
+              evaluate(
+                  metadata(),
+                  "SELECT id FROM users WHERE email = ?",
+                  "INSERT INTO users (email) VALUES (?) ON DUPLICATE KEY UPDATE name = VALUES(name)"))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("unique index covers the checked predicate — find-then-insert is catchable")
+    void uniqueBackedInsertIsSafe() {
+      assertThat(
+              evaluate(
+                  metadata(),
+                  "SELECT id FROM accounts WHERE email = ?",
+                  "INSERT INTO accounts (email) VALUES (?)"))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("UPDATE whose WHERE carries a version column — optimistic locking")
+    void versionColumnUpdateIsSafe() {
+      assertThat(
+              evaluate(
+                  metadata(),
+                  "SELECT balance FROM users WHERE id = ?",
+                  "UPDATE users SET balance = ? WHERE id = ? AND version = ?"))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("INSERT case without index metadata — no evidence, no finding")
+    void insertWithoutMetadataIsSilent() {
+      assertThat(
+              evaluate(
+                  null,
+                  "SELECT id FROM users WHERE email = ?",
+                  "INSERT INTO users (email) VALUES (?)"))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("self-referential SET (atomic decrement) — already the atomic form")
+    void atomicDecrementIsSafe() {
+      assertThat(
+              evaluate(
+                  metadata(),
+                  "SELECT quantity FROM users WHERE id = ?",
+                  "UPDATE users SET quantity = quantity - ? WHERE id = ?"))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("read and write on different keys — not the RMW pattern")
+    void nonOverlappingPredicatesAreSilent() {
+      assertThat(
+              evaluate(
+                  metadata(),
+                  "SELECT id FROM users WHERE email = ?",
+                  "UPDATE users SET last_login = NOW() WHERE id = ?"))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("write to an unrelated table")
+    void unrelatedTableIsSilent() {
+      assertThat(
+              evaluate(
+                  metadata(),
+                  "SELECT id FROM users WHERE email = ?",
+                  "INSERT INTO audit_log (entry) VALUES (?)"))
+          .isEmpty();
+    }
+  }
+}

--- a/query-audit-core/src/test/java/io/queryaudit/core/eval/SeverityAuditTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/eval/SeverityAuditTest.java
@@ -1075,6 +1075,6 @@ class SeverityAuditTest {
           .isNotNull();
     }
     // Verify the total count matches what we audited (56 issue types)
-    assertThat(IssueType.values().length).isEqualTo(66);
+    assertThat(IssueType.values().length).isEqualTo(67);
   }
 }


### PR DESCRIPTION
## Summary

Closes #169.

Check-then-act races: a `SELECT` without a locking clause followed — in the same test — by an `INSERT`/`UPDATE` on the same table, with nothing converting the race into a safe operation. Correct on one thread; lost updates and duplicate rows under concurrent load. The sequence-level completion of the lock-rule family: those judge locks that *are* taken, this rule judges the sequence where a lock (or constraint) is *missing*.

## Precision design

Exemptions, in check order — each one is a legitimate resolution of the race:

| Exemption | Why safe |
|---|---|
| `SELECT ... FOR UPDATE/SHARE` | pessimistic lock (a locked read also supersedes an earlier unlocked one) |
| upsert (`ON DUPLICATE KEY UPDATE` / `ON CONFLICT`) | the constraint resolves the race |
| INSERT with a unique index covering the SELECT's equality predicate | race becomes a catchable error — cross-checked against **real index metadata**; no metadata → INSERT case stays silent |
| UPDATE whose WHERE carries a version-style column | `@Version` optimistic locking |
| self-referential `SET col = col - ?` | already the atomic form the rule's own suggestion prescribes |
| no equality-column overlap between read and write predicates | login-by-email then touch-by-id is not the pattern |

INFO severity — deliberate last-write-wins semantics exist and the rule cannot see them. Declares `getRuleCode()` for exact profile/disable matching.

## The evaluation harness earned its keep

The first draft flagged the e-commerce workload's `UPDATE inventory SET quantity = quantity - ?` — which is **exactly the atomic pattern the rule should recommend** — and pushed scenario precision below the 0.7 gate. The self-referential-SET and predicate-overlap exemptions came out of that failure, not out of imagination. Full suite (3,389 tests) green afterwards, evaluation gates included.

## Tests

Canonical shapes of the production races that motivated the issue: find-then-insert without unique backing and read-then-update without a lock (fire, with call site in the finding), plus seven silent cases (FOR UPDATE, upsert, unique-backed insert, version column, atomic decrement, non-overlapping keys, unrelated table, no-metadata insert) and sequence dedup.

## Docs

Rule row in the issue-code catalog; rule-count mentions bumped 64→65 (codes 66→67).