### PR TITLE
docs: bring the front doors up to 0.5.0 — README rework, new-rule registration, version markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@
 
 Most SQL performance problems -- N+1 queries, missing indexes, unsafe DML -- are invisible during development because test datasets are small. They only surface in production under real load, causing outages and firefighting.
 
-**QueryAudit shifts that discovery left into your test suite.**
+**QueryAudit shifts that discovery left into your test suite** — and since 0.5.0 it goes a
+step further: it turns your suite's database behavior into an explicit, enforceable
+**contract**. Detect the anti-patterns, freeze the query profile as
+[snapshot contracts](https://haroya01.github.io/query-audit/guide/contracts/), and gate every
+change — human or automated — on an explicit, reviewable behavior diff.
 
 | | Without QueryAudit | With QueryAudit |
 |---|---|---|
@@ -28,12 +32,13 @@ Most SQL performance problems -- N+1 queries, missing indexes, unsafe DML -- are
 
 ## What It Does
 
-QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes each one against **64 detection rules**, cross-references index metadata from your database, and fails your build when it finds performance anti-patterns.
+QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes each one against **66 detection rules**, cross-references index metadata from your database, and fails your build when it finds performance anti-patterns.
 
-- **64 detection rules** covering N+1 queries, missing indexes, DML safety, locking risks, ORM anti-patterns, and more
-- **Zero configuration** -- add one annotation and go
-- **Per-type query budgets** -- `@ExpectQueries(select = 2, insert = 1)` fails the test when a SELECT / INSERT / UPDATE / DELETE budget is exceeded
-- **Actionable reports** -- every issue includes the SQL, table, column, and a concrete fix suggestion
+- **66 detection rules** covering N+1 queries, missing indexes, DML safety, locking and race risks, connection-lifecycle misuse, ORM anti-patterns, and more
+- **Zero configuration** -- add one annotation and go; or flip [`mode: all`](https://haroya01.github.io/query-audit/guide/configuration/#audit-coverage-mode) to audit every test with per-test opt-out
+- **Rule profiles** -- `strict` / `recommended` / `minimal` tiers for a quiet, trustworthy first run
+- **Per-type query budgets** -- `@ExpectQueries(select = 2, insert = 1)` fails the test when a SELECT / INSERT / UPDATE / DELETE budget is exceeded, and [snapshot contracts](https://haroya01.github.io/query-audit/guide/contracts/) record those budgets for the whole suite in one run
+- **Actionable reports** -- every issue includes the SQL, table, column, call site, a concrete fix suggestion, and (in `report.json`) a machine-readable remediation hint
 - **No production overhead** -- runs only in your test suite
 
 ### Supported Databases
@@ -53,8 +58,8 @@ QueryAudit intercepts every SQL query executed during your JUnit tests, analyzes
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0'
-    testImplementation 'io.github.haroya01:query-audit-mysql:0.4.0'
+    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0' // x-release-please-version
+    testImplementation 'io.github.haroya01:query-audit-mysql:0.4.0' // x-release-please-version
 }
 ```
 
@@ -62,8 +67,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0'
-    testImplementation 'io.github.haroya01:query-audit-postgresql:0.4.0'
+    testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0' // x-release-please-version
+    testImplementation 'io.github.haroya01:query-audit-postgresql:0.4.0' // x-release-please-version
 }
 ```
 
@@ -76,13 +81,13 @@ dependencies {
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-spring-boot-starter</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.0</version> <!-- x-release-please-version -->
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-mysql</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.0</version> <!-- x-release-please-version -->
     <scope>test</scope>
 </dependency>
 ```
@@ -93,13 +98,13 @@ dependencies {
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-spring-boot-starter</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.0</version> <!-- x-release-please-version -->
     <scope>test</scope>
 </dependency>
 <dependency>
     <groupId>io.github.haroya01</groupId>
     <artifactId>query-audit-postgresql</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.0</version> <!-- x-release-please-version -->
     <scope>test</scope>
 </dependency>
 ```
@@ -110,8 +115,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    testImplementation 'io.github.haroya01:query-audit-junit5:0.4.0'
-    testRuntimeOnly 'io.github.haroya01:query-audit-mysql:0.4.0'  // or query-audit-postgresql
+    testImplementation 'io.github.haroya01:query-audit-junit5:0.4.0' // x-release-please-version
+    testRuntimeOnly 'io.github.haroya01:query-audit-mysql:0.4.0'  // or query-audit-postgresql // x-release-please-version
 }
 ```
 
@@ -181,9 +186,11 @@ INFO (for review)
 
 ---
 
-## 64 Detection Rules
+## 66 Detection Rules
 
-QueryAudit ships with 64 detection rules organized into two confidence tiers:
+QueryAudit ships with 66 active detection rules (68 issue types in the catalog; one detector
+is disabled by default and one EXPLAIN-based type is reserved), organized into two confidence
+tiers:
 
 **Confirmed (ERROR / WARNING)** -- structural and schema-based checks that are reliable regardless of test data size. These inspect SQL text, repetition patterns, and cross-reference actual index metadata from your database.
 
@@ -197,10 +204,11 @@ QueryAudit ships with 64 detection rules organized into two confidence tiers:
 | **SQL Anti-Patterns** | SELECT *, function in WHERE, OR abuse, OFFSET pagination, LIKE wildcard, implicit type conversion | 6 |
 | **DML Safety** | UPDATE without WHERE, DML without index, INSERT with SELECT *, INSERT ON DUPLICATE KEY | 6 |
 | **Join Issues** | Cartesian join, too many joins, implicit join, unused join, correlated subquery | 5 |
-| **Locking** | FOR UPDATE without index, FOR UPDATE on non-unique index, range lock risk, INSERT...SELECT locks source | 4 |
+| **Locking & Races** | FOR UPDATE without index, FOR UPDATE on non-unique index, range lock risk, INSERT...SELECT locks source, read-modify-write without lock | 5 |
 | **Query Structure** | DISTINCT misuse, HAVING misuse, UNION without ALL, large IN list, NOT IN subquery, ORDER BY RAND | 8 |
 | **Hibernate / ORM** | Collection delete-reinsert, derived delete loads entities, excessive column fetch | 3 |
 | **MySQL-Specific** | FIND_IN_SET, REGEXP usage, string concat in WHERE, implicit columns INSERT | 4 |
+| **Connection Lifecycle** | Connection held while non-database work runs (the pool-exhaustion shape) | 1 |
 | **EXPLAIN-Based** | Full table scan, filesort, temporary table | 3 |
 | **Miscellaneous** | Slow query, unbounded result set, query count regression, non-deterministic pagination, and more | 6 |
 
@@ -212,11 +220,12 @@ See the [Detection Rules Overview](https://haroya01.github.io/query-audit/detect
 
 | Annotation | Description |
 |---|---|
-| `@QueryAudit` | Full analysis -- intercepts queries, runs all 64 detection rules, fails on confirmed issues |
+| `@QueryAudit` | Full analysis -- intercepts queries, runs the full rule set, fails on confirmed issues |
 | `@EnableQueryInspector` | Report-only mode -- runs all detections but never fails the test |
 | `@DetectNPlusOne` | Focused check -- fails only if N+1 query patterns are detected |
 | `@ExpectMaxQueryCount(n)` | Query budget -- fails if more than `n` queries are executed |
 | `@ExpectQueries(select=n, ...)` | Per-type query budget -- fails when a SELECT/INSERT/UPDATE/DELETE budget is exceeded |
+| `@QueryAuditExclude` | Opts a test class or method out of auditing -- the `mode: all` escape hatch |
 
 Query budgets make per-test contracts explicit -- and `@ExpectQueries(insert = 0, update = 0, delete = 0)` turns a test into a read-only contract:
 
@@ -228,6 +237,17 @@ void createOrder() {
     orderService.createOrder(request);
 }
 ```
+
+---
+
+## Beyond Detection
+
+Since 0.5.0, detection is the first rung of a ladder -- the rest turns findings into enforced, machine-consumable contracts:
+
+- **[Audit coverage `mode: all`](https://haroya01.github.io/query-audit/guide/configuration/#audit-coverage-mode)** -- audit every test in the suite; tests opt *out* with `@QueryAuditExclude`. Pairs with the baseline so brownfield adoption fails only on *new* violations.
+- **[Rule profiles](https://haroya01.github.io/query-audit/guide/configuration/#rule-profiles)** -- `strict` (everything), `recommended` (opinionated rules off), `minimal` (safety-critical gate). Explicit `disabled-rules` / `enabled-rules` always win.
+- **[Query snapshot contracts](https://haroya01.github.io/query-audit/guide/contracts/)** -- record every test's query profile once; any deviation, in either direction, fails until the contract is re-recorded. The contracts file diff *is* the behavior change, reviewable in the PR.
+- **[Versioned `report.json` + delta verdict](https://haroya01.github.io/query-audit/guide/reports/)** -- a `schemaVersion`ed envelope embedding call sites, structured remediation hints, and the index state behind each finding, plus a compare command whose exit code answers the fix-loop question: *did my change resolve the finding without introducing new ones?* Built for CI gates and automated dev loops alike -- a tool (or an agent) can act on the report without database access and verify its fix from the verdict alone.
 
 ---
 
@@ -251,6 +271,8 @@ Configure via `application.yml` (Spring Boot) or programmatically:
 query-audit:
   enabled: true
   fail-on-detection: true
+  mode: annotated        # or "all" -- audit every test, opt out with @QueryAuditExclude
+  profile: recommended   # strict | recommended | minimal
   n-plus-one:
     threshold: 3
   offset-pagination:

--- a/docs/detections/overview.md
+++ b/docs/detections/overview.md
@@ -122,6 +122,8 @@ The complete searchable reference of issue types emitted by the active detection
 | 62 | findById for Association | `find-by-id-for-association` | INFO | Hibernate/ORM | findById() used only for FK association; consider getReferenceById() |
 | 63 | Filesort | `filesort` | INFO | EXPLAIN-Based | Filesort detected in EXPLAIN output |
 | 64 | Temporary Table | `temporary-table` | INFO | EXPLAIN-Based | Temporary table usage in EXPLAIN output |
+| 65 | Read-Modify-Write | `read-modify-write` | INFO | Locking Risks | SELECT without a lock followed by INSERT/UPDATE on the same table, with no unique-constraint backing, upsert, atomic SET, or version column |
+| 66 | Connection Held Idle | `connection-held-idle` | INFO | Connection Lifecycle | Connection held while non-database work runs -- the pool-exhaustion shape |
 
 !!! note "Rule numbering"
     Rules 50-60 are INFO severity. The table numbers are for reference only and do not correspond
@@ -269,6 +271,8 @@ but are worth reviewing.
 | `non-deterministic-pagination` | ORDER BY+LIMIT on non-unique column | Detect ORDER BY + LIMIT on non-unique columns |
 | `force-index-hint` | FORCE/USE/IGNORE INDEX overrides optimizer | Detect index hint keywords in query |
 | `find-by-id-for-association` | `findById()` used only for FK association — consider `getReferenceById()` to skip the SELECT | Spring Data return-type and call-site analysis |
+| `read-modify-write` | Check-then-act race: unlocked SELECT then INSERT/UPDATE on the same table | Sequence analysis + unique-index cross-check; exempts FOR UPDATE, upserts, @Version columns, atomic `SET col = col - ?`, non-overlapping predicates |
+| `connection-held-idle` | Connection held while non-database work runs | held − database-work time per connection checkout, from JDBC lifecycle events; threshold `connection-held-idle.threshold-ms` (200ms default) |
 | `n-plus-one-suspect` | Same-structure query repeated at the SQL level — suspect only; the Hibernate-level tracker is authoritative | SQL pattern repetition heuristic |
 | `filesort` | Filesort detected in the execution plan | MySQL/PostgreSQL EXPLAIN analyzers |
 | `temporary-table` | Temporary table usage in the execution plan | MySQL/PostgreSQL EXPLAIN analyzers |
@@ -282,7 +286,7 @@ but are worth reviewing.
 
 ## Disabled & Reserved Rules
 
-The `IssueType` enum currently has **66 entries**. **64 are actively emitted** by detection
+The `IssueType` enum currently has **68 entries**. **66 are actively emitted** by detection
 rules. The remaining 2 entries fall into two categories:
 
 ### Disabled Rules (1 entry)
@@ -309,19 +313,20 @@ for full-table-scan detection in the EXPLAIN analyzers.
 
 | Category | Count |
 |----------|-------|
-| Active issue types emitted by detectors | **64** |
+| Active issue types emitted by detectors | **66** |
 | Disabled (DuplicateQueryDetector) | 1 |
 | Reserved (full-scan) | 1 |
-| **Total IssueType enum entries** | **66** |
+| **Total IssueType enum entries** | **68** |
 
 !!! note "Why fewer detector classes than active issue types?"
     A single detector can emit multiple issue types. The biggest example is
     `MissingIndexDetector`, which is registered as one detection rule but emits 4 different
     `IssueType`s (`missing-where-index`, `missing-join-index`, `missing-order-by-index`,
     `missing-group-by-index`) -- one per SQL clause it analyzes. On top of the core rules,
-    the MySQL/PostgreSQL EXPLAIN analyzers emit `filesort` and `temporary-table`, and the
+    the MySQL/PostgreSQL EXPLAIN analyzers emit `filesort` and `temporary-table`, the
     Hibernate-level trackers emit `find-by-id-for-association` and the authoritative N+1
-    signal -- these run outside `QueryAuditAnalyzer.createRules()`.
+    signal, and the connection lifecycle tracker emits `connection-held-idle` -- these run
+    outside `QueryAuditAnalyzer.createRules()`.
 
 ---
 
@@ -393,6 +398,10 @@ for full-table-scan detection in the EXPLAIN analyzers.
 - `for-update-non-unique` -- FOR UPDATE on non-unique index (WARNING)
 - `range-lock-risk` -- Range lock risk (WARNING)
 - `for-update-no-timeout` -- FOR UPDATE without timeout (WARNING)
+- `read-modify-write` -- Check-then-act race without lock or unique-constraint backing (INFO)
+
+### Connection Lifecycle
+- `connection-held-idle` -- Connection held while non-database work runs, the pool-exhaustion shape (INFO)
 
 ### MySQL-Specific
 - `string-concat-where` -- String concatenation in WHERE (WARNING)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -161,7 +161,7 @@ query-audit-spring-boot-starter  <-- Add this too if using Spring Boot
 
 | Module | Artifact ID | Description |
 |---|---|---|
-| **Core** | `query-audit-core` | Detection engine (64 rules), SQL parser, report generator. Always required (pulled transitively). |
+| **Core** | `query-audit-core` | Detection engine (66 rules), SQL parser, report generator. Always required (pulled transitively). |
 | **MySQL** | `query-audit-mysql` | MySQL `IndexMetadataProvider` via `SHOW INDEX`. Includes core + junit5 transitively. |
 | **PostgreSQL** | `query-audit-postgresql` | PostgreSQL `IndexMetadataProvider` via `pg_catalog`. Includes core + junit5 transitively. |
 | **JUnit 5** | `query-audit-junit5` | JUnit 5 extension, `@QueryAudit` / `@DetectNPlusOne` / `@ExpectMaxQueryCount` annotations. |

--- a/docs/getting-started/spring-boot.md
+++ b/docs/getting-started/spring-boot.md
@@ -285,4 +285,4 @@ Or per-test:
 
 - :material-arrow-right: [Configuration Reference](../guide/configuration.md) -- Full list of `application.yml` properties
 - :material-arrow-right: [Annotations Guide](../guide/annotations.md) -- All 4 annotations explained
-- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 65 detection rules
+- :material-arrow-right: [Detection Rules](../detections/overview.md) -- All 66 detection rules

--- a/docs/guide/annotations.md
+++ b/docs/guide/annotations.md
@@ -9,7 +9,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 
 | Annotation | Target | Purpose | Test Failure |
 |---|---|---|---|
-| `@QueryAudit` | Class / Method | Full analysis with all 65 detection rules | Yes (configurable) |
+| `@QueryAudit` | Class / Method | Full analysis with all 66 detection rules | Yes (configurable) |
 | `@EnableQueryInspector` | Class | Report-only mode, never fails | No |
 | `@DetectNPlusOne` | Class / Method | N+1 detection only | Yes (on N+1 only) |
 | `@ExpectMaxQueryCount` | Method | Assert max query count | Yes (on count exceeded) |
@@ -45,7 +45,7 @@ QueryAudit provides four annotations for different use cases. All annotations tr
 
 ## @QueryAudit
 
-The primary annotation. Enables full query analysis with all 65 detection rules across
+The primary annotation. Enables full query analysis with all 66 detection rules across
 SELECT, INSERT, UPDATE, and DELETE statements.
 
 ```java

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ description: Catch N+1 queries, missing indexes, and SQL anti-patterns before th
 # QueryAudit
 
 <p class="qg-tagline">
-Stop shipping slow queries. Catch N+1, missing indexes, and dozens of other SQL anti-patterns automatically during your JUnit tests -- 65 detection rules in total.
+Stop shipping slow queries. Catch N+1, missing indexes, and dozens of other SQL anti-patterns automatically during your JUnit tests -- 66 detection rules in total.
 </p>
 
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
@@ -118,7 +118,7 @@ Every issue includes the exact SQL statement, affected table, column, the detect
   <div class="qg-flow-arrow">:material-arrow-right:</div>
   <div class="qg-flow-step">:material-table-key: Fetch index metadata</div>
   <div class="qg-flow-arrow">:material-arrow-right:</div>
-  <div class="qg-flow-step">:material-magnify: Apply 65 rules</div>
+  <div class="qg-flow-step">:material-magnify: Apply 66 rules</div>
   <div class="qg-flow-arrow">:material-arrow-right:</div>
   <div class="qg-flow-step">:material-alert-circle: Report & fail</div>
 </div>
@@ -128,7 +128,7 @@ QueryAudit hooks into your test's `DataSource` via a lightweight proxy. During t
 1. **Parses** each query to identify tables, columns, joins, and clauses
 2. **Fetches index metadata** from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`)
 3. **Cross-references** the query structure against actual indexes
-4. **Applies 65 detection rules** covering N+1, missing indexes, DML safety, locking risks, and more
+4. **Applies 66 detection rules** covering N+1, missing indexes, DML safety, locking risks, and more
 5. **Produces a structured report** with severity, root cause, and fix suggestions
 
 No runtime agents. No production overhead. Just add an annotation.
@@ -221,7 +221,7 @@ Existing tools help with **observability** -- they let you *see* your queries:
 | **p6spy** | Logs queries with bind parameters | Same -- logging only |
 | **Spring Hibernate statistics** | Counts queries per session | Counts, but doesn't analyze |
 
-**QueryAudit closes the gap.** It doesn't just log queries -- it applies 65 detection rules to every captured query, cross-references index metadata from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`), and produces a structured report with concrete fix suggestions.
+**QueryAudit closes the gap.** It doesn't just log queries -- it applies 66 detection rules to every captured query, cross-references index metadata from your database (MySQL `SHOW INDEX` or PostgreSQL `pg_catalog`), and produces a structured report with concrete fix suggestions.
 
 | Capability | datasource-proxy | p6spy | QueryAudit |
 |---|:---:|:---:|:---:|

--- a/docs/references.md
+++ b/docs/references.md
@@ -95,4 +95,4 @@ peer-reviewed academic research, and established technical literature.
 ## See Also
 
 - [Architecture Overview](architecture/overview.md) -- How detection rules use these references
-- [Configuration Reference](guide/configuration.md) -- All 65 detection rules and their codes
+- [Configuration Reference](guide/configuration.md) -- All 66 detection rules and their codes

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,11 @@
           "type": "generic",
           "path": "gradle.properties",
           "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "README.md",
+          "glob": false
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
## Summary

The 0.5.0 feature PRs each shipped their own guide pages, but the two **front-door** documents still described the 0.4.0 product. This closes the documentation gap before the release PR goes out.

## README

- Reframed around the **detect → contract → gate** ladder that 0.5.0 completes, with the agent/automation story as the closing beat of the *Beyond Detection* section — the product concept, in the front door's own words.
- Counts corrected to the current catalog: **66 active issue types, 68 total** (counting convention from #162), with the Locking & Races and new Connection Lifecycle categories reflected in the rules table.
- New **Beyond Detection** section linking `mode: all`, rule profiles, snapshot contracts, and the versioned report + delta verdict.
- Annotations table gains `@QueryAuditExclude`; the configuration sample shows `mode` and `profile`.

## Never-stale versions (ratchet)

Dependency snippets now carry `x-release-please-version` annotations (10 sites) and README.md joins release-please's `extra-files` — **the release PR bumps the versions newcomers copy-paste from now on**, permanently ending the staleness that had them at 0.3.2 while 0.4.0 was current.

## detections/overview.md

- `read-modify-write` and `connection-held-idle` registered in the quick-reference table (rows 65–66), the INFO severity table, and Rules by Category (new *Connection Lifecycle* category).
- Accounting updated: 66 active / 1 disabled / 1 reserved / 68 total. The out-of-registry note now names the connection lifecycle tracker alongside the EXPLAIN analyzers and Hibernate trackers.

## Consistency sweep

Rule-count mentions unified to 66 across `index.md`, `references.md`, `annotations.md`, `installation.md`, and the Spring Boot guide.

Note for the release: since README.md is now in `extra-files`, release-please will refresh PR #173 to include the README version bumps when this merges.