### PR TITLE
docs: bump getting-started dependency snippets to 0.5.0 and put them on release-please

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -37,8 +37,8 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.5.0' // x-release-please-version
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.5.0' // x-release-please-version
     }
     ```
 
@@ -49,7 +49,7 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.5.0' // x-release-please-version
     }
     ```
 
@@ -59,8 +59,8 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.3.2'
-        testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.5.0' // x-release-please-version
+        testImplementation 'io.github.haroya01:query-audit-postgresql:0.5.0' // x-release-please-version
     }
     ```
 
@@ -71,7 +71,7 @@ Choose the tab that matches your database and build tool:
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-postgresql:0.3.2'
+        testImplementation 'io.github.haroya01:query-audit-postgresql:0.5.0' // x-release-please-version
     }
     ```
 
@@ -84,13 +84,13 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-spring-boot-starter</artifactId>
-            <version>0.3.2</version>
+            <version>0.5.0</version> <!-- x-release-please-version -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-mysql</artifactId>
-            <version>0.3.2</version>
+            <version>0.5.0</version> <!-- x-release-please-version -->
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -103,7 +103,7 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-mysql</artifactId>
-            <version>0.3.2</version>
+            <version>0.5.0</version> <!-- x-release-please-version -->
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -116,13 +116,13 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-spring-boot-starter</artifactId>
-            <version>0.3.2</version>
+            <version>0.5.0</version> <!-- x-release-please-version -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-postgresql</artifactId>
-            <version>0.3.2</version>
+            <version>0.5.0</version> <!-- x-release-please-version -->
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -135,7 +135,7 @@ Choose the tab that matches your database and build tool:
         <dependency>
             <groupId>io.github.haroya01</groupId>
             <artifactId>query-audit-postgresql</artifactId>
-            <version>0.3.2</version>
+            <version>0.5.0</version> <!-- x-release-please-version -->
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -45,8 +45,8 @@ No configuration. No extra beans. No proxy setup. Just the annotation.
 
     ```gradle
     dependencies {
-        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.4.0'
-        testImplementation 'io.github.haroya01:query-audit-mysql:0.4.0'
+        testImplementation 'io.github.haroya01:query-audit-spring-boot-starter:0.5.0' // x-release-please-version
+        testImplementation 'io.github.haroya01:query-audit-mysql:0.5.0' // x-release-please-version
     }
     ```
 
@@ -56,13 +56,13 @@ No configuration. No extra beans. No proxy setup. Just the annotation.
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-spring-boot-starter</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version> <!-- x-release-please-version -->
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>io.github.haroya01</groupId>
         <artifactId>query-audit-mysql</artifactId>
-        <version>0.4.0</version>
+        <version>0.5.0</version> <!-- x-release-please-version -->
         <scope>test</scope>
     </dependency>
     ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,16 @@
           "type": "generic",
           "path": "README.md",
           "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/getting-started/installation.md",
+          "glob": false
+        },
+        {
+          "type": "generic",
+          "path": "docs/getting-started/quickstart.md",
+          "glob": false
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
Found while auditing the published docs site: **installation.md still showed 0.3.2** and quickstart.md 0.4.0 — the copy-paste surfaces newcomers actually use were up to two releases stale.

Same cure as the README got in #179: bump every dependency coordinate to 0.5.0, annotate the lines with `x-release-please-version`, and register both files in release-please's `extra-files` — future release PRs keep them current automatically. Prose references to historical versions ('Spring Boot 4.x requires query-audit 0.3.2+') are deliberately untouched.