### PR TITLE
feat(junit5): connection-held-idle — flag transactions holding a connection during non-database work

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -23,6 +23,7 @@ All properties are optional. The table below lists every supported key under the
 | `wrap-data-source.enabled` | `boolean` | `true` | Surgical escape hatch (issue #134) — disables only the auto-wrap `BeanPostProcessor` while keeping `QueryInterceptor` and `QueryAuditConfig` beans active. Use this when integrating with an existing datasource-proxy (e.g. gavlyukovskiy). |
 | `fail-on-detection` | `boolean` | `true` | Whether confirmed issues (ERROR/WARNING) should cause the test to fail with an `AssertionError`. |
 | `count-instead-of-exists.enabled` | `boolean` | `false` | Enable the `count-instead-of-exists` INFO detector. Off by default because it can fire on legitimate aggregate counts. |
+| `connection-held-idle.threshold-ms` | `long` | `200` | Minimum idle time (connection held minus database work) before the `connection-held-idle` rule fires. Requires the non-DB work to actually take time in tests — zero-latency mocks never reproduce the gap. |
 | `repeated-insert.exclude-tables` | `List<String>` | `["temp_*", "staging_*", "*_temp", "*_staging"]` | Table-name globs (case-insensitive, `*` wildcard) treated as deliberate staging targets — repeated single-row inserts into these tables are not flagged. |
 | `n-plus-one.threshold` | `int` | `3` | Number of times a structurally identical query must repeat before it is flagged as N+1. |
 | `offset-pagination.threshold` | `int` | `1000` | The OFFSET value that triggers a warning. |
@@ -417,7 +418,7 @@ These can be passed via `-D` flags on the command line:
 
 ## Issue Types Reference
 
-All 67 issue codes that can be used in `suppress`, `failOn`, and `suppress-patterns`.
+All 68 issue codes that can be used in `suppress`, `failOn`, and `suppress-patterns`.
 Of these, 64 are actively emitted; the remaining 2 are disabled or reserved (see
 [Detection Rules Overview](../detections/overview.md#disabled-reserved-rules)).
 
@@ -459,6 +460,7 @@ Of these, 64 are actively emitted; the remaining 2 are disabled or reserved (see
 | `distinct-misuse` | `DISTINCT_MISUSE` | Unnecessary DISTINCT |
 | `having-misuse` | `HAVING_MISUSE` | HAVING on non-aggregate column |
 | `range-lock-risk` | `RANGE_LOCK_RISK` | Range + FOR UPDATE on unindexed column |
+| `connection-held-idle` | `CONNECTION_HELD_IDLE` | Connection held while non-database work runs — the pool-exhaustion shape |
 | `query-count-regression` | `QUERY_COUNT_REGRESSION` | Query count regression vs baseline |
 | `dml-without-index` | `DML_WITHOUT_INDEX` | UPDATE/DELETE WHERE without index |
 | `repeated-single-insert` | `REPEATED_SINGLE_INSERT` | Repeated single-row INSERT |

--- a/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/QueryAuditConfig.java
@@ -49,6 +49,7 @@ public class QueryAuditConfig {
   private final boolean includeSetupQueries;
   private final boolean countInsteadOfExistsEnabled;
   private final AuditMode auditMode;
+  private final long connectionHeldIdleThresholdMs;
   private final RuleProfile ruleProfile;
   private final Set<String> enabledRules;
 
@@ -79,6 +80,7 @@ public class QueryAuditConfig {
     this.includeSetupQueries = builder.includeSetupQueries;
     this.countInsteadOfExistsEnabled = builder.countInsteadOfExistsEnabled;
     this.auditMode = builder.auditMode;
+    this.connectionHeldIdleThresholdMs = builder.connectionHeldIdleThresholdMs;
     this.ruleProfile = builder.ruleProfile;
     this.enabledRules = Collections.unmodifiableSet(new HashSet<>(builder.enabledRules));
   }
@@ -271,6 +273,16 @@ public class QueryAuditConfig {
   }
 
   /**
+   * Minimum idle time (connection held minus database work, in milliseconds) before the
+   * connection-held-idle rule fires. Conservative default: 200ms.
+   *
+   * @since 0.5.0
+   */
+  public long getConnectionHeldIdleThresholdMs() {
+    return connectionHeldIdleThresholdMs;
+  }
+
+  /**
    * Returns the active rule profile tier. Defaults to {@link RuleProfile#STRICT} (all rules).
    *
    * @since 0.5.0
@@ -364,6 +376,7 @@ public class QueryAuditConfig {
     private boolean includeSetupQueries = false;
     private boolean countInsteadOfExistsEnabled = false;
     private AuditMode auditMode = AuditMode.ANNOTATED;
+    private long connectionHeldIdleThresholdMs = 200;
     private RuleProfile ruleProfile = RuleProfile.STRICT;
     private Set<String> enabledRules = new HashSet<>();
 
@@ -398,6 +411,7 @@ public class QueryAuditConfig {
       b.repositoryReturnTypeResolver = source.repositoryReturnTypeResolver;
       b.countInsteadOfExistsEnabled = source.countInsteadOfExistsEnabled;
       b.auditMode = source.auditMode;
+      b.connectionHeldIdleThresholdMs = source.connectionHeldIdleThresholdMs;
       b.ruleProfile = source.ruleProfile;
       b.enabledRules = new HashSet<>(source.enabledRules);
       return b;
@@ -597,6 +611,16 @@ public class QueryAuditConfig {
     /** Adds a single rule code to run even when the profile tier excludes it. */
     public Builder addEnabledRule(String ruleCode) {
       this.enabledRules.add(ruleCode);
+      return this;
+    }
+
+    /**
+     * Sets the connection-held-idle threshold in milliseconds.
+     *
+     * @since 0.5.0
+     */
+    public Builder connectionHeldIdleThresholdMs(long thresholdMs) {
+      this.connectionHeldIdleThresholdMs = thresholdMs;
       return this;
     }
 

--- a/query-audit-core/src/main/java/io/queryaudit/core/config/RuleProfile.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/config/RuleProfile.java
@@ -54,7 +54,8 @@ public enum RuleProfile {
           "n-plus-one-suspect", // SQL-level heuristic; the confirmed rule stays
           "mergeable-queries", // advice, not a defect
           "for-update-no-timeout", // environment-dependent
-          "window-no-partition" // often deliberate over the full result
+          "window-no-partition", // often deliberate over the full result
+          "connection-held-idle" // wall-clock heuristic; needs realistic latency in tests
           );
 
   /**

--- a/query-audit-core/src/main/java/io/queryaudit/core/interceptor/ConnectionUsageTracker.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/interceptor/ConnectionUsageTracker.java
@@ -1,0 +1,204 @@
+package io.queryaudit.core.interceptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.ConnectionInfo;
+import net.ttddyy.dsproxy.listener.MethodExecutionContext;
+import net.ttddyy.dsproxy.listener.MethodExecutionListener;
+
+/**
+ * Tracks how long each JDBC connection is held versus how long it actually executes SQL, so the
+ * connection-held-idle rule can flag transactions that keep a pooled connection while slow non-DB
+ * work runs (issue #168).
+ *
+ * <p>Per-statement rules structurally cannot see this failure mode: the SQL is all fine, the
+ * transaction boundary is wrong, and under load the pool drains and takes down unrelated endpoints.
+ * The tracker observes the {@code getConnection}/{@code close} lifecycle and the elapsed time of
+ * every {@code execute*}/{@code commit}/{@code rollback} call in between — the gap is time the
+ * connection was held doing something other than database work.
+ *
+ * <p>Wall-clock caveat, stated up front: the measurement needs the non-DB work to actually take
+ * time in the test (Testcontainers, WireMock with latency). Zero-latency mocks never reproduce the
+ * gap. The clock is injectable for deterministic unit tests.
+ *
+ * @author haroya
+ * @since 0.5.0
+ */
+public class ConnectionUsageTracker implements MethodExecutionListener {
+
+  /** JDBC calls whose elapsed time counts as database work rather than idle time. */
+  private static final Set<String> DB_WORK_METHODS =
+      Set.of(
+          "execute",
+          "executeQuery",
+          "executeUpdate",
+          "executeBatch",
+          "executeLargeUpdate",
+          "executeLargeBatch",
+          "commit",
+          "rollback");
+
+  private static final Set<String> SKIP_PREFIXES =
+      Set.of(
+          "java.lang.Thread",
+          "java.base/",
+          "sun.",
+          "jdk.",
+          "io.queryaudit.",
+          "org.springframework.",
+          "org.hibernate.",
+          "org.junit.",
+          "org.gradle.",
+          "net.ttddyy.",
+          "com.zaxxer.",
+          "org.apache.",
+          "net.bytebuddy.",
+          "com.sun.");
+
+  /** One completed connection checkout: how long it was held and how much of that was SQL. */
+  public record ConnectionSession(
+      String connectionId,
+      long heldMillis,
+      long databaseWorkMillis,
+      boolean released,
+      String acquireCallSite) {
+
+    public long idleMillis() {
+      return Math.max(0, heldMillis - databaseWorkMillis);
+    }
+  }
+
+  private static final class OpenSession {
+    volatile long acquiredNanos;
+    final String acquireCallSite;
+    final AtomicLong dbWorkMillis = new AtomicLong();
+
+    OpenSession(long acquiredNanos, String acquireCallSite) {
+      this.acquiredNanos = acquiredNanos;
+      this.acquireCallSite = acquireCallSite;
+    }
+
+    /** Re-anchors a connection acquired before the window so only in-window time is measured. */
+    void rebase(long windowStartNanos) {
+      this.acquiredNanos = windowStartNanos;
+      this.dbWorkMillis.set(0);
+    }
+  }
+
+  private final LongSupplier nanoClock;
+  private final Map<String, OpenSession> openSessions = new ConcurrentHashMap<>();
+  private final List<ConnectionSession> completedSessions =
+      Collections.synchronizedList(new ArrayList<>());
+  private volatile boolean active = false;
+
+  public ConnectionUsageTracker() {
+    this(System::nanoTime);
+  }
+
+  /** Clock-injectable constructor for deterministic tests. */
+  public ConnectionUsageTracker(LongSupplier nanoClock) {
+    this.nanoClock = nanoClock;
+  }
+
+  /**
+   * Starts a fresh tracking window (called per test). Connection lifecycle bookkeeping runs
+   * continuously — Spring's transaction manager acquires the test's connection before this
+   * extension's own callbacks run — so connections already open are re-anchored to the window start
+   * instead of being lost.
+   */
+  public void start() {
+    long now = nanoClock.getAsLong();
+    openSessions.values().forEach(open -> open.rebase(now));
+    completedSessions.clear();
+    active = true;
+  }
+
+  /**
+   * Stops tracking. Connections still open at the end of the window are recorded as unreleased
+   * sessions — a connection held to the end of the test is the worst offender, not an exemption.
+   */
+  public void stop() {
+    active = false;
+    long now = nanoClock.getAsLong();
+    // Still-open connections stay in the map (they are physically open — the next window
+    // re-anchors them); they are reported against this window as unreleased holds.
+    openSessions.forEach(
+        (id, open) ->
+            completedSessions.add(
+                new ConnectionSession(
+                    id,
+                    toMillis(now - open.acquiredNanos),
+                    open.dbWorkMillis.get(),
+                    false,
+                    open.acquireCallSite)));
+  }
+
+  /** Sessions completed during the current window, releases and end-of-window holds alike. */
+  public List<ConnectionSession> getCompletedSessions() {
+    return List.copyOf(completedSessions);
+  }
+
+  @Override
+  public void beforeMethod(MethodExecutionContext context) {
+    // all bookkeeping happens after the call, when elapsed time and results exist
+  }
+
+  @Override
+  public void afterMethod(MethodExecutionContext context) {
+    if (context.getThrown() != null) {
+      return;
+    }
+    ConnectionInfo info = context.getConnectionInfo();
+    if (info == null || info.getConnectionId() == null) {
+      return;
+    }
+    String methodName = context.getMethod().getName();
+    String connectionId = info.getConnectionId();
+
+    if ("getConnection".equals(methodName) && context.getTarget() instanceof DataSource) {
+      openSessions.put(
+          connectionId, new OpenSession(nanoClock.getAsLong(), captureAcquireCallSite()));
+      return;
+    }
+    if (DB_WORK_METHODS.contains(methodName)) {
+      OpenSession open = openSessions.get(connectionId);
+      if (open != null) {
+        open.dbWorkMillis.addAndGet(Math.max(0, context.getElapsedTime()));
+      }
+      return;
+    }
+    if ("close".equals(methodName) && context.getTarget() instanceof java.sql.Connection) {
+      OpenSession open = openSessions.remove(connectionId);
+      if (open != null && active) {
+        completedSessions.add(
+            new ConnectionSession(
+                connectionId,
+                toMillis(nanoClock.getAsLong() - open.acquiredNanos),
+                open.dbWorkMillis.get(),
+                true,
+                open.acquireCallSite));
+      }
+    }
+  }
+
+  private static long toMillis(long nanos) {
+    return nanos / 1_000_000L;
+  }
+
+  private static String captureAcquireCallSite() {
+    for (StackTraceElement frame : Thread.currentThread().getStackTrace()) {
+      String cls = frame.getClassName();
+      if (SKIP_PREFIXES.stream().noneMatch(cls::startsWith) && !cls.contains("$Proxy")) {
+        return frame.toString();
+      }
+    }
+    return null;
+  }
+}

--- a/query-audit-core/src/main/java/io/queryaudit/core/interceptor/DataSourceProxyFactory.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/interceptor/DataSourceProxyFactory.java
@@ -19,8 +19,8 @@ public final class DataSourceProxyFactory {
   /**
    * Wraps the given {@code DataSource} in a proxy that delegates query lifecycle events to the
    * supplied {@link QueryInterceptor}. The proxy is itself wrapped in a {@link
-   * NonClosingDataSource} so Spring does not auto-infer a destroy method on the post-BPP instance
-   * — see issue #153 for the cascade-close regression this prevents.
+   * NonClosingDataSource} so Spring does not auto-infer a destroy method on the post-BPP instance —
+   * see issue #153 for the cascade-close regression this prevents.
    *
    * @param original the real data source to wrap
    * @param interceptor the interceptor that will record queries
@@ -31,6 +31,7 @@ public final class DataSourceProxyFactory {
         ProxyDataSourceBuilder.create(original)
             .name("query-audit")
             .listener(interceptor)
+            .methodListener(interceptor.getConnectionTracker())
             .build();
     return new NonClosingDataSource(proxy);
   }

--- a/query-audit-core/src/main/java/io/queryaudit/core/interceptor/QueryInterceptor.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/interceptor/QueryInterceptor.java
@@ -77,6 +77,14 @@ public class QueryInterceptor implements QueryExecutionListener {
   // so their stack traces are identical. Pooling avoids redundant String objects.
   private final Map<String, String> stackTracePool = new ConcurrentHashMap<>();
 
+  // Connection lifecycle tracking for the connection-held-idle rule (issue #168).
+  private final ConnectionUsageTracker connectionTracker = new ConnectionUsageTracker();
+
+  /** Returns the connection lifecycle tracker registered alongside this interceptor. */
+  public ConnectionUsageTracker getConnectionTracker() {
+    return connectionTracker;
+  }
+
   @Override
   public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
     // no-op
@@ -137,12 +145,14 @@ public class QueryInterceptor implements QueryExecutionListener {
     sqlPool.clear();
     stackTracePool.clear();
     capacityWarningLogged = false;
+    connectionTracker.start();
     currentPhase = LifecyclePhase.TEST;
     active = true;
   }
 
   public void stop() {
     active = false;
+    connectionTracker.stop();
   }
 
   public List<QueryRecord> getRecordedQueries() {

--- a/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
+++ b/query-audit-core/src/main/java/io/queryaudit/core/model/IssueType.java
@@ -66,6 +66,8 @@ public enum IssueType {
       WARNING),
   READ_MODIFY_WRITE(
       "read-modify-write", "Read-modify-write without lock or unique-constraint backing", INFO),
+  CONNECTION_HELD_IDLE(
+      "connection-held-idle", "Connection held while non-database work runs", INFO),
   QUERY_COUNT_REGRESSION("query-count-regression", "Query count regression detected", WARNING),
   UPDATE_WITHOUT_WHERE(
       "update-without-where", "UPDATE/DELETE without WHERE clause affects all rows", ERROR),

--- a/query-audit-core/src/test/java/io/queryaudit/core/eval/SeverityAuditTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/eval/SeverityAuditTest.java
@@ -1075,6 +1075,6 @@ class SeverityAuditTest {
           .isNotNull();
     }
     // Verify the total count matches what we audited (56 issue types)
-    assertThat(IssueType.values().length).isEqualTo(67);
+    assertThat(IssueType.values().length).isEqualTo(68);
   }
 }

--- a/query-audit-core/src/test/java/io/queryaudit/core/interceptor/ConnectionUsageTrackerTest.java
+++ b/query-audit-core/src/test/java/io/queryaudit/core/interceptor/ConnectionUsageTrackerTest.java
@@ -1,0 +1,153 @@
+package io.queryaudit.core.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.ConnectionInfo;
+import net.ttddyy.dsproxy.listener.MethodExecutionContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ConnectionUsageTracker (issue #168)")
+class ConnectionUsageTrackerTest {
+
+  private final AtomicLong nanos = new AtomicLong();
+  private final ConnectionUsageTracker tracker = new ConnectionUsageTracker(nanos::get);
+
+  private static final DataSource DATA_SOURCE =
+      (DataSource)
+          Proxy.newProxyInstance(
+              ConnectionUsageTrackerTest.class.getClassLoader(),
+              new Class<?>[] {DataSource.class},
+              (proxy, method, args) -> null);
+
+  private static final Connection CONNECTION =
+      (Connection)
+          Proxy.newProxyInstance(
+              ConnectionUsageTrackerTest.class.getClassLoader(),
+              new Class<?>[] {Connection.class},
+              (proxy, method, args) -> null);
+
+  private static final java.sql.Statement STATEMENT =
+      (java.sql.Statement)
+          Proxy.newProxyInstance(
+              ConnectionUsageTrackerTest.class.getClassLoader(),
+              new Class<?>[] {java.sql.Statement.class},
+              (proxy, method, args) -> null);
+
+  private void fire(String methodName, Object target, String connectionId, long elapsedMs)
+      throws Exception {
+    MethodExecutionContext context = new MethodExecutionContext();
+    Method method = findMethod(target, methodName);
+    context.setMethod(method);
+    context.setTarget(target);
+    context.setElapsedTime(elapsedMs);
+    ConnectionInfo info = new ConnectionInfo();
+    info.setConnectionId(connectionId);
+    context.setConnectionInfo(info);
+    tracker.afterMethod(context);
+  }
+
+  private static Method findMethod(Object target, String name) throws Exception {
+    for (Method m : target.getClass().getMethods()) {
+      if (m.getName().equals(name)) {
+        return m;
+      }
+    }
+    throw new NoSuchMethodException(name);
+  }
+
+  private void advanceMillis(long ms) {
+    nanos.addAndGet(ms * 1_000_000L);
+  }
+
+  @Test
+  @DisplayName("held vs database-work time: the idle gap is the finding")
+  void tracksHeldVersusDbWork() throws Exception {
+    tracker.start();
+
+    fire("getConnection", DATA_SOURCE, "1", 0);
+    advanceMillis(20);
+    fire("executeQuery", STATEMENT, "1", 20);
+    advanceMillis(300); // slow non-DB work while holding the connection
+    fire("close", CONNECTION, "1", 0);
+
+    List<ConnectionUsageTracker.ConnectionSession> sessions = tracker.getCompletedSessions();
+    assertThat(sessions).hasSize(1);
+    ConnectionUsageTracker.ConnectionSession session = sessions.get(0);
+    assertThat(session.heldMillis()).isEqualTo(320);
+    assertThat(session.databaseWorkMillis()).isEqualTo(20);
+    assertThat(session.idleMillis()).isEqualTo(300);
+    assertThat(session.released()).isTrue();
+  }
+
+  @Test
+  @DisplayName("commit time counts as database work, not idle time")
+  void commitCountsAsDbWork() throws Exception {
+    tracker.start();
+
+    fire("getConnection", DATA_SOURCE, "1", 0);
+    advanceMillis(150);
+    fire("executeUpdate", STATEMENT, "1", 100);
+    fire("commit", CONNECTION, "1", 50);
+    fire("close", CONNECTION, "1", 0);
+
+    ConnectionUsageTracker.ConnectionSession session = tracker.getCompletedSessions().get(0);
+    assertThat(session.databaseWorkMillis()).isEqualTo(150);
+    assertThat(session.idleMillis()).isZero();
+  }
+
+  @Test
+  @DisplayName("a connection never closed in the window is recorded as unreleased at stop()")
+  void unreleasedConnectionRecordedAtStop() throws Exception {
+    tracker.start();
+
+    fire("getConnection", DATA_SOURCE, "1", 0);
+    advanceMillis(500);
+    tracker.stop();
+
+    ConnectionUsageTracker.ConnectionSession session = tracker.getCompletedSessions().get(0);
+    assertThat(session.heldMillis()).isEqualTo(500);
+    assertThat(session.released()).isFalse();
+  }
+
+  @Test
+  @DisplayName("concurrent checkouts are tracked independently by connection id")
+  void independentSessions() throws Exception {
+    tracker.start();
+
+    fire("getConnection", DATA_SOURCE, "1", 0);
+    advanceMillis(50);
+    fire("getConnection", DATA_SOURCE, "2", 0);
+    advanceMillis(50);
+    fire("close", CONNECTION, "1", 0); // held 100
+    advanceMillis(200);
+    fire("close", CONNECTION, "2", 0); // held 250
+
+    List<ConnectionUsageTracker.ConnectionSession> sessions = tracker.getCompletedSessions();
+    assertThat(sessions).hasSize(2);
+    assertThat(sessions.get(0).heldMillis()).isEqualTo(100);
+    assertThat(sessions.get(1).heldMillis()).isEqualTo(250);
+  }
+
+  @Test
+  @DisplayName("inactive tracker records nothing; start() clears the previous window")
+  void inactiveAndReset() throws Exception {
+    fire("getConnection", DATA_SOURCE, "1", 0);
+    fire("close", CONNECTION, "1", 0);
+    assertThat(tracker.getCompletedSessions()).isEmpty();
+
+    tracker.start();
+    fire("getConnection", DATA_SOURCE, "1", 0);
+    fire("close", CONNECTION, "1", 0);
+    assertThat(tracker.getCompletedSessions()).hasSize(1);
+
+    tracker.start();
+    assertThat(tracker.getCompletedSessions()).isEmpty();
+  }
+}

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/DataSourceResolver.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/DataSourceResolver.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
 import net.ttddyy.dsproxy.listener.ChainListener;
+import net.ttddyy.dsproxy.listener.CompositeMethodListener;
+import net.ttddyy.dsproxy.listener.MethodExecutionListener;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -58,10 +60,10 @@ class DataSourceResolver {
 
   /**
    * Hooks the QueryInterceptor into the DataSource and returns a cleanup callback that must be
-   * invoked from {@code afterAll} so that listeners do not accumulate on a shared proxy across
-   * test classes. If the DataSource is already a {@link ProxyDataSource}, the interceptor is added
-   * as a listener (Strategy 1). Otherwise, a fresh proxy is created via {@link
-   * DataSourceProxyFactory} and stored in {@link QueryAuditDataSourceStore} (Strategy 2).
+   * invoked from {@code afterAll} so that listeners do not accumulate on a shared proxy across test
+   * classes. If the DataSource is already a {@link ProxyDataSource}, the interceptor is added as a
+   * listener (Strategy 1). Otherwise, a fresh proxy is created via {@link DataSourceProxyFactory}
+   * and stored in {@link QueryAuditDataSourceStore} (Strategy 2).
    *
    * @return a cleanup callback that detaches the interceptor; never {@code null}
    */
@@ -71,7 +73,12 @@ class DataSourceResolver {
     if (proxy != null) {
       proxy.addListener(interceptor);
       ChainListener chain = proxy.getProxyConfig().getQueryListener();
-      return () -> detachListener(chain, interceptor);
+      CompositeMethodListener methodChain = proxy.getProxyConfig().getMethodListener();
+      methodChain.addListener(interceptor.getConnectionTracker());
+      return () -> {
+        detachListener(chain, interceptor);
+        detachMethodListener(methodChain, interceptor.getConnectionTracker());
+      };
     }
 
     // Strategy 2: Wrap with our own proxy via DataSourceProxyFactory
@@ -84,6 +91,14 @@ class DataSourceResolver {
    * Removes a previously-added listener from a {@link ChainListener}. {@code ChainListener} does
    * not expose a {@code removeListener} API directly, so we copy → filter → reinstall.
    */
+  private static void detachMethodListener(
+      CompositeMethodListener chain, MethodExecutionListener target) {
+    List<MethodExecutionListener> remaining = new ArrayList<>(chain.getListeners());
+    if (remaining.remove(target)) {
+      chain.setListeners(remaining);
+    }
+  }
+
   private static void detachListener(ChainListener chain, QueryExecutionListener target) {
     List<QueryExecutionListener> remaining = new ArrayList<>(chain.getListeners());
     if (remaining.remove(target)) {

--- a/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
+++ b/query-audit-junit5/src/main/java/io/queryaudit/junit5/QueryAuditExtension.java
@@ -7,6 +7,7 @@ import io.queryaudit.core.config.AuditMode;
 import io.queryaudit.core.config.QueryAuditConfig;
 import io.queryaudit.core.detector.QueryAuditAnalyzer;
 import io.queryaudit.core.detector.RepositoryReturnTypeResolver;
+import io.queryaudit.core.interceptor.ConnectionUsageTracker;
 import io.queryaudit.core.interceptor.LazyLoadTracker;
 import io.queryaudit.core.interceptor.QueryInterceptor;
 import io.queryaudit.core.model.*;
@@ -259,6 +260,9 @@ public class QueryAuditExtension
     // --- EXPLAIN-based detection ---
     report = runExplainAnalysis(context, report, queries);
 
+    // --- Connection-held-idle detection (issue #168) ---
+    report = mergeConnectionHeldIdleIssues(report, interceptor, config);
+
     List<BaselineEntry> baseline = analyzer.getBaseline();
     ConsoleReporter reporter =
         new ConsoleReporter(System.out, ConsoleReporter.detectColorSupport(), baseline);
@@ -496,6 +500,66 @@ public class QueryAuditExtension
         System.err.println("[QueryAudit] Failed to write HTML report: " + e.getMessage());
       }
     }
+  }
+
+  // ── Connection-held-idle (issue #168) ──────────────────────────────
+
+  /**
+   * Flags connection checkouts whose held time exceeded their database-work time by more than the
+   * configured threshold — the pool-exhaustion shape: a transaction holding its connection while
+   * slow non-DB work (HTTP call, push send, file I/O) runs. Sessions never released by the end of
+   * the test are the worst offenders and are flagged with their full held time.
+   */
+  private QueryAuditReport mergeConnectionHeldIdleIssues(
+      QueryAuditReport report, QueryInterceptor interceptor, QueryAuditConfig config) {
+    if (config.isRuleExcluded(IssueType.CONNECTION_HELD_IDLE.getCode())) {
+      return report;
+    }
+    List<Issue> idleIssues = new ArrayList<>();
+    for (ConnectionUsageTracker.ConnectionSession session :
+        interceptor.getConnectionTracker().getCompletedSessions()) {
+      long idleMillis = session.idleMillis();
+      if (idleMillis < config.getConnectionHeldIdleThresholdMs()) {
+        continue;
+      }
+      idleIssues.add(
+          new Issue(
+              IssueType.CONNECTION_HELD_IDLE,
+              Severity.INFO,
+              null,
+              null,
+              null,
+              "Connection "
+                  + session.connectionId()
+                  + " held "
+                  + session.heldMillis()
+                  + "ms but executed database work for only "
+                  + session.databaseWorkMillis()
+                  + "ms ("
+                  + idleMillis
+                  + "ms idle"
+                  + (session.released() ? "" : ", never released in the test window")
+                  + ") — under load this shape exhausts the pool",
+              "Release the connection before slow non-database work: move external calls (HTTP,"
+                  + " push, file I/O) out of the transaction, or split the transaction around"
+                  + " them",
+              session.acquireCallSite()));
+    }
+    if (idleIssues.isEmpty()) {
+      return report;
+    }
+    List<Issue> mergedInfo = new ArrayList<>(report.getInfoIssues());
+    mergedInfo.addAll(idleIssues);
+    return new QueryAuditReport(
+        report.getTestClass(),
+        report.getTestName(),
+        report.getConfirmedIssues(),
+        mergedInfo,
+        report.getAcknowledgedIssues(),
+        report.getAllQueries(),
+        report.getUniquePatternCount(),
+        report.getTotalQueryCount(),
+        report.getTotalExecutionTimeNanos());
   }
 
   // ── Query snapshot contracts (issue #166) ─────────────────────────

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditAutoConfiguration.java
@@ -66,6 +66,7 @@ public class QueryAuditAutoConfiguration {
         .slowQueryWarningMs(properties.getSlowQuery().getWarningMs())
         .slowQueryErrorMs(properties.getSlowQuery().getErrorMs())
         .countInsteadOfExistsEnabled(properties.getCountInsteadOfExists().isEnabled())
+        .connectionHeldIdleThresholdMs(properties.getConnectionHeldIdle().getThresholdMs())
         .build();
   }
 

--- a/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
+++ b/query-audit-spring-boot-starter/src/main/java/io/queryaudit/spring/QueryAuditProperties.java
@@ -55,6 +55,7 @@ public class QueryAuditProperties {
   private WriteAmplification writeAmplification = new WriteAmplification();
   private SlowQuery slowQuery = new SlowQuery();
   private CountInsteadOfExists countInsteadOfExists = new CountInsteadOfExists();
+  private ConnectionHeldIdle connectionHeldIdle = new ConnectionHeldIdle();
   private WrapDataSource wrapDataSource = new WrapDataSource();
 
   // ── Top-level getters & setters ────────────────────────────────────
@@ -233,6 +234,14 @@ public class QueryAuditProperties {
 
   public void setSlowQuery(SlowQuery slowQuery) {
     this.slowQuery = slowQuery;
+  }
+
+  public ConnectionHeldIdle getConnectionHeldIdle() {
+    return connectionHeldIdle;
+  }
+
+  public void setConnectionHeldIdle(ConnectionHeldIdle connectionHeldIdle) {
+    this.connectionHeldIdle = connectionHeldIdle;
   }
 
   public CountInsteadOfExists getCountInsteadOfExists() {
@@ -425,6 +434,19 @@ public class QueryAuditProperties {
   /**
    * @since 0.4.0
    */
+  public static class ConnectionHeldIdle {
+    /** Minimum idle time (held minus database work, ms) before the rule fires. */
+    private long thresholdMs = 200;
+
+    public long getThresholdMs() {
+      return thresholdMs;
+    }
+
+    public void setThresholdMs(long thresholdMs) {
+      this.thresholdMs = thresholdMs;
+    }
+  }
+
   public static class CountInsteadOfExists {
     private boolean enabled = false;
 


### PR DESCRIPTION
## Summary

Closes #168. The last item of the v0.5.0 milestone.

The most expensive JDBC anti-pattern is structurally invisible to per-statement rules: a transaction that holds its pooled connection while slow non-DB work (HTTP call, push send, file I/O) runs between statements. The SQL is all fine — the transaction boundary is wrong. Under load the pool drains and takes down unrelated endpoints: the exact cascading-outage shape from the production incident that motivated this rule, where an event listener performed an external push call inside a transaction.

## How it works

- `ConnectionUsageTracker` (a dsproxy `MethodExecutionListener`) observes `getConnection`/`close` and the elapsed time of every `execute*`/`commit`/`rollback` in between, keyed by dsproxy's `ConnectionInfo` id. **held − databaseWork = idle**; sessions with idle ≥ threshold (default 200ms, `query-audit.connection-held-idle.threshold-ms`) become INFO findings with the acquire call site.
- Registered by `DataSourceProxyFactory` at wrap time and attached/detached by `DataSourceResolver` on already-proxied DataSources, symmetric with the query listener.
- Connections still open at window end are reported as **unreleased holds** — a connection held to the end of the test is the worst offender, not an exemption.

## The E2E probe earned its keep

The first design gated all bookkeeping on the per-test window — and the probe stayed **silent**: Spring's transaction manager acquires the test's connection *before* this extension's callbacks run, so the tracker never saw the acquire. The shipped design does lifecycle bookkeeping continuously and re-anchors already-open connections at window start. After the fix, a `@Transactional` probe sleeping 350ms produced:

```
Connection 4 held 421ms but executed database work for only 7ms
(414ms idle, never released in the test window) — under load this shape exhausts the pool
```

## Honest limits (documented)

- Wall-clock heuristic: the non-DB work must actually take time in tests (Testcontainers, WireMock with latency) — zero-latency mocks never reproduce the gap.
- Therefore listed in the **recommended-profile exclusions**: `strict` runs it, first-run defaults stay quiet. INFO severity until field-tested.

## Tests

Deterministic unit tests with an injectable clock (held-vs-work accounting, commit counted as DB work, unreleased-at-stop, independent concurrent checkouts, window reset), plus the real-behavior probe above. Full suite green; IssueType catalog now 68 codes (rebased over #177).